### PR TITLE
add a condition code that is always true.

### DIFF
--- a/src/gen/conditions.rs
+++ b/src/gen/conditions.rs
@@ -2701,7 +2701,7 @@ fn test_double_spend() {
 #[test]
 fn test_always_true() {
     // ALWAYS_TRUE
-    let (a, conds) = cond_test("((({h1} ({h2} (123 (((0x00 )))))").unwrap();
+    let (a, conds) = cond_test("((({h1} ({h2} (123 (((1 )))))").unwrap();
 
     // just make sure there are no constraints
     assert_eq!(conds.agg_sig_unsafe.len(), 0);
@@ -2722,7 +2722,7 @@ fn test_always_true() {
 fn test_always_true_with_arg() {
     // ALWAYS_TRUE, but with one unknown argument
     // unknown arguments are expected and always allowed
-    let (a, conds) = cond_test("((({h1} ({h2} (123 (((0x00 ( 42 )))))").unwrap();
+    let (a, conds) = cond_test("((({h1} ({h2} (123 (((1 ( 42 )))))").unwrap();
 
     // just make sure there are no constraints
     assert_eq!(conds.agg_sig_unsafe.len(), 0);

--- a/src/gen/opcodes.rs
+++ b/src/gen/opcodes.rs
@@ -34,7 +34,7 @@ pub const ASSERT_HEIGHT_RELATIVE: ConditionOpcode = 82;
 pub const ASSERT_HEIGHT_ABSOLUTE: ConditionOpcode = 83;
 
 // no-op condition
-pub const ALWAYS_TRUE: ConditionOpcode = 0;
+pub const ALWAYS_TRUE: ConditionOpcode = 1;
 
 pub const CREATE_COIN_COST: Cost = 1800000;
 pub const AGG_SIG_COST: Cost = 1200000;
@@ -137,7 +137,7 @@ fn test_parse_opcode() {
     // leading zeros are not allowed, it makes it a different value
     assert_eq!(opcode_tester(&mut a, &[ASSERT_HEIGHT_ABSOLUTE, 0]), None);
     assert_eq!(opcode_tester(&mut a, &[0, ASSERT_HEIGHT_ABSOLUTE]), None);
-    assert_eq!(opcode_tester(&mut a, &[1]), None);
+    assert_eq!(opcode_tester(&mut a, &[0]), None);
 
     // a pair is never a valid condition
     let v1 = a.new_atom(&[0]).unwrap();

--- a/src/gen/opcodes.rs
+++ b/src/gen/opcodes.rs
@@ -33,6 +33,9 @@ pub const ASSERT_SECONDS_ABSOLUTE: ConditionOpcode = 81;
 pub const ASSERT_HEIGHT_RELATIVE: ConditionOpcode = 82;
 pub const ASSERT_HEIGHT_ABSOLUTE: ConditionOpcode = 83;
 
+// no-op condition
+pub const ALWAYS_TRUE: ConditionOpcode = 0;
+
 pub const CREATE_COIN_COST: Cost = 1800000;
 pub const AGG_SIG_COST: Cost = 1200000;
 
@@ -60,7 +63,8 @@ pub fn parse_opcode(a: &Allocator, op: NodePtr) -> Option<ConditionOpcode> {
         | ASSERT_SECONDS_RELATIVE
         | ASSERT_SECONDS_ABSOLUTE
         | ASSERT_HEIGHT_RELATIVE
-        | ASSERT_HEIGHT_ABSOLUTE => Some(buf[0]),
+        | ASSERT_HEIGHT_ABSOLUTE
+        | ALWAYS_TRUE => Some(buf[0]),
         _ => None,
     }
 }
@@ -129,10 +133,11 @@ fn test_parse_opcode() {
         opcode_tester(&mut a, &[ASSERT_HEIGHT_ABSOLUTE]),
         Some(ASSERT_HEIGHT_ABSOLUTE)
     );
+    assert_eq!(opcode_tester(&mut a, &[ALWAYS_TRUE]), Some(ALWAYS_TRUE));
     // leading zeros are not allowed, it makes it a different value
     assert_eq!(opcode_tester(&mut a, &[ASSERT_HEIGHT_ABSOLUTE, 0]), None);
     assert_eq!(opcode_tester(&mut a, &[0, ASSERT_HEIGHT_ABSOLUTE]), None);
-    assert_eq!(opcode_tester(&mut a, &[0]), None);
+    assert_eq!(opcode_tester(&mut a, &[1]), None);
 
     // a pair is never a valid condition
     let v1 = a.new_atom(&[0]).unwrap();


### PR DESCRIPTION
The actual integer value can be debated, I don't have a strong opinion.
I also took the opportunity to assert `cost` in the existing unit tests (in addition to the new one).

The change to enable negative op-codes is a pretty big portion of this patch, and maybe it's not worth it. The patch would be smaller if we pick a positive no-op code.