### PR TITLE
make the python module also export key functionality from clvm_rs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,3 +57,10 @@ jobs:
         . ./activate
         cd tests
         ./test-generators.py
+
+    - name: Run cost checks
+      run: |
+        . ./activate
+        cd tests
+        ./generate-programs.py
+        ./run-programs.py

--- a/tests/run-programs.py
+++ b/tests/run-programs.py
@@ -54,7 +54,7 @@ for hexname in sorted(glob.glob('programs/*.hex')):
     output += proc.stdout.decode('UTF-8')
     end = time.perf_counter()
 
-    if 'FAIL: cost exceeded' not in output:
+    if 'FAIL: ' not in output or 'cost exceeded' not in output:
         ret += 1
         print(Fore.RED + '\nTEST FAILURE: expected cost to be exceeded\n' + Style.RESET_ALL)
         print(output)

--- a/tests/run.py
+++ b/tests/run.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+from chia_rs import run_chia_program
+
+def run_clvm(fn, env=None):
+
+    program_data = bytes.fromhex(open(fn, 'r').read())
+    if env is not None:
+        env_data = bytes.fromhex(open(env, 'r').read())
+    else:
+        env_data = bytes.fromhex("ff80")
+    # constants from the main chia blockchain:
+    # https://github.com/Chia-Network/chia-blockchain/blob/main/chia/consensus/default_constants.py
+    max_cost = 11000000000
+    cost_per_byte = 12000
+
+    max_cost -= (len(program_data) + len(env_data)) * cost_per_byte
+    return run_chia_program(
+        program_data,
+        env_data,
+        max_cost,
+        0,
+    )
+
+def count_tree_size(tree) -> int:
+    stack = [tree]
+    ret = 0
+    while len(stack):
+        i = stack.pop()
+        if i.atom is not None:
+            ret += len(i.atom)
+        elif i.pair is not None:
+            stack.append(i.pair[1])
+            stack.append(i.pair[0])
+        else:
+            # this shouldn't happen
+            assert False
+    return ret
+
+if __name__ == "__main__":
+    import sys
+    from time import time
+
+    try:
+        start = time()
+        cost, result = run_clvm(sys.argv[1], sys.argv[2])
+        duration = time() - start;
+        print(f"cost: {cost}")
+        print(f"execution time: {duration:.2f}s")
+    except Exception as e:
+        print("FAIL:", e)
+        sys.exit(1)
+    start = time()
+    ret_size = count_tree_size(result)
+    duration = time() - start;
+    print(f"returned bytes: {ret_size}")
+    print(f"parse return value time: {duration:.2f}s")
+    sys.exit(0)

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -11,6 +11,10 @@ use pyo3::prelude::*;
 use pyo3::types::PyModule;
 use pyo3::{wrap_pyfunction, PyResult, Python};
 
+use crate::run_program::{
+    __pyo3_get_function_run_chia_program, __pyo3_get_function_serialized_length,
+};
+
 pub const MEMPOOL_MODE: u32 = NO_NEG_DIV
     | COND_CANON_INTS
     | NO_UNKNOWN_CONDS
@@ -20,24 +24,24 @@ pub const MEMPOOL_MODE: u32 = NO_NEG_DIV
 
 #[pymodule]
 pub fn chia_rs(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(a_test_function, m)?)?;
     m.add_function(wrap_pyfunction!(run_generator, m)?)?;
     m.add_class::<PySpendBundleConditions>()?;
     m.add_class::<PySpend>()?;
-    m.add("NO_NEG_DIV", NO_NEG_DIV)?;
     m.add("COND_CANON_INTS", COND_CANON_INTS)?;
     m.add("COND_ARGS_NIL", COND_ARGS_NIL)?;
     m.add("NO_UNKNOWN_CONDS", NO_UNKNOWN_CONDS)?;
-    m.add("NO_UNKNOWN_OPS", NO_UNKNOWN_OPS)?;
     m.add("STRICT_ARGS_COUNT", STRICT_ARGS_COUNT)?;
     m.add("MEMPOOL_MODE", MEMPOOL_MODE)?;
     //m.add_class::<Coin>()?;
     //m.add_class::<Fullblock>()?;
 
-    Ok(())
-}
+    // facilities from clvm_rs
 
-#[pyfunction]
-pub fn a_test_function() -> u128 {
-    500
+    m.add_function(wrap_pyfunction!(run_chia_program, m)?)?;
+    m.add("NO_NEG_DIV", NO_NEG_DIV)?;
+    m.add("NO_UNKNOWN_OPS", NO_UNKNOWN_OPS)?;
+
+    m.add_function(wrap_pyfunction!(serialized_length, m)?)?;
+
+    Ok(())
 }

--- a/wheel/src/lib.rs
+++ b/wheel/src/lib.rs
@@ -1,3 +1,4 @@
 mod adapt_response;
 mod api;
 mod run_generator;
+mod run_program;

--- a/wheel/src/run_program.rs
+++ b/wheel/src/run_program.rs
@@ -1,0 +1,90 @@
+use super::adapt_response::eval_err_to_pyresult;
+use clvmr::allocator::{Allocator, NodePtr, SExp};
+use clvmr::chia_dialect::ChiaDialect;
+use clvmr::cost::Cost;
+use clvmr::reduction::Response;
+use clvmr::run_program::run_program;
+use clvmr::serialize::{node_from_bytes, serialized_length_from_bytes};
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyTuple};
+use std::rc::Rc;
+
+#[pyclass(subclass, unsendable)]
+#[derive(Clone)]
+pub struct LazyNode {
+    allocator: Rc<Allocator>,
+    node: NodePtr,
+}
+
+impl ToPyObject for LazyNode {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        let node: &PyCell<LazyNode> = PyCell::new(py, self.clone()).unwrap();
+        let pa: &PyAny = node;
+        pa.to_object(py)
+    }
+}
+
+#[pymethods]
+impl LazyNode {
+    #[getter(pair)]
+    pub fn pair(&self, py: Python) -> PyResult<Option<PyObject>> {
+        match &self.allocator.sexp(self.node) {
+            SExp::Pair(p1, p2) => {
+                let r1 = Self::new(self.allocator.clone(), *p1);
+                let r2 = Self::new(self.allocator.clone(), *p2);
+                let v: &PyTuple = PyTuple::new(py, &[r1, r2]);
+                Ok(Some(v.into()))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    #[getter(atom)]
+    pub fn atom(&self, py: Python) -> Option<PyObject> {
+        match &self.allocator.sexp(self.node) {
+            SExp::Atom(atom) => Some(PyBytes::new(py, self.allocator.buf(atom)).into()),
+            _ => None,
+        }
+    }
+}
+
+impl LazyNode {
+    pub const fn new(a: Rc<Allocator>, n: NodePtr) -> Self {
+        Self {
+            allocator: a,
+            node: n,
+        }
+    }
+}
+
+#[pyfunction]
+pub fn serialized_length(program: &[u8]) -> PyResult<u64> {
+    Ok(serialized_length_from_bytes(program)?)
+}
+
+#[pyfunction]
+pub fn run_chia_program(
+    py: Python,
+    program: &[u8],
+    args: &[u8],
+    max_cost: Cost,
+    flags: u32,
+) -> PyResult<(Cost, LazyNode)> {
+    let mut allocator = Allocator::new();
+
+    let r: Response = (|| -> PyResult<Response> {
+        let program = node_from_bytes(&mut allocator, program)?;
+        let args = node_from_bytes(&mut allocator, args)?;
+        let dialect = ChiaDialect::new(flags);
+
+        Ok(py
+            .allow_threads(|| run_program(&mut allocator, &dialect, program, args, max_cost, None)))
+    })()?;
+    match r {
+        Ok(reduction) => {
+            let val = LazyNode::new(Rc::new(allocator), reduction.1);
+            Ok((reduction.0, val))
+        }
+        Err(eval_err) => eval_err_to_pyresult(py, eval_err, allocator),
+    }
+}


### PR DESCRIPTION
This makes it possible for chia-blockchain to only depend on the chia_rs module.

There's some duplicated code with `clvm_rs/wheel` here, I can't think of a way to avoid it, but I think it's still worth it.