### PR TITLE
add ToJsonDict trait and generic implementation for Streamable types

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,22 +35,32 @@ jobs:
       with:
         toolchain: stable
 
+    - name: setup venv
+      run: |
+        python -m venv venv
+        ln -s venv/bin/activate
+
     - name: Install dependencies
       run: |
+        . ./activate
         python -m pip install maturin
         rustup target add x86_64-unknown-linux-musl
+        python -m pip install pytest
 
     - name: Build
       env:
         CC: gcc
       run: |
-        python -m venv venv
-        ln -s venv/bin/activate
         . ./activate
         git clone https://github.com/Chia-Network/clvm_tools.git --branch=main --single-branch
         python -m pip install ./clvm_tools
         python -m pip install colorama
         maturin develop --release -m wheel/Cargo.toml
+
+    - name: python tests
+      run: |
+        . ./activate
+        pytest tests
 
     - name: test generators
       run: |

--- a/src/streamable/bytes.rs
+++ b/src/streamable/bytes.rs
@@ -20,6 +20,12 @@ impl From<&[u8]> for Bytes {
     }
 }
 
+impl fmt::Display for Bytes {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(&hex::encode(&self.0))
+    }
+}
+
 struct ByteVisitor<const N: usize>;
 
 impl<'de, const N: usize> serde::de::Visitor<'de> for ByteVisitor<N> {
@@ -113,6 +119,11 @@ impl<const N: usize> BytesImpl<N> {
 
 impl<const N: usize> Debug for BytesImpl<N> {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        formatter.write_str(&hex::encode(self.0))
+    }
+}
+impl<const N: usize> fmt::Display for BytesImpl<N> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str(&hex::encode(self.0))
     }
 }

--- a/tests/test_streamable.py
+++ b/tests/test_streamable.py
@@ -1,0 +1,34 @@
+from chia_rs import PySpend, PySpendBundleConditions
+
+
+def test_json_spend() -> None:
+
+    coin = b"bcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbc"
+    ph = b"abababababababababababababababab"
+    ph2 = b"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
+    sig = b"abababababababababababababababababababababababab"
+    a = PySpend(coin, ph, None, 0, [(ph2, 1000000, None)], [(sig, b"msg")])
+
+    assert a.to_json_dict() == {
+        "coin_id": "0x" + coin.hex(),
+        "puzzle_hash": "0x" + ph.hex(),
+        "height_relative": None,
+        "seconds_relative": 0,
+        "create_coin": [["0x" + ph2.hex(), 1000000, None]],
+        "agg_sig_me": [["0x" + sig.hex(), "0x6d7367"]],
+    }
+
+
+def test_json_spend_bundle_conditions() -> None:
+
+    sig = b"abababababababababababababababababababababababab"
+    a = PySpendBundleConditions([], 1000, 1337, 42, [(sig, b"msg")], 12345678)
+
+    assert a.to_json_dict() == {
+        "spends": [],
+        "reserve_fee": 1000,
+        "height_absolute": 1337,
+        "seconds_absolute": 42,
+        "agg_sig_unsafe": [["0x" + sig.hex(), "0x6d7367"]],
+        "cost": 12345678,
+    }

--- a/wheel/py_streamable/src/lib.rs
+++ b/wheel/py_streamable/src/lib.rs
@@ -80,6 +80,18 @@ pub fn py_streamable_macro(input: TokenStream) -> TokenStream {
                     pub fn __bytes__<'p>(&self, py: Python<'p>) -> PyResult<&'p PyBytes> {
                         Ok(PyBytes::new(py, &self.to_bytes()?))
                     }
+
+                    pub fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {
+                        ToJsonDict::to_json_dict(self, py)
+                    }
+                }
+
+                impl ToJsonDict for #ident {
+                    fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {
+                        let ret = PyDict::new(py);
+                        #(ret.set_item(stringify!(#fnames), self.#fnames.to_json_dict(py)?)?);*;
+                        Ok(ret.into())
+                    }
                 }
             }
         }

--- a/wheel/src/lib.rs
+++ b/wheel/src/lib.rs
@@ -2,3 +2,4 @@ mod adapt_response;
 mod api;
 mod run_generator;
 mod run_program;
+mod to_json_dict;

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -1,4 +1,5 @@
 use super::adapt_response::eval_err_to_pyresult;
+use super::to_json_dict::ToJsonDict;
 
 use chia::gen::conditions::{parse_spends, Spend, SpendBundleConditions};
 use chia::gen::validation_error::{ErrorCode, ValidationErr};
@@ -16,7 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use pyo3::class::basic::{CompareOp, PyObjectProtocol};
 use pyo3::prelude::*;
-use pyo3::types::PyBytes;
+use pyo3::types::{PyBytes, PyDict};
 
 use py_streamable::Streamable;
 

--- a/wheel/src/to_json_dict.rs
+++ b/wheel/src/to_json_dict.rs
@@ -1,0 +1,70 @@
+use chia::streamable::bytes::{Bytes, BytesImpl};
+use pyo3::prelude::*;
+use pyo3::types::PyList;
+
+pub trait ToJsonDict {
+    fn to_json_dict(&self, py: Python) -> PyResult<PyObject>;
+}
+
+impl ToJsonDict for u32 {
+    fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {
+        Ok(self.to_object(py))
+    }
+}
+
+impl ToJsonDict for u64 {
+    fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {
+        Ok(self.to_object(py))
+    }
+}
+
+impl<const N: usize> ToJsonDict for BytesImpl<N> {
+    fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {
+        Ok(format!("0x{}", self).to_object(py))
+    }
+}
+
+impl ToJsonDict for Bytes {
+    fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {
+        Ok(format!("0x{}", self).to_object(py))
+    }
+}
+
+impl<T: ToJsonDict> ToJsonDict for Vec<T> {
+    fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {
+        let list = PyList::empty(py);
+        for v in self {
+            list.append(v.to_json_dict(py)?)?;
+        }
+        Ok(list.into())
+    }
+}
+
+impl<T: ToJsonDict> ToJsonDict for Option<T> {
+    fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {
+        match self {
+            None => Ok(py.None()),
+            Some(v) => Ok(v.to_json_dict(py)?),
+        }
+    }
+}
+
+// if we need more of these, we should probably make a macro
+impl<T: ToJsonDict, U: ToJsonDict> ToJsonDict for (T, U) {
+    fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {
+        let list = PyList::empty(py);
+        list.append(self.0.to_json_dict(py)?)?;
+        list.append(self.1.to_json_dict(py)?)?;
+        Ok(list.into())
+    }
+}
+
+impl<T: ToJsonDict, U: ToJsonDict, W: ToJsonDict> ToJsonDict for (T, U, W) {
+    fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {
+        let list = PyList::empty(py);
+        list.append(self.0.to_json_dict(py)?)?;
+        list.append(self.1.to_json_dict(py)?)?;
+        list.append(self.2.to_json_dict(py)?)?;
+        Ok(list.into())
+    }
+}


### PR DESCRIPTION
converting these two type, `PySpend` and `PySpendBundleConditions`, into json isn't critical, but we rely on it for `__str__()` on streamable types, which is used in tests (and one error log).