### PR TITLE
improve the parse_rust() function to accept a buffer

### DIFF
--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -51,7 +51,7 @@ jobs:
             if [ ! -f "activate" ]; then ln -s venv/bin/activate; fi && \
             . ./activate && \
             pip install maturin && \
-            CC=gcc maturin build --no-sdist --release --manylinux 2014 -m wheel/Cargo.toml \
+            CC=gcc maturin build --release --manylinux 2014 -m wheel/Cargo.toml \
           '
 
     - name: Upload artifacts

--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [[ARM64, Linux]]
+        python: ["cp37-cp37m", "cp38-cp38", "cp39-cp39"]
 
     steps:
     - name: Checkout repository
@@ -34,6 +35,7 @@ jobs:
     - name: Build Python wheels
       run: |
         podman run --rm=true \
+          --env PYVER=${{ matrix.python }} \
           -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
           quay.io/pypa/manylinux2014_aarch64 \
           bash -exc '\
@@ -44,12 +46,10 @@ jobs:
             source $HOME/.cargo/env && \
             rustup target add aarch64-unknown-linux-musl && \
             rm -rf venv && \
-            export PATH=/opt/python/cp39-cp39/bin/:$PATH && \
-            export PATH=/opt/python/cp38-cp38/bin/:$PATH && \
-            export PATH=/opt/python/cp37-cp37m/bin/:$PATH && \
-            /opt/python/cp38-cp38/bin/python -m venv venv && \
+            /opt/python/${PYVER}/bin/python -m venv venv && \
             if [ ! -f "activate" ]; then ln -s venv/bin/activate; fi && \
             . ./activate && \
+            python --version && \
             pip install maturin && \
             CC=gcc maturin build --release --manylinux 2014 -m wheel/Cargo.toml \
           '

--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [[ARM64, Linux]]
-        python: ["cp37-cp37m", "cp38-cp38", "cp39-cp39"]
+        python: ["cp37-cp37m", "cp38-cp38", "cp39-cp39", "cp310-cp310"]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -40,7 +40,7 @@ jobs:
         . ./venv/bin/activate
         export PATH=~/.cargo/bin:$PATH
         arch -arm64 pip install maturin
-        arch -arm64 maturin build --no-sdist -i python --release -m wheel/Cargo.toml
+        arch -arm64 maturin build -i python --release -m wheel/Cargo.toml
 
     - name: Install chia_rs wheel
       run: |

--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: [m1]
     strategy:
       fail-fast: false
+      matrix:
+        python: ["3.8", "3.9", "3.10"]
 
     steps:
     - name: Cancel previous runs on the same branch
@@ -23,6 +25,9 @@ jobs:
       uses: styfle/cancel-workflow-action@0.7.0
       with:
         access_token: ${{ github.token }}
+
+    - name: Install Python ${{ matrix.python }}
+      run: brew install python@${{ matrix.python }}
 
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,14 +18,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: [3.7]
+        python: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       name: Install Python ${{ matrix.python }}
       with:
         python-version: ${{ matrix.python }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -75,7 +75,7 @@ jobs:
             . /venv/bin/activate && \
             pip install --upgrade pip && \
             pip install maturin && \
-            CC=gcc maturin build --release --manylinux 2010 -i python -m wheel/Cargo.toml \
+            CC=gcc maturin build --sdist --release --manylinux 2010 -i python -m wheel/Cargo.toml \
           '
           python -m venv venv
           ln -s venv/bin/activate

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,7 +49,7 @@ jobs:
         python -m venv venv
         ln -s venv/bin/activate
         . ./activate
-        maturin build --no-sdist -i python --release -m wheel/Cargo.toml
+        maturin build -i python --release -m wheel/Cargo.toml
 
     - name: Build Linux in manylinux2010 with maturin on Python ${{ matrix.python }}
       if: startsWith(matrix.os, 'ubuntu')
@@ -86,7 +86,7 @@ jobs:
         python -m venv venv
         . .\venv\Scripts\Activate.ps1
         ln -s venv\Scripts\Activate.ps1 activate
-        maturin build --no-sdist -i python --release -m wheel/Cargo.toml
+        maturin build -i python --release -m wheel/Cargo.toml
         # this will install into the venv
         # it'd be better to use the wheel, but I can't figure out how to do that
         # TODO: figure this out
@@ -101,7 +101,7 @@ jobs:
         ls target/wheels/
         # this mess puts the name of the `.whl` file into `$WHEEL_PATH`
         # remove the dot, use the `glob` lib to grab the file from the directory
-        WHEEL_PATH=$(echo ${{ matrix.python }} | python -c 'DOTLESS=input().replace(".", ""); import glob; print(" ".join(glob.glob("target/wheels/chia_rs-*-cp%s-abi*.whl" % DOTLESS)))' )
+        WHEEL_PATH=$(echo ${{ matrix.python }} | python -c 'DOTLESS=input().replace(".", ""); import glob; print(" ".join(glob.glob("target/wheels/chia_rs-*-cp%s-*.whl" % DOTLESS)))' )
         echo ${WHEEL_PATH}
         pip install ${WHEEL_PATH}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ py-bindings = ["dep:pyo3"]
 
 [dependencies]
 serde = { version = "1.0.130", features = ["derive", "rc"] }
-clvmr = "=0.1.20"
+clvmr = "=0.1.22"
 # bincode = { git = "https://github.com/richardkiss/bincode", branch = "chia" }
 # the patched bincode is needed to enable serialization. However, a github dependency disqualifies
 # any build crates from being uploaded to crates.io, so this is temporarily disabled.
 hex = "=0.4.3"
-pyo3 = { version = "=0.15.1", features = ["abi3-py37", "extension-module"], optional = true }
+pyo3 = { version = "=0.15.1", features = ["extension-module"], optional = true }
 
 [dev-dependencies]
-num-traits = "=0.2.14"
+num-traits = "=0.2.15"
 
 [lib]
 name = "chia"

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -16,9 +16,9 @@ path = "src/lib.rs"
 
 [dependencies]
 chia = { path = "..", features = ["py-bindings"] }
-clvmr = "=0.1.20"
+clvmr = "=0.1.22"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
-pyo3 = { version = "=0.15.1", features = ["abi3-py37", "extension-module", "multiple-pymethods"] }
+pyo3 = { version = "=0.15.1", features = ["extension-module", "multiple-pymethods"] }
 py_streamable = { path = "py_streamable" }
 hex = "=0.4.3"
 sha2 = "=0.9.5"

--- a/wheel/src/coin.rs
+++ b/wheel/src/coin.rs
@@ -10,6 +10,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 use chia::streamable::bytes::Bytes32;
+use pyo3::buffer::PyBuffer;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
 use sha2::{Digest, Sha256};

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -18,6 +18,7 @@ use clvmr::run_program::run_program;
 use clvmr::serialize::node_from_bytes;
 use serde::{Deserialize, Serialize};
 
+use pyo3::buffer::PyBuffer;
 use pyo3::class::basic::{CompareOp, PyObjectProtocol};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};


### PR DESCRIPTION
This avoids a copy of the entire serialized buffer when calling `parse_rust()`. It especially speeds up wallet sync:

main:
```
INFO     Successfully subscribed and updated 103906 coin ids
INFO     Sync (trusted: True) duration was: 148.95257115364075
```

with this patch:
```
INFO     Successfully subscribed and updated 103906 coin ids
INFO     Sync (trusted: True) duration was: 123.46990084648132
```

The CPU profile of the wallet sync looks like this:

main:

![chia-hotspot-2](https://user-images.githubusercontent.com/661450/180912552-a35a3e30-539e-4f8a-986e-22cd74517b21.png)

this patch:

![chia-hotspot-2](https://user-images.githubusercontent.com/661450/180912767-e59cd8ed-8628-4da1-b873-28abc69624d6.png)

