### PR TITLE
add support for get_hash() to the Streamable trait and the derive macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ py-bindings = ["dep:pyo3"]
 clvmr = "=0.1.22"
 hex = "=0.4.3"
 pyo3 = { version = "=0.15.1", features = ["extension-module"], optional = true }
-chia_streamable_macro = { version = "=0.1.0", path = "chia_streamable_macro" }
+chia_streamable_macro = { version = "=0.2.1", path = "chia_streamable_macro" }
 
 [dev-dependencies]
 num-traits = "=0.2.15"

--- a/chia_streamable_macro/Cargo.toml
+++ b/chia_streamable_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia_streamable_macro"
-version = "0.1.0"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Streamable derive macro for serializing/deserializing types in Chia protocol format"

--- a/chia_streamable_macro/src/lib.rs
+++ b/chia_streamable_macro/src/lib.rs
@@ -37,6 +37,9 @@ pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
 
     let ret = quote! {
         impl Streamable for #ident {
+            fn update_digest(&self, digest: &mut Sha256) {
+                #(self.#fnames.update_digest(digest);)*
+            }
             fn stream(&self, out: &mut Vec<u8>) -> chia_error::Result<()> {
                 #(self.#fnames.stream(out)?;)*
                 Ok(())

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -19,5 +19,5 @@ chia = { path = "..", features = ["py-bindings"] }
 clvmr = "=0.1.22"
 pyo3 = { version = "=0.15.1", features = ["extension-module", "multiple-pymethods"] }
 py_streamable = { path = "py_streamable" }
-chia_streamable_macro = { version = "0.1.0", path = "../chia_streamable_macro" }
+chia_streamable_macro = { version = "0.2.1", path = "../chia_streamable_macro" }
 hex = "=0.4.3"

--- a/wheel/py_streamable/src/lib.rs
+++ b/wheel/py_streamable/src/lib.rs
@@ -80,6 +80,11 @@ pub fn py_streamable_macro(input: TokenStream) -> TokenStream {
                         Self::parse(&mut input).map_err(|e| <chia::chia_error::Error as Into<PyErr>>::into(e)).map(|v| (v, input.position() as u32))
                     }
 
+                    pub fn get_hash<'p>(&self, py: Python<'p>) -> PyResult<&'p PyBytes> {
+                        let mut ctx = Sha256::new();
+                        Streamable::update_digest(self, &mut ctx);
+                        Ok(PyBytes::new(py, &ctx.finish()))
+                    }
                     pub fn to_bytes<'p>(&self, py: Python<'p>) -> PyResult<&'p PyBytes> {
                         let mut writer = Vec::<u8>::new();
                         self.stream(&mut writer).map_err(|e| <chia::chia_error::Error as Into<PyErr>>::into(e))?;

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -14,6 +14,7 @@ use clvmr::cost::Cost;
 use clvmr::reduction::{EvalErr, Reduction};
 use clvmr::run_program::run_program;
 use clvmr::serialize::node_from_bytes;
+use clvmr::sha2::Sha256;
 
 use pyo3::buffer::PyBuffer;
 use pyo3::class::basic::{CompareOp, PyObjectProtocol};


### PR DESCRIPTION
This mirrors the python `Streamable` protocol, which has a `get_hash()` function. Although, the one I added here nests by taking the hashing context by mutable reference. The python binding wraps it to give it the same behavior as in python though.