### PR TITLE
turn tree_hash() into non-recursive implementation

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -42,3 +42,9 @@ name = "parse-conditions"
 path = "fuzz_targets/parse-conditions.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "tree-hash"
+path = "fuzz_targets/tree-hash.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/tree-hash.rs
+++ b/fuzz/fuzz_targets/tree-hash.rs
@@ -1,0 +1,12 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use clvmr::allocator::Allocator;
+use chia::fuzzing_utils::{BitCursor, make_tree};
+use chia::gen::get_puzzle_and_solution::tree_hash;
+
+fuzz_target!(|data: &[u8]| {
+    let mut a = Allocator::new();
+    let input = make_tree(&mut a, &mut BitCursor::new(data));
+    let _ret = tree_hash(&a, input);
+});

--- a/src/gen/get_puzzle_and_solution.rs
+++ b/src/gen/get_puzzle_and_solution.rs
@@ -5,24 +5,43 @@ use clvmr::op_utils::u64_from_bytes;
 use clvmr::sha2::{Digest, Sha256};
 use std::convert::AsRef;
 
-// TOOD: make this not recursive
+enum TreeOp {
+    SExp(NodePtr),
+    Cons,
+}
+
 // TODO: perhaps this should move to clvm_rs
-fn tree_hash(a: &Allocator, node: NodePtr) -> [u8; 32] {
-    match a.sexp(node) {
-        SExp::Atom(atom) => {
-            let mut sha256 = Sha256::new();
-            sha256.update(&[1_u8]);
-            sha256.update(a.buf(&atom));
-            sha256.finalize().into()
-        }
-        SExp::Pair(left, right) => {
-            let mut sha256 = Sha256::new();
-            sha256.update(&[2_u8]);
-            sha256.update(tree_hash(a, left));
-            sha256.update(tree_hash(a, right));
-            sha256.finalize().into()
+pub fn tree_hash(a: &Allocator, node: NodePtr) -> [u8; 32] {
+    let mut hashes: Vec<[u8; 32]> = vec![];
+    let mut ops = vec![TreeOp::SExp(node)];
+
+    while !ops.is_empty() {
+        match ops.pop().unwrap() {
+            TreeOp::SExp(node) => match a.sexp(node) {
+                SExp::Atom(atom) => {
+                    let mut sha256 = Sha256::new();
+                    sha256.update([1_u8]);
+                    sha256.update(a.buf(&atom));
+                    hashes.push(sha256.finalize().into())
+                }
+                SExp::Pair(left, right) => {
+                    ops.push(TreeOp::Cons);
+                    ops.push(TreeOp::SExp(left));
+                    ops.push(TreeOp::SExp(right));
+                }
+            },
+            TreeOp::Cons => {
+                let mut sha256 = Sha256::new();
+                sha256.update([2_u8]);
+                sha256.update(hashes.pop().unwrap());
+                sha256.update(hashes.pop().unwrap());
+                hashes.push(sha256.finalize().into());
+            }
         }
     }
+
+    assert!(hashes.len() == 1);
+    hashes[0]
 }
 
 // returns parent-coin ID, amount, puzzle-reveal and solution
@@ -260,12 +279,34 @@ fn test_tree_hash() {
     };
 
     // test tree hash
-    {
+    let root_hash = {
         let mut sha256 = Sha256::new();
         sha256.update(&[2_u8]);
         sha256.update(atom1_hash.as_slice());
         sha256.update(atom2_hash.as_slice());
+        let root_hash = sha256.finalize();
 
-        assert_eq!(tree_hash(&a, root), sha256.finalize().as_slice());
+        assert_eq!(tree_hash(&a, root), root_hash.as_slice());
+        root_hash
+    };
+
+    let atom3 = a.new_atom(&[7, 8, 9]).unwrap();
+    let root2 = a.new_pair(root, atom3).unwrap();
+
+    let atom3_hash = {
+        let mut sha256 = Sha256::new();
+        sha256.update(&[1_u8]);
+        sha256.update(&[7, 8, 9]);
+        sha256.finalize()
+    };
+
+    // test deeper tree hash
+    {
+        let mut sha256 = Sha256::new();
+        sha256.update(&[2_u8]);
+        sha256.update(root_hash.as_slice());
+        sha256.update(atom3_hash.as_slice());
+
+        assert_eq!(tree_hash(&a, root2), sha256.finalize().as_slice());
     }
 }


### PR DESCRIPTION
harden the `tree_hash()` function by moving away from a recursive implementation.
extend unit test
add fuzzer