### PR TITLE
make python types sendable

### DIFF
--- a/wheel/src/coin.rs
+++ b/wheel/src/coin.rs
@@ -11,7 +11,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use std::convert::TryInto;
 
-#[pyclass(unsendable)]
+#[pyclass]
 #[derive(Streamable, PyStreamable, Hash, Debug, Clone, Eq, PartialEq)]
 pub struct Coin {
     #[pyo3(get)]

--- a/wheel/src/coin_state.rs
+++ b/wheel/src/coin_state.rs
@@ -8,7 +8,7 @@ use py_streamable::PyStreamable;
 
 use pyo3::prelude::*;
 
-#[pyclass(unsendable)]
+#[pyclass]
 #[derive(Streamable, PyStreamable, Hash, Debug, Clone, Eq, PartialEq)]
 pub struct CoinState {
     #[pyo3(get)]

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -20,7 +20,7 @@ use chia::streamable::Streamable;
 use chia_streamable_macro::Streamable;
 use py_streamable::PyStreamable;
 
-#[pyclass(unsendable, name = "Spend")]
+#[pyclass(name = "Spend")]
 #[derive(Streamable, PyStreamable, Hash, Debug, Clone, Eq, PartialEq)]
 pub struct PySpend {
     #[pyo3(get)]
@@ -37,7 +37,7 @@ pub struct PySpend {
     pub agg_sig_me: Vec<(Bytes48, Bytes)>,
 }
 
-#[pyclass(unsendable, name = "SpendBundleConditions")]
+#[pyclass(name = "SpendBundleConditions")]
 #[derive(Streamable, PyStreamable, Hash, Debug, Clone, Eq, PartialEq)]
 pub struct PySpendBundleConditions {
     #[pyo3(get)]


### PR DESCRIPTION
This allows them to be used across threads in python