### PR TITLE
support Tuples (unnamed members)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ py-bindings = ["dep:pyo3"]
 clvmr = "=0.1.23"
 hex = "=0.4.3"
 pyo3 = { version = "=0.15.1", features = ["extension-module"], optional = true }
-chia_streamable_macro = { version = "=0.2.2", path = "chia_streamable_macro" }
+chia_streamable_macro = { version = "=0.2.3", path = "chia_streamable_macro" }
 
 [dev-dependencies]
 num-traits = "=0.2.15"

--- a/chia_streamable_macro/Cargo.toml
+++ b/chia_streamable_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia_streamable_macro"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Streamable derive macro for serializing/deserializing types in Chia protocol format"

--- a/chia_streamable_macro/src/lib.rs
+++ b/chia_streamable_macro/src/lib.rs
@@ -2,7 +2,7 @@ extern crate proc_macro;
 #[macro_use]
 extern crate quote;
 
-use syn::{parse_macro_input, DeriveInput, FieldsNamed};
+use syn::{parse_macro_input, DeriveInput, FieldsNamed, FieldsUnnamed};
 
 use proc_macro::TokenStream;
 
@@ -11,6 +11,7 @@ pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
     let DeriveInput { ident, data, .. } = parse_macro_input!(input);
 
     let mut fnames = Vec::<syn::Ident>::new();
+    let mut findices = Vec::<syn::Index>::new();
     let mut ftypes = Vec::<syn::Type>::new();
     match data {
         syn::Data::Enum(_) => {
@@ -20,8 +21,11 @@ pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
             panic!("Streamable does not support Unions");
         }
         syn::Data::Struct(s) => match s.fields {
-            syn::Fields::Unnamed(_) => {
-                panic!("Streamable does not support tuples");
+            syn::Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => {
+                for (index, f) in unnamed.iter().enumerate() {
+                    findices.push(syn::Index::from(index));
+                    ftypes.push(f.ty.clone());
+                }
             }
             syn::Fields::Unit => {
                 panic!("Streamable does not support the unit type");
@@ -35,19 +39,39 @@ pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
         },
     };
 
-    let ret = quote! {
-        impl Streamable for #ident {
-            fn update_digest(&self, digest: &mut clvmr::sha2::Sha256) {
-                #(self.#fnames.update_digest(digest);)*
+    if !fnames.is_empty() {
+        let ret = quote! {
+            impl Streamable for #ident {
+                fn update_digest(&self, digest: &mut clvmr::sha2::Sha256) {
+                    #(self.#fnames.update_digest(digest);)*
+                }
+                fn stream(&self, out: &mut Vec<u8>) -> chia_error::Result<()> {
+                    #(self.#fnames.stream(out)?;)*
+                    Ok(())
+                }
+                fn parse(input: &mut std::io::Cursor<&[u8]>) -> chia_error::Result<Self> {
+                    Ok(#ident{ #( #fnames: <#ftypes as Streamable>::parse(input)?, )* })
+                }
             }
-            fn stream(&self, out: &mut Vec<u8>) -> chia_error::Result<()> {
-                #(self.#fnames.stream(out)?;)*
-                Ok(())
+        };
+        ret.into()
+    } else if !findices.is_empty() {
+        let ret = quote! {
+            impl Streamable for #ident {
+                fn update_digest(&self, digest: &mut clvmr::sha2::Sha256) {
+                    #(self.#findices.update_digest(digest);)*
+                }
+                fn stream(&self, out: &mut Vec<u8>) -> chia_error::Result<()> {
+                    #(self.#findices.stream(out)?;)*
+                    Ok(())
+                }
+                fn parse(input: &mut std::io::Cursor<&[u8]>) -> chia_error::Result<Self> {
+                    Ok(#ident( #( <#ftypes as Streamable>::parse(input)?, )* ))
+                }
             }
-            fn parse(input: &mut std::io::Cursor<&[u8]>) -> chia_error::Result<Self> {
-                Ok(#ident{ #( #fnames: <#ftypes as Streamable>::parse(input)?, )* })
-            }
-        }
-    };
-    ret.into()
+        };
+        ret.into()
+    } else {
+        panic!("unknown error");
+    }
 }

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -19,5 +19,5 @@ chia = { path = "..", features = ["py-bindings"] }
 clvmr = "=0.1.23"
 pyo3 = { version = "=0.15.1", features = ["extension-module", "multiple-pymethods"] }
 py_streamable = { path = "py_streamable" }
-chia_streamable_macro = { version = "0.2.2", path = "../chia_streamable_macro" }
+chia_streamable_macro = { version = "0.2.3", path = "../chia_streamable_macro" }
 hex = "=0.4.3"


### PR DESCRIPTION
as well as 128 bit integral types in the rust streamable macro.

Plain tuples were already supported (up to a few fields). This adds support for arbitrary types with unnamed members. i.e. when you define a type like this:

```
struct G1Element([u8;48]);
```

This is a step towards being able to have more chia types in rust. The wallet-protocol types are next on my list.