### PR TITLE
add uncurry() function to clvm-utils

### DIFF
--- a/clvm-utils/fuzz/Cargo.toml
+++ b/clvm-utils/fuzz/Cargo.toml
@@ -27,3 +27,9 @@ name = "tree-hash"
 path = "fuzz_targets/tree-hash.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "uncurry"
+path = "fuzz_targets/uncurry.rs"
+test = false
+doc = false

--- a/clvm-utils/fuzz/fuzz_targets/tree-hash.rs
+++ b/clvm-utils/fuzz/fuzz_targets/tree-hash.rs
@@ -7,6 +7,6 @@ use clvm_utils::tree_hash::tree_hash;
 
 fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();
-    let input = make_tree(&mut a, &mut BitCursor::new(data));
+    let input = make_tree(&mut a, &mut BitCursor::new(data), false);
     let _ret = tree_hash(&a, input);
 });

--- a/clvm-utils/fuzz/fuzz_targets/uncurry.rs
+++ b/clvm-utils/fuzz/fuzz_targets/uncurry.rs
@@ -3,11 +3,10 @@ use libfuzzer_sys::fuzz_target;
 
 use clvmr::allocator::Allocator;
 use chia::fuzzing_utils::{BitCursor, make_tree};
-use chia::gen::get_puzzle_and_solution::parse_coin_spend;
+use clvm_utils::uncurry::uncurry;
 
 fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();
-    let input = make_tree(&mut a, &mut BitCursor::new(data), false);
-
-    let _ret = parse_coin_spend(&a, input);
+    let input = make_tree(&mut a, &mut BitCursor::new(data), true);
+    let _ret = uncurry(&a, input);
 });

--- a/clvm-utils/src/lib.rs
+++ b/clvm-utils/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod tree_hash;
+pub mod uncurry;

--- a/clvm-utils/src/uncurry.rs
+++ b/clvm-utils/src/uncurry.rs
@@ -1,0 +1,194 @@
+use clvmr::allocator::{Allocator, NodePtr};
+use clvmr::node::Node;
+
+fn unwrap3(node: Node) -> Option<(Node, Node, Node)> {
+    let mut i = node;
+    let n1 = i.next()?;
+    let n2 = i.next()?;
+    let n3 = i.next()?;
+    if i.next().is_some() {
+        return None;
+    }
+    Some((n1, n2, n3))
+}
+
+fn check(n: &Node, atom: &[u8]) -> Option<()> {
+    if n.atom()? == atom {
+        Some(())
+    } else {
+        None
+    }
+}
+
+fn unwrap_quote(node: Node) -> Option<Node> {
+    let p = node.pair()?;
+    check(&p.0, &[1_u8])?;
+    Some(p.1)
+}
+
+// matches
+// (2 (1 . self) rest)
+// returning (self, rest)
+fn match_wrapper(node: Node) -> Option<(Node, Node)> {
+    let (ev, quoted_inner, args_list) = unwrap3(node)?;
+    check(&ev, &[2_u8])?;
+    let inner = unwrap_quote(quoted_inner)?;
+    Some((inner, args_list))
+}
+
+// returns the inner puzzle and the list of arguments, or Err, in case the node
+// is not conforming to the standard curry format
+pub fn uncurry(a: &Allocator, node: NodePtr) -> Option<(NodePtr, Vec<NodePtr>)> {
+    let mut ret_args = Vec::<NodePtr>::new();
+
+    let n = Node::new(a, node);
+    let (inner, args) = match_wrapper(n)?;
+
+    let mut rest = args;
+    while rest.pair().is_some() {
+        // match
+        // (4 (1 . <arg>) <rest>)
+        let (cons, quoted_arg, r) = unwrap3(rest.clone())?;
+        rest = r;
+        let arg = unwrap_quote(quoted_arg)?;
+        check(&cons, &[4_u8])?;
+        ret_args.push(arg.node);
+    }
+    Some((inner.node, ret_args))
+}
+
+// ==== tests ===
+
+#[test]
+fn simple_uncurry() {
+    let mut a = Allocator::new();
+    let inner = a.new_atom(b"abcdefghijklmnopqrstuvwxyz012345").unwrap();
+    let null = a.null();
+    let quote = a.one();
+    let apply = a.new_atom(&[2_u8]).unwrap();
+    let cons = a.new_atom(&[4_u8]).unwrap();
+    let foobar = a.new_atom(b"foobar").unwrap();
+
+    // (q . "foobar")
+    let quoted_foobar = a.new_pair(quote, foobar).unwrap();
+    // (c (q . "fobar") ())
+    // 3 times, for 3 foobar arguments
+    let args = a.new_pair(null, null).unwrap();
+    let args = a.new_pair(quoted_foobar, args).unwrap();
+    let args = a.new_pair(cons, args).unwrap();
+
+    let args = a.new_pair(args, null).unwrap();
+    let args = a.new_pair(quoted_foobar, args).unwrap();
+    let args = a.new_pair(cons, args).unwrap();
+
+    let args = a.new_pair(args, null).unwrap();
+    let args = a.new_pair(quoted_foobar, args).unwrap();
+    let args = a.new_pair(cons, args).unwrap();
+
+    let quoted_inner = a.new_pair(quote, inner).unwrap();
+
+    let wrapper = a.new_pair(args, null).unwrap();
+    let wrapper = a.new_pair(quoted_inner, wrapper).unwrap();
+    let wrapper = a.new_pair(apply, wrapper).unwrap();
+
+    assert!(uncurry(&a, wrapper).unwrap() == (inner, vec![foobar, foobar, foobar]));
+}
+
+#[test]
+fn test_unwrap_quote() {
+    let mut a = Allocator::new();
+    let quote = a.one();
+    let foobar = a.new_atom(b"foobar").unwrap();
+    let quoted_foobar = a.new_pair(quote, foobar).unwrap();
+    let double_quoted_foobar = a.new_pair(quote, quoted_foobar).unwrap();
+    let invalid_quote = a.new_pair(a.null(), foobar).unwrap();
+
+    // positive tests
+    assert_eq!(
+        unwrap_quote(Node::new(&a, quoted_foobar)).unwrap().node,
+        foobar
+    );
+    assert_eq!(
+        unwrap_quote(Node::new(&a, double_quoted_foobar))
+            .unwrap()
+            .node,
+        quoted_foobar
+    );
+
+    // negative tests
+    assert!(unwrap_quote(Node::new(&a, foobar)).is_none());
+    assert!(unwrap_quote(Node::new(&a, invalid_quote)).is_none());
+    assert!(unwrap_quote(Node::new(&a, a.null())).is_none());
+}
+
+#[test]
+fn test_check() {
+    let mut a = Allocator::new();
+    let quote = a.one();
+    let foobar = a.new_atom(b"foobar").unwrap();
+    let quoted_foobar = a.new_pair(quote, foobar).unwrap();
+
+    assert!(check(&Node::new(&a, quote), &[1_u8]).is_some());
+    assert!(check(&Node::new(&a, foobar), b"foobar").is_some());
+
+    // the wrong atom value
+    assert!(check(&Node::new(&a, foobar), &[1_u8]).is_none());
+    assert!(check(&Node::new(&a, quote), b"foobar").is_none());
+
+    // pairs alwaus fail
+    assert!(check(&Node::new(&a, quoted_foobar), b"foobar").is_none());
+    assert!(check(&Node::new(&a, quoted_foobar), &[1_u8]).is_none());
+}
+
+#[test]
+fn test_unwrap3() {
+    let mut a = Allocator::new();
+    let foobar = a.new_atom(b"foobar").unwrap();
+    let list1 = a.new_pair(foobar, a.null()).unwrap();
+    let list2 = a.new_pair(foobar, list1).unwrap();
+    let list3 = a.new_pair(foobar, list2).unwrap();
+    let list4 = a.new_pair(foobar, list3).unwrap();
+
+    // negative tests
+    assert!(unwrap3(Node::new(&a, foobar)).is_none());
+    assert!(unwrap3(Node::new(&a, list1)).is_none());
+    assert!(unwrap3(Node::new(&a, list2)).is_none());
+    assert!(unwrap3(Node::new(&a, list4)).is_none());
+
+    // positive test
+    let foobar_tuple = unwrap3(Node::new(&a, list3)).unwrap();
+    assert!(foobar_tuple.0.node == foobar);
+    assert!(foobar_tuple.1.node == foobar);
+    assert!(foobar_tuple.2.node == foobar);
+}
+
+#[test]
+fn test_match_wrapper() {
+    let mut a = Allocator::new();
+    let apply = a.new_atom(&[2_u8]).unwrap();
+    let rest = a.new_atom(b"args").unwrap();
+    let inner = a.new_atom(b"inner").unwrap();
+    let quoted_inner = a.new_pair(a.one(), inner).unwrap();
+
+    let input2 = a.new_pair(rest, a.null()).unwrap();
+    let input1 = a.new_pair(quoted_inner, input2).unwrap();
+    let input = a.new_pair(apply, input1).unwrap();
+    let invalid_input = a.new_pair(a.one(), input1).unwrap();
+    let long_input = a.new_pair(apply, input).unwrap();
+
+    // input: (2 (1 . self) rest)
+    // returns: (self, rest)
+    let matched = match_wrapper(Node::new(&a, input)).unwrap();
+    assert!(matched.0.node == inner);
+    assert!(matched.1.node == rest);
+
+    // negative tests
+    assert!(match_wrapper(Node::new(&a, long_input)).is_none());
+    assert!(match_wrapper(Node::new(&a, invalid_input)).is_none());
+    assert!(match_wrapper(Node::new(&a, quoted_inner)).is_none());
+    assert!(match_wrapper(Node::new(&a, apply)).is_none());
+    assert!(match_wrapper(Node::new(&a, rest)).is_none());
+    assert!(match_wrapper(Node::new(&a, inner)).is_none());
+    assert!(match_wrapper(Node::new(&a, input2)).is_none());
+    assert!(match_wrapper(Node::new(&a, input1)).is_none());
+}

--- a/fuzz/fuzz_targets/parse-cond-args.rs
+++ b/fuzz/fuzz_targets/parse-cond-args.rs
@@ -17,7 +17,7 @@ use chia::gen::opcodes::{
 
 fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();
-    let input = make_tree(&mut a, &mut BitCursor::new(data));
+    let input = make_tree(&mut a, &mut BitCursor::new(data), false);
     for flags in &[0, COND_ARGS_NIL, STRICT_ARGS_COUNT] {
         for op in &[AGG_SIG_ME, AGG_SIG_UNSAFE, ALWAYS_TRUE,
     ASSERT_COIN_ANNOUNCEMENT, ASSERT_HEIGHT_ABSOLUTE, ASSERT_HEIGHT_RELATIVE, ASSERT_MY_AMOUNT,

--- a/fuzz/fuzz_targets/parse-conditions.rs
+++ b/fuzz/fuzz_targets/parse-conditions.rs
@@ -9,7 +9,7 @@ use chia::gen::flags::{COND_ARGS_NIL, STRICT_ARGS_COUNT, NO_UNKNOWN_CONDS};
 
 fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();
-    let input = make_tree(&mut a, &mut BitCursor::new(data));
+    let input = make_tree(&mut a, &mut BitCursor::new(data), false);
     for flags in &[0, COND_ARGS_NIL, STRICT_ARGS_COUNT, NO_UNKNOWN_CONDS] {
         let _ret = parse_spends(&a, input, 33000000000, *flags);
     }

--- a/fuzz/fuzz_targets/puzzle-coin-solution.rs
+++ b/fuzz/fuzz_targets/puzzle-coin-solution.rs
@@ -9,7 +9,7 @@ const HASH: [u8;32] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 
 fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();
-    let input = make_tree(&mut a, &mut BitCursor::new(data));
+    let input = make_tree(&mut a, &mut BitCursor::new(data), false);
 
     let _ret = get_puzzle_and_solution_for_coin(&a, input, HASH.into(), 1337, HASH.into());
 });

--- a/src/fuzzing_utils.rs
+++ b/src/fuzzing_utils.rs
@@ -54,17 +54,26 @@ const BUFFER: [u8; 63] = [
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 ];
 
-pub fn make_tree(a: &mut Allocator, cursor: &mut BitCursor) -> NodePtr {
+pub fn make_tree(a: &mut Allocator, cursor: &mut BitCursor, short_atoms: bool) -> NodePtr {
     match cursor.read_bits(1) {
         None => a.null(),
         Some(0) => {
-            let first = make_tree(a, cursor);
-            let second = make_tree(a, cursor);
+            let first = make_tree(a, cursor, short_atoms);
+            let second = make_tree(a, cursor, short_atoms);
             a.new_pair(first, second).unwrap()
         }
-        Some(_) => match cursor.read_bits(6) {
-            None => a.null(),
-            Some(len) => a.new_atom(&BUFFER[..len as usize]).unwrap(),
-        },
+        Some(_) => {
+            if short_atoms {
+                match cursor.read_bits(8) {
+                    None => a.null(),
+                    Some(val) => a.new_atom(&[val]).unwrap(),
+                }
+            } else {
+                match cursor.read_bits(6) {
+                    None => a.null(),
+                    Some(len) => a.new_atom(&BUFFER[..len as usize]).unwrap(),
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This adds an `uncurry()` function to `clvm-utils`. It's implemented to not allocate a new list for the arguments with the clvm allocator. This enables using it on a potential future read-only allocator.