### PR TITLE
improve test coverage of edge case in merkle_tree_set

### DIFF
--- a/src/merkle_set.rs
+++ b/src/merkle_set.rs
@@ -91,6 +91,8 @@ fn radix_sort(range: &mut [[u8; 32]], depth: u8) -> ([u8; 32], NodeType) {
             // if every bit is identical, we have a duplicate value
             // duplicate values are collapsed (since this is a set)
             // so just return one of the duplicates as if there was only one
+            debug_assert!(range.len() > 1);
+            debug_assert!(range[0] == range[1]);
             (range[0], NodeType::Term)
         } else {
             // this means either the left or right bucket/sub tree was empty.
@@ -114,6 +116,22 @@ fn radix_sort(range: &mut [[u8; 32]], depth: u8) -> ([u8; 32], NodeType) {
                 (child_hash, child_type)
             }
         }
+    } else if depth == 255 {
+        // this is an edge case where we make it all the way down to the
+        // bottom of the tree, and split the last pair. This has the same
+        // effect as the else-block, but since we use u8 for depth, it would
+        // overflow
+        debug_assert!(range.len() > 1);
+        debug_assert!(left < range.len() as i32);
+        (
+            hash(
+                NodeType::Term,
+                NodeType::Term,
+                &range[0],
+                &range[left as usize],
+            ),
+            NodeType::MidDbl,
+        )
     } else {
         let (left_hash, left_type) = radix_sort(&mut range[..left as usize], depth + 1);
         let (right_hash, right_type) = radix_sort(&mut range[left as usize..], depth + 1);
@@ -547,4 +565,152 @@ fn test_compute_merkle_root_5() {
     //   o   b
     //  / \
     // e   c
+}
+
+#[test]
+fn test_merkle_left_edge() {
+    let a = [
+        0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0,
+    ];
+    let b = [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 1,
+    ];
+    let c = [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 2,
+    ];
+    let d = [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 3,
+    ];
+
+    let mut expected = hashdown(&[1, 1], &c, &d);
+    expected = hashdown(&[1, 2], &b, &expected);
+
+    for _i in 0..253 {
+        expected = hashdown(&[2, 0], &expected, &BLANK);
+    }
+
+    expected = hashdown(&[2, 1], &expected, &a);
+
+    assert_eq!(compute_merkle_set_root(&mut [a, b, c, d]), expected)
+    // this tree looks like this:
+    //           o
+    //          / \
+    //         o   a
+    //        / \
+    //       o   E
+    //      / \
+    //     .   E
+    //     .
+    //     .
+    //    / \
+    //   o   E
+    //  / \
+    // b   o
+    //    / \
+    //   c   d
+}
+
+#[test]
+fn test_merkle_left_edge_duplicates() {
+    let a = [
+        0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0,
+    ];
+    let b = [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 1,
+    ];
+    let c = [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 2,
+    ];
+    let d = [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 3,
+    ];
+
+    let mut expected = hashdown(&[1, 1], &c, &d);
+    expected = hashdown(&[1, 2], &b, &expected);
+
+    for _i in 0..253 {
+        expected = hashdown(&[2, 0], &expected, &BLANK);
+    }
+
+    expected = hashdown(&[2, 1], &expected, &a);
+
+    // all fields are duplicated
+    assert_eq!(
+        compute_merkle_set_root(&mut [a, b, c, d, a, b, c, d]),
+        expected
+    )
+    // this tree looks like this:
+    //           o
+    //          / \
+    //         o   a
+    //        / \
+    //       o   E
+    //      / \
+    //     .   E
+    //     .
+    //     .
+    //    / \
+    //   o   E
+    //  / \
+    // b   o
+    //    / \
+    //   c   d
+}
+
+#[test]
+fn test_merkle_right_edge() {
+    let a = [
+        0x40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0,
+    ];
+    let b = [
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff,
+    ];
+    let c = [
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xfe,
+    ];
+    let d = [
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xfd,
+    ];
+
+    let mut expected = hashdown(&[1, 1], &c, &b);
+    expected = hashdown(&[1, 2], &d, &expected);
+
+    for _i in 0..253 {
+        expected = hashdown(&[0, 2], &BLANK, &expected);
+    }
+
+    expected = hashdown(&[1, 2], &a, &expected);
+
+    assert_eq!(compute_merkle_set_root(&mut [a, b, c, d]), expected)
+    // this tree looks like this:
+    //           o
+    //          / \
+    //         a   o
+    //            / \
+    //           E   o
+    //              / \
+    //             E   o
+    //                 .
+    //                 .
+    //                 .
+    //                 o
+    //                / \
+    //               d   o
+    //                  / \
+    //                 c   b
 }


### PR DESCRIPTION
This patch adds tests for the edge case where two hashes are only separated by bit 255. The tests are converted from the tests in `chia-blockchain`.