### PR TITLE
add support for remaining primitive types to json serialization/deserialization

### DIFF
--- a/chia-protocol/src/bytes.rs
+++ b/chia-protocol/src/bytes.rs
@@ -50,6 +50,12 @@ impl From<Vec<u8>> for Bytes {
     }
 }
 
+impl AsRef<[u8]> for Bytes {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 impl fmt::Display for Bytes {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str(&hex::encode(&self.0))

--- a/chia-protocol/src/from_json_dict.rs
+++ b/chia-protocol/src/from_json_dict.rs
@@ -69,29 +69,28 @@ where
     }
 }
 
-impl FromJsonDict for bool {
-    fn from_json_dict(o: &PyAny) -> PyResult<Self> {
-        o.extract()
-    }
+macro_rules! from_json_primitive {
+    ($t:ty) => {
+        impl FromJsonDict for $t {
+            fn from_json_dict(o: &PyAny) -> PyResult<Self> {
+                o.extract()
+            }
+        }
+    };
 }
 
-impl FromJsonDict for u32 {
-    fn from_json_dict(o: &PyAny) -> PyResult<Self> {
-        o.extract()
-    }
-}
-
-impl FromJsonDict for u64 {
-    fn from_json_dict(o: &PyAny) -> PyResult<Self> {
-        o.extract()
-    }
-}
-
-impl FromJsonDict for String {
-    fn from_json_dict(o: &PyAny) -> PyResult<Self> {
-        o.extract()
-    }
-}
+from_json_primitive!(bool);
+from_json_primitive!(u8);
+from_json_primitive!(i8);
+from_json_primitive!(u16);
+from_json_primitive!(i16);
+from_json_primitive!(u32);
+from_json_primitive!(i32);
+from_json_primitive!(u64);
+from_json_primitive!(i64);
+from_json_primitive!(u128);
+from_json_primitive!(i128);
+from_json_primitive!(String);
 
 impl<T> FromJsonDict for Vec<T>
 where

--- a/chia-protocol/src/to_json_dict.rs
+++ b/chia-protocol/src/to_json_dict.rs
@@ -6,23 +6,28 @@ pub trait ToJsonDict {
     fn to_json_dict(&self, py: Python) -> PyResult<PyObject>;
 }
 
-impl ToJsonDict for bool {
-    fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.to_object(py))
-    }
+macro_rules! to_json_primitive {
+    ($t:ty) => {
+        impl ToJsonDict for $t {
+            fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {
+                Ok(self.to_object(py))
+            }
+        }
+    };
 }
 
-impl ToJsonDict for u32 {
-    fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.to_object(py))
-    }
-}
-
-impl ToJsonDict for u64 {
-    fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {
-        Ok(self.to_object(py))
-    }
-}
+to_json_primitive!(bool);
+to_json_primitive!(u8);
+to_json_primitive!(i8);
+to_json_primitive!(u16);
+to_json_primitive!(i16);
+to_json_primitive!(u32);
+to_json_primitive!(i32);
+to_json_primitive!(u64);
+to_json_primitive!(i64);
+to_json_primitive!(u128);
+to_json_primitive!(i128);
+to_json_primitive!(String);
 
 impl<const N: usize> ToJsonDict for BytesImpl<N> {
     fn to_json_dict(&self, py: Python) -> PyResult<PyObject> {


### PR DESCRIPTION
there were some primitives missing, implementing the traits. This patch also makes a macro to mitigate repetition.

Additionally, another earlier oversight was to not implement the `AsRef` trait for `Bytes` (but just `BytesImpl<n>`). So that's also added.