### PR TITLE
Use macos-10.14 to build macOS Intel wheel

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,7 +27,7 @@ jobs:
             matrix: macos
             runs-on:
               arm: [macOS, ARM64]
-              intel: [macos-latest]
+              intel: [macos-10.14]
           - name: Ubuntu
             matrix: ubuntu
             runs-on:


### PR DESCRIPTION
Compare and contrast with https://github.com/Chia-Network/chia_rs/pull/94.