### PR TITLE
MacOS deployment target on M1

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -159,7 +159,7 @@ jobs:
     - name: Build MacOs with maturin on Python ${{ matrix.python }}
       if: matrix.os.matrix == 'macos'
       env:
-        MACOSX_DEPLOYMENT_TARGET: 10.14
+        MACOSX_DEPLOYMENT_TARGET: ${{ matrix.arch.matrix == 'intel' && '10.14' || '11.0' }}
       run: |
         python${{ matrix.python.major-dot-minor }} -m venv venv
         . venv/bin/activate


### PR DESCRIPTION
lowering the deployment target across the board for all MacOS builds appears to have been a mistake. The M1 builds recently started failing by pip declaring the wheel built against the older MacOS version as not being supported.

Possibly caused by MacOS 10.4 is older than the M1 architecture.

It looks like this ticket may be related: https://github.com/actions/setup-python/issues/469