### PR TITLE
Streamable enums

### DIFF
--- a/chia-protocol/src/chia_error.rs
+++ b/chia-protocol/src/chia_error.rs
@@ -13,6 +13,7 @@ pub enum Error {
     InvalidString,
     InputTooLarge,
     SequenceTooLarge,
+    InvalidEnum,
     Custom(String),
 }
 
@@ -27,6 +28,7 @@ impl fmt::Display for Error {
             Error::EndOfBuffer => write!(fmt, "unexpected end of buffer"),
             Error::InputTooLarge => write!(fmt, "input buffer too large"),
             Error::SequenceTooLarge => write!(fmt, "sequence too large"),
+            Error::InvalidEnum => write!(fmt, "invalid enum value"),
             Error::Custom(ref s) => s.fmt(fmt),
         }
     }

--- a/chia-protocol/src/chia_protocol.rs
+++ b/chia-protocol/src/chia_protocol.rs
@@ -14,8 +14,12 @@ use crate::to_json_dict::ToJsonDict;
 use chia_py_streamable_macro::PyStreamable;
 #[cfg(feature = "py-bindings")]
 use pyo3::prelude::*;
+#[cfg(feature = "py-bindings")]
+use std::io::Cursor;
 
 #[repr(u8)]
+#[cfg_attr(feature = "py-bindings", derive(PyStreamable))]
+#[derive(Streamable, Hash, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ProtocolMessageTypes {
     // Shared protocol (all services)
     Handshake = 1,
@@ -133,6 +137,8 @@ pub trait ChiaProtocolMessage {
 }
 
 #[repr(u8)]
+#[cfg_attr(feature = "py-bindings", derive(PyStreamable))]
+#[derive(Streamable, Hash, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum NodeType {
     FullNode = 1,
     Harvester = 2,
@@ -144,7 +150,7 @@ pub enum NodeType {
 }
 
 streamable_struct! (Message {
-    msg_type: u8,
+    msg_type: ProtocolMessageTypes,
     id: Option<u16>,
     data: Bytes,
 });
@@ -159,7 +165,7 @@ message_struct! (Handshake {
     // Which port the server is listening on
     server_port: u16,
     // NodeType (full node, wallet, farmer, etc.)
-    node_type: u8,
+    node_type: NodeType,
     // Key value dict to signal support for additional capabilities/features
     capabilities: Vec<(u16, String)>,
 });

--- a/chia-protocol/src/streamable.rs
+++ b/chia-protocol/src/streamable.rs
@@ -741,3 +741,28 @@ fn test_stream_u128() {
         ]
     );
 }
+
+#[cfg(test)]
+#[derive(Streamable, Hash, Copy, Debug, Clone, Eq, PartialEq)]
+enum TestEnum {
+    A = 0,
+    B = 1,
+    C = 255,
+}
+
+#[test]
+fn test_parse_enum() {
+    from_bytes::<TestEnum>(&[0], TestEnum::A);
+    from_bytes::<TestEnum>(&[1], TestEnum::B);
+    from_bytes::<TestEnum>(&[255], TestEnum::C);
+    from_bytes_fail::<TestEnum>(&[3], Error::InvalidEnum);
+    from_bytes_fail::<TestEnum>(&[254], Error::InvalidEnum);
+    from_bytes_fail::<TestEnum>(&[128], Error::InvalidEnum);
+}
+
+#[test]
+fn test_stream_enum() {
+    assert_eq!(stream::<TestEnum>(&TestEnum::A), &[0_u8]);
+    assert_eq!(stream::<TestEnum>(&TestEnum::B), &[1_u8]);
+    assert_eq!(stream::<TestEnum>(&TestEnum::C), &[255_u8]);
+}

--- a/chia_streamable_macro/Cargo.toml
+++ b/chia_streamable_macro/Cargo.toml
@@ -12,5 +12,5 @@ repository = "https://github.com/Chia-Network/chia_rs/"
 proc-macro = true
 
 [dependencies]
-syn = "1.0.86"
+syn = { version = "1.0.86", features = ["full"] }
 quote = "1.0.15"

--- a/chia_streamable_macro/src/lib.rs
+++ b/chia_streamable_macro/src/lib.rs
@@ -2,6 +2,7 @@ extern crate proc_macro;
 #[macro_use]
 extern crate quote;
 
+use syn::Lit::Int;
 use syn::{parse_macro_input, DeriveInput, FieldsNamed, FieldsUnnamed};
 
 use proc_macro::TokenStream;
@@ -14,8 +15,54 @@ pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
     let mut findices = Vec::<syn::Index>::new();
     let mut ftypes = Vec::<syn::Type>::new();
     match data {
-        syn::Data::Enum(_) => {
-            panic!("Streamable does not support Enums");
+        syn::Data::Enum(e) => {
+            let mut names = Vec::<syn::Ident>::new();
+            let mut values = Vec::<u8>::new();
+            for v in e.variants.iter() {
+                names.push(v.ident.clone());
+                let expr = match &v.discriminant {
+                    Some((_, expr)) => expr,
+                    None => {
+                        panic!("unsupported enum");
+                    }
+                };
+                let l = match expr {
+                    syn::Expr::Lit(l) => l,
+                    _ => {
+                        panic!("unsupported enum (no literal)");
+                    }
+                };
+                let i = match &l.lit {
+                    Int(i) => i,
+                    _ => {
+                        panic!("unsupported enum (literal is not integer)");
+                    }
+                };
+                match i.base10_parse::<u8>() {
+                    Ok(v) => values.push(v),
+                    Err(_) => {
+                        panic!("unsupported enum (value not u8)");
+                    }
+                }
+            }
+            let ret = quote! {
+                impl Streamable for #ident {
+                    fn update_digest(&self, digest: &mut clvmr::sha2::Sha256) {
+                        <u8 as Streamable>::update_digest(&(*self as u8), digest);
+                    }
+                    fn stream(&self, out: &mut Vec<u8>) -> chia_error::Result<()> {
+                        <u8 as Streamable>::stream(&(*self as u8), out)
+                    }
+                    fn parse(input: &mut std::io::Cursor<&[u8]>) -> chia_error::Result<Self> {
+                        let v = <u8 as Streamable>::parse(input)?;
+                        match &v {
+                            #(#values => Ok(#ident::#names),)*
+                            _ => Err(chia_error::Error::InvalidEnum),
+                        }
+                    }
+                }
+            };
+            return ret.into();
         }
         syn::Data::Union(_) => {
             panic!("Streamable does not support Unions");

--- a/wheel/chia_rs.pyi
+++ b/wheel/chia_rs.pyi
@@ -150,12 +150,12 @@ class G2Element:
     def from_json_dict(o: Dict[str, Any]) -> G2Element: ...
 
 class Message:
-    msg_type: ProtocolMessageTypes
+    msg_type: int
     id: Optional[int]
     data: bytes
     def __init__(
         self,
-        msg_type: ProtocolMessageTypes,
+        msg_type: int,
         id: Optional[int],
         data: bytes
     ) -> None: ...
@@ -181,7 +181,7 @@ class Handshake:
     protocol_version: String
     software_version: String
     server_port: int
-    node_type: NodeType
+    node_type: int
     capabilities: List[(int, String)]
     def __init__(
         self,

--- a/wheel/chia_rs.pyi
+++ b/wheel/chia_rs.pyi
@@ -150,12 +150,12 @@ class G2Element:
     def from_json_dict(o: Dict[str, Any]) -> G2Element: ...
 
 class Message:
-    msg_type: int
+    msg_type: ProtocolMessageTypes
     id: Optional[int]
     data: bytes
     def __init__(
         self,
-        msg_type: int,
+        msg_type: ProtocolMessageTypes,
         id: Optional[int],
         data: bytes
     ) -> None: ...
@@ -181,7 +181,7 @@ class Handshake:
     protocol_version: String
     software_version: String
     server_port: int
-    node_type: int
+    node_type: NodeType
     capabilities: List[(int, String)]
     def __init__(
         self,

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -6,7 +6,7 @@ output_file = Path(__file__).parent.resolve() / "chia_rs.pyi"
 input_dir = Path(__file__).parent.parent.resolve() / "chia-protocol" / "src"
 
 # enums are exposed to python as int
-enums = set(["NodeType", "ProtocolMessageType"])
+enums = set(["NodeType", "ProtocolMessageTypes"])
 
 def transform_type(m: str) -> str:
     n, t = m.split(":")
@@ -53,7 +53,7 @@ class {name}:
 
 
 def rust_type_to_python(t: str) -> str:
-    return (
+    ret = (
         t.replace("<", "[")
         .replace(">", "]")
         .replace("Vec", "List")
@@ -71,6 +71,9 @@ def rust_type_to_python(t: str) -> str:
         .replace("i128", "int")
         .strip()
     )
+    if ret in enums:
+        ret = "int"
+    return ret
 
 
 def parse_rust_source(filename: str) -> List[Tuple[str, List[str]]]:

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -5,6 +5,8 @@ from glob import glob
 output_file = Path(__file__).parent.resolve() / "chia_rs.pyi"
 input_dir = Path(__file__).parent.parent.resolve() / "chia-protocol" / "src"
 
+# enums are exposed to python as int
+enums = set(["NodeType", "ProtocolMessageType"])
 
 def transform_type(m: str) -> str:
     n, t = m.split(":")
@@ -12,6 +14,8 @@ def transform_type(m: str) -> str:
         t = t.replace("List[", "Sequence[")
     elif "bytes32" == t.strip():
         t = " bytes"
+    elif t.strip() in enums:
+        t = " int"
     return f"{n}:{t}"
 
 


### PR DESCRIPTION
This patch adds support for (simple) `enum`s to the `Streamable` macro (in `chia_streamable_macro`). The way it works is it iterates over all enum variants and ensures that:
* they all have an integral value assigned to them
* that the integral value fits in a `u8` variable (because that's what we use for message types)

With this new feature, it's possible to directly use the enums as fields of streamable types, so the `msg_type` and `node_type` are made proper enums.

Rust doesn't allow casting integers to enum variants (but it does support casting enums to ints), therefore, the generated `parse()` function for enums creates a large `match` statement for all integral values, returning the corresponding enum value.

The python binding macro implements py03 conversions for enums to and from python integers as well as implements the `ToJsonDict` and `FromJsonDict` to complete the support for inclusion in Stresmable types.

Since these enums are exposed to python as plain integers, so does the `generate_type_stubs.py`