### PR TITLE
Implement std::error::Error trait for chia-protocol's Error

### DIFF
--- a/chia-protocol/src/chia_error.rs
+++ b/chia-protocol/src/chia_error.rs
@@ -1,3 +1,4 @@
+use std::error;
 use std::fmt;
 
 #[cfg(feature = "py-bindings")]
@@ -31,6 +32,12 @@ impl fmt::Display for Error {
             Error::InvalidEnum => write!(fmt, "invalid enum value"),
             Error::Custom(ref s) => s.fmt(fmt),
         }
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        None
     }
 }
 


### PR DESCRIPTION
This is a trivial change to implement the [`std::error::Error` trait](https://doc.rust-lang.org/std/error/trait.Error.html) for chia-protocol's `chia_error::Error`. This makes working with `Result`s  that use `chia_error::Error` as error, such as the result obtained from Streamable::parse easier (especially in combination with simple error propagation/handling libraries such as [anyhow](https://github.com/dtolnay/anyhow)).

As `chia_error::Error`s currently don't track any underlying errors, the actual implementation simply stubs out the `source` method to always return `None`.