### PR TITLE
analyze-chain tool

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -225,6 +225,23 @@ jobs:
         python wheel/generate_type_stubs.py
         git diff --exit-code
 
+  build-tools:
+    name: build chia-tools
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clean workspace
+      uses: Chia-Network/actions/clean-workspace@main
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: cargo build
+      run: |
+        cd chia-tools
+        cargo build
+
   build-sdist:
     name: sdist - ${{ matrix.os.name }} ${{ matrix.python.major-dot-minor }} ${{ matrix.arch.name }}
     runs-on: ${{ matrix.os.runs-on[matrix.arch.matrix] }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # the "wheel" crate is excluded from the workspace because pyo3 has problems with
 # "cargo test" and "cargo bench"
 [workspace]
-members = ["wasm", "chia_streamable_macro", "chia-bls", "clvm-utils", "chia-protocol", "chia_py_streamable_macro"]
+members = ["wasm", "chia_streamable_macro", "chia-bls", "clvm-utils", "chia-protocol", "chia_py_streamable_macro", "chia-tools"]
 exclude = ["wheel"]
 
 [package]

--- a/chia-protocol/src/bytes.rs
+++ b/chia-protocol/src/bytes.rs
@@ -14,8 +14,18 @@ use pyo3::prelude::*;
 #[cfg(feature = "py-bindings")]
 use pyo3::types::PyBytes;
 
-#[derive(Hash, Debug, Clone, Eq, PartialEq)]
+#[derive(Hash, Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Bytes(Vec<u8>);
+
+impl Bytes {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
 
 impl Streamable for Bytes {
     fn update_digest(&self, digest: &mut Sha256) {
@@ -62,7 +72,7 @@ impl fmt::Display for Bytes {
     }
 }
 
-#[derive(Hash, PartialEq, Eq, Copy, Clone)]
+#[derive(Hash, PartialEq, Eq, Copy, Clone, PartialOrd, Ord)]
 pub struct BytesImpl<const N: usize>([u8; N]);
 
 impl<const N: usize> Streamable for BytesImpl<N> {

--- a/chia-protocol/src/program.rs
+++ b/chia-protocol/src/program.rs
@@ -20,6 +20,16 @@ use pyo3::prelude::*;
 #[derive(Hash, Debug, Clone, Eq, PartialEq)]
 pub struct Program(Bytes);
 
+impl Program {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
 impl Streamable for Program {
     fn update_digest(&self, digest: &mut Sha256) {
         digest.update(&self.0);
@@ -40,5 +50,11 @@ impl Streamable for Program {
         let program = buf[..len as usize].to_vec();
         input.set_position(pos + len);
         Ok(Program(program.into()))
+    }
+}
+
+impl AsRef<[u8]> for Program {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
     }
 }

--- a/chia-tools/Cargo.toml
+++ b/chia-tools/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "chia-tools"
+version = "0.1.16"
+edition = "2021"
+license = "Apache-2.0"
+description = "Utility functions and types used by the Chia blockchain full node"
+authors = ["Arvid Norberg <arvid@chia.net>"]
+homepage = "https://github.com/Chia-Network/chia_rs/chia-tools"
+repository = "https://github.com/Chia-Network/chia_rs/chia-tools"
+
+[dependencies]
+chia-protocol = { version = ">=0.2.0", path = "../chia-protocol" }
+clvmr = { version = ">=0.2.2", features = ["counters"] }
+chia = { path = "..", version = ">=0.2.0" }
+sqlite = "=0.30.3"
+clap = { version = "=4.0.29", features = ["derive"] }
+zstd = "=0.12.1"
+
+[[bin]]
+name = "analyze-chain"
+test = false
+bench = false

--- a/chia-tools/graph.gnuplot
+++ b/chia-tools/graph.gnuplot
@@ -1,0 +1,69 @@
+set term png size 1200,600
+
+set output "blockchain-stack-usage.png"
+set xlabel "block height"
+set ylabel "elements"
+set title "block stack usage"
+set key top right
+plot "chain-resource-usage.dat" using 1:2 with dots title "value stack depth", \
+"chain-resource-usage.dat" using 1:3 with dots title "environment stack depth", \
+"chain-resource-usage.dat" using 1:4 with dots title "operations stack depth"
+
+set output "blockchain-heap-usage.png"
+set title "block heap usage"
+set ylabel "MB"
+
+plot "chain-resource-usage.dat" using 1:($5)*8/1000000 with dots title "Atom size", \
+"chain-resource-usage.dat" using 1:($6)*8/1000000 with dots title "Pair size", \
+"chain-resource-usage.dat" using 1:($7)/1000000 with dots title "Heap size"
+
+set output "block-execution-time.png"
+set title "block validation time"
+set ylabel "microseconds"
+
+plot "chain-resource-usage.dat" using 1:13 with dots title "block generator"
+
+set output "block-loading-time.png"
+plot "chain-resource-usage.dat" using 1:11 with dots title "block decompress + parse", \
+"chain-resource-usage.dat" using 1:12 with dots title "block reference lookup", \
+"chain-resource-usage.dat" using 1:14 with dots title "conditions`
+
+set output "block-cost-vs-time.png"
+set title "block CLVM execution time versus CLVM cost"
+set xlabel "CLVM cost (millions)"
+set ylabel "CLVM execution time (s)"
+set key off
+plot "chain-resource-usage.dat" using ($9/1000000):($13/1000000) with dots title "blocks", \
+
+set output "blockchain-stack-usage-cdf.png"
+set xlabel "elements"
+set ylabel "fraction of blocks"
+set title "block stack usage"
+set xrange [0:5000]
+set key bottom right
+plot "chain-resource-usage-cdf.dat" using 2:1 with lines title "value stack depth", \
+"chain-resource-usage-cdf.dat" using 3:1 with lines title "environment stack depth", \
+"chain-resource-usage-cdf.dat" using 4:1 with lines title "operations stack depth"
+
+set output "blockchain-heap-usage-cdf.png"
+set title "block heap usage"
+set xlabel "MB"
+set xrange [0:30]
+
+plot "chain-resource-usage-cdf.dat" using ($5)*8/1000000:1 with lines title "Atom size", \
+"chain-resource-usage-cdf.dat" using ($6)*8/1000000:1 with lines title "Pair size", \
+"chain-resource-usage-cdf.dat" using ($7)/1000000:1 with lines title "Heap size"
+
+set output "block-execution-time-cdf.png"
+set title "block validation time"
+set xlabel "microseconds"
+set xrange [0:300000]
+
+plot "chain-resource-usage-cdf.dat" using 13:1 with lines title "block generator", \
+
+set output "block-loading-time-cdf.png"
+set xrange [0:2000]
+
+plot "chain-resource-usage-cdf.dat" using 11:1 with lines title "block decompress + parse", \
+"chain-resource-usage-cdf.dat" using 12:1 with lines title "block reference lookup", \
+"chain-resource-usage-cdf.dat" using 14:1 with lines title "conditions"

--- a/chia-tools/parse-analyze-chain.py
+++ b/chia-tools/parse-analyze-chain.py
@@ -1,0 +1,63 @@
+from typing import Dict, List
+
+all_counters: Dict[str, List[int]] = {}
+
+keys = ["val_stack:",
+     "env_stack:",
+     "op_stack:",
+     "atoms:",
+     "pairs:",
+     "heap:",
+     "block_cost:",
+     "clvm_cost:",
+     "cond_cost:",
+     "parse_time:",
+     "ref_lookup_time:",
+     "execute_time:",
+     "conditions_time:",
+]
+
+def to_int(value: str) -> int:
+    if value[-1] == ',':
+        return int(value[:-1])
+    return int(value)
+
+num_samples = 0
+
+with open("chain-resource-usage.log", "r") as f:
+    for l in f:
+        cols = l.split()
+        height = to_int(cols[0])
+        all_counters.setdefault("height", []).append(height)
+        for k in keys:
+            i = cols.index(k)
+            v = to_int(cols[i + 1])
+            all_counters.setdefault(k, []).append(v)
+        num_samples += 1
+
+with open("chain-resource-usage.dat", "w+") as out:
+    out.write("# ")
+    for k in keys:
+        out.write(f"{k} ")
+    out.write(f"\n")
+
+    for i in range(num_samples):
+        out.write(f"{all_counters['height'][i]}")
+        for k in keys:
+            out.write(f" {all_counters[k][i]}")
+        out.write(f"\n")
+
+for k in keys:
+    all_counters[k] = sorted(all_counters[k])
+
+with open("chain-resource-usage-cdf.dat", "w+") as out:
+    out.write("# ")
+    for k in keys:
+        out.write(f"{k} ")
+    out.write(f"\n")
+
+    for i in range(num_samples):
+        out.write(f"{i/num_samples:0.3f}")
+        for k in keys:
+            out.write(f" {all_counters[k][i]}")
+        out.write(f"\n")

--- a/chia-tools/src/bin/analyze-chain.rs
+++ b/chia-tools/src/bin/analyze-chain.rs
@@ -1,0 +1,218 @@
+use clap::Parser;
+
+use chia_protocol::FullBlock;
+use chia_protocol::Streamable;
+use std::io::Write;
+use std::time::SystemTime;
+
+use sqlite::State;
+
+use chia::gen::conditions::parse_spends;
+use chia::gen::flags::MEMPOOL_MODE;
+use chia::gen::validation_error::ValidationErr;
+use chia::generator_rom::{COST_PER_BYTE, GENERATOR_ROM};
+use clvmr::reduction::Reduction;
+use clvmr::run_program_with_counters;
+use clvmr::serde::node_from_bytes;
+use clvmr::Allocator;
+use clvmr::ChiaDialect;
+
+/// Analyze the blocks in a chia blockchain database
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Path to blockchain database file to analyze
+    #[arg(short, long)]
+    file: String,
+
+    /// Specifies whether to run the blocks in the stricter mempool mode or not
+    #[arg(short, long, default_value_t = false)]
+    mempool_mode: bool,
+
+    /// Start at this block height
+    #[arg(short, long, default_value_t = 225694)]
+    start: u32,
+
+    /// The height to stop at
+    #[arg(short, long, default_value_t = 0xffffffff)]
+    end: u32,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let connection = sqlite::open(args.file).expect("failed to open database file");
+
+    let mut statement = connection
+        .prepare(
+            "SELECT height, block \
+        FROM full_blocks \
+        WHERE height >= ? AND height <= ? AND in_main_chain=1 \
+        ORDER BY height",
+        )
+        .expect("failed to prepare SQL statement enumerating blocks");
+    statement
+        .bind((1, args.start as i64))
+        .expect("failed to bind start height to sql query");
+    statement
+        .bind((2, args.end as i64))
+        .expect("failed to bind start height to sql query");
+
+    let mut block_ref_lookup = connection
+        .prepare("SELECT block FROM full_blocks WHERE height=? and in_main_chain=1")
+        .expect("failed to prepare SQL statement looking up ref-blocks");
+
+    let mut output =
+        std::fs::File::create("chain-resource-usage.log").expect("failed to open output file");
+
+    // We only create a single allocator, load it with the generator ROM and
+    // then we keep reusing it
+    let mut a = Allocator::new_limited(500000000, 62500000, 62500000);
+    let generator_rom =
+        node_from_bytes(&mut a, &GENERATOR_ROM).expect("failed to parse generator ROM");
+    let allocator_checkpoint = a.checkpoint();
+
+    while let Ok(State::Row) = statement.next() {
+        let height: u32 = statement
+            .read::<i64, _>(0)
+            .expect("missing height")
+            .try_into()
+            .expect("invalid height in block record");
+        let block_buffer = statement.read::<Vec<u8>, _>(1).expect("invalid block blob");
+
+        let start_parse = SystemTime::now();
+        let block_buffer =
+            zstd::stream::decode_all(&mut std::io::Cursor::<Vec<u8>>::new(block_buffer))
+                .expect("failed to decompress block");
+        let block = FullBlock::parse(&mut std::io::Cursor::<&[u8]>::new(&block_buffer))
+            .expect("failed to parse FullBlock");
+
+        let ti = match block.transactions_info {
+            Some(ti) => ti,
+            None => {
+                continue;
+            }
+        };
+
+        if let Some(program) = block.transactions_generator {
+            a.restore_checkpoint(&allocator_checkpoint);
+
+            let generator =
+                node_from_bytes(&mut a, program.as_ref()).expect("failed to parse block generator");
+
+            let parse_timing = start_parse.elapsed().expect("failed to get system time");
+
+            let mut args = a.null();
+
+            let start_ref_lookup = SystemTime::now();
+            // iterate in reverse order since we're building a linked list from
+            // the tail
+            for height in block.transactions_generator_ref_list.iter().rev() {
+                block_ref_lookup
+                    .reset()
+                    .expect("sqlite reset statement failed");
+                block_ref_lookup
+                    .bind((1, *height as i64))
+                    .expect("failed to look up ref-block");
+
+                block_ref_lookup
+                    .next()
+                    .expect("failed to fetch block-ref row");
+                let ref_block = block_ref_lookup
+                    .read::<Vec<u8>, _>(0)
+                    .expect("failed to lookup block reference");
+
+                let ref_block =
+                    zstd::stream::decode_all(&mut std::io::Cursor::<Vec<u8>>::new(ref_block))
+                        .expect("failed to decompress block");
+
+                let ref_block = FullBlock::parse(&mut std::io::Cursor::<&[u8]>::new(&ref_block))
+                    .expect("failed to parse ref-block");
+                let ref_gen = match ref_block.transactions_generator {
+                    None => {
+                        panic!("block ref has no generator");
+                    }
+                    Some(g) => g,
+                };
+
+                let ref_gen = a
+                    .new_atom(ref_gen.as_ref())
+                    .expect("failed to allocate atom for ref_block");
+                args = a.new_pair(ref_gen, args).expect("failed to allocate pair");
+            }
+            let ref_lookup_timing = start_ref_lookup
+                .elapsed()
+                .expect("failed to get system time");
+
+            let byte_cost = program.len() as u64 * COST_PER_BYTE;
+
+            args = a.new_pair(args, a.null()).expect("failed to allocate pair");
+            let args = a.new_pair(args, a.null()).expect("failed to allocate pair");
+            let args = a
+                .new_pair(generator, args)
+                .expect("failed to allocate pair");
+
+            let start_execute = SystemTime::now();
+            let dialect = ChiaDialect::new(0);
+            let (counters, result) = run_program_with_counters(
+                &mut a,
+                &dialect,
+                generator_rom,
+                args,
+                ti.cost - byte_cost,
+            );
+            let execute_timing = start_execute.elapsed().expect("failed to get system time");
+
+            let Reduction(clvm_cost, generator_output) = result.expect("block generator failed");
+
+            let start_conditions = SystemTime::now();
+            // we pass in what's left of max_cost here, to fail early in case the
+            // cost of a condition brings us over the cost limit
+            let conds = match parse_spends(&a, generator_output, ti.cost - clvm_cost, MEMPOOL_MODE)
+            {
+                Err(ValidationErr(_, _)) => {
+                    panic!("failed to parse conditions in block {height}");
+                }
+                Ok(c) => c,
+            };
+            let conditions_timing = start_conditions
+                .elapsed()
+                .expect("failed to get system time");
+
+            assert!(clvm_cost + byte_cost + conds.cost == ti.cost);
+
+            output
+                .write_fmt(format_args!(
+                    "{} val_stack: {} \
+                env_stack: {} \
+                op_stack: {} \
+                atoms: {} \
+                pairs: {} \
+                heap: {} \
+                block_cost: {} \
+                clvm_cost: {} \
+                cond_cost: {} \
+                parse_time: {} \
+                ref_lookup_time: {} \
+                execute_time: {} \
+                conditions_time: {} \
+                \n",
+                    height,
+                    counters.val_stack_usage,
+                    counters.env_stack_usage,
+                    counters.op_stack_usage,
+                    counters.atom_count,
+                    counters.pair_count,
+                    counters.heap_size,
+                    ti.cost,
+                    clvm_cost,
+                    conds.cost,
+                    parse_timing.as_micros(),
+                    ref_lookup_timing.as_micros(),
+                    execute_timing.as_micros(),
+                    conditions_timing.as_micros(),
+                ))
+                .expect("failed to write to output file");
+        }
+    }
+}

--- a/chia_py_streamable_macro/Cargo.toml
+++ b/chia_py_streamable_macro/Cargo.toml
@@ -12,5 +12,5 @@ repository = "https://github.com/Chia-Network/chia_rs/chia_py_streamable_macro/"
 proc-macro = true
 
 [dependencies]
-syn = "1.0.86"
-quote = "1.0.15"
+syn = ">1.0.86"
+quote = ">1.0.15"

--- a/chia_streamable_macro/Cargo.toml
+++ b/chia_streamable_macro/Cargo.toml
@@ -12,5 +12,5 @@ repository = "https://github.com/Chia-Network/chia_rs/"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.86", features = ["full"] }
-quote = "1.0.15"
+syn = { version = ">1.0.86", features = ["full"] }
+quote = ">1.0.15"


### PR DESCRIPTION
This patch adds a new crate called `chia-tools` along with one program, `analyze-chain`. This is similar to `analyze_chain.py` in the `chia-blockchain` repository.

when analyzing the mainnet blockchain, this tool (along with the log parser and gnuplot scripts) produces plots like these:

![block-loading-time-cdf](https://user-images.githubusercontent.com/661450/212913083-8e2b6f5b-3b72-42f0-812e-9344126da57a.png)
![blockchain-stack-usage-cdf](https://user-images.githubusercontent.com/661450/212913127-24a297bd-9362-4c8c-9be0-5cf853cbc8a7.png)
![block-cost-vs-time](https://user-images.githubusercontent.com/661450/212913171-958e46f4-c5f5-430a-a6f2-8a39a6855612.png)
