### PR TITLE
Allow Serde-serialisation of Streamable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "pyo3",
  "rand",
  "rstest",
+ "serde",
  "sha2",
  "thiserror",
 ]
@@ -404,6 +405,7 @@ dependencies = [
  "hex",
  "pyo3",
  "rstest",
+ "serde",
  "sha2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ rcgen = "0.13.1"
 rsa = "0.9.5"
 time = "0.3.22"
 rusqlite = "0.31.0"
+serde = { version = "1.0.198", features = ["derive"] }
 clap = "4.5.8"
 zstd = "0.13.2"
 blocking-threadpool = "1.0.1"

--- a/crates/chia-bls/Cargo.toml
+++ b/crates/chia-bls/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [features]
 py-bindings = ["dep:pyo3", "chia_py_streamable_macro", "chia-traits/py-bindings"]
 arbitrary = ["dep:arbitrary"]
+serde = ["dep:serde"]
 
 [dependencies]
 chia-traits = { workspace = true }
@@ -27,6 +28,7 @@ thiserror = { workspace = true }
 pyo3 = { workspace = true, features = ["multiple-pymethods"], optional = true }
 arbitrary = { workspace = true, optional = true }
 lru = { workspace = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/crates/chia-bls/src/public_key.rs
+++ b/crates/chia-bls/src/public_key.rs
@@ -26,6 +26,16 @@ impl<'a> arbitrary::Arbitrary<'a> for PublicKey {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for PublicKey {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        serializer.serialize_str(&hex::encode(self.to_bytes()))
+    }
+}
+
 impl PublicKey {
     pub fn from_bytes_unchecked(bytes: &[u8; 48]) -> Result<Self> {
         // check if the element is canonical

--- a/crates/chia-bls/src/signature.rs
+++ b/crates/chia-bls/src/signature.rs
@@ -28,6 +28,16 @@ impl<'a> arbitrary::Arbitrary<'a> for Signature {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for Signature {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        serializer.serialize_str(&hex::encode(self.to_bytes()))
+    }
+}
+
 impl Signature {
     pub fn from_bytes_unchecked(buf: &[u8; 96]) -> Result<Self> {
         let p2 = unsafe {

--- a/crates/chia-protocol/Cargo.toml
+++ b/crates/chia-protocol/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [features]
 py-bindings = ["dep:pyo3", "dep:chia_py_streamable_macro", "chia-traits/py-bindings", "chia-bls/py-bindings"]
 arbitrary = ["dep:arbitrary", "chia-bls/arbitrary"]
+serde = ["dep:serde", "chia-bls/serde"]
 
 [dependencies]
 pyo3 = { workspace = true, features = ["multiple-pymethods", "num-bigint"], optional = true }
@@ -27,6 +28,7 @@ clvm-traits = { workspace = true, features = ["derive"] }
 clvm-utils = { workspace = true }
 chia-bls = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/chia-protocol/src/bytes.rs
+++ b/crates/chia-protocol/src/bytes.rs
@@ -20,6 +20,7 @@ use pyo3::types::PyBytes;
 
 #[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Bytes(Vec<u8>);
 
 impl Bytes {
@@ -368,6 +369,13 @@ impl<const N: usize> Deref for BytesImpl<N> {
 
     fn deref(&self) -> &[u8] {
         &self.0
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<const N: usize> serde::Serialize for BytesImpl<N> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&hex::encode(self.0))
     }
 }
 

--- a/crates/chia-protocol/src/chia_protocol.rs
+++ b/crates/chia-protocol/src/chia_protocol.rs
@@ -8,6 +8,7 @@ use chia_py_streamable_macro::{PyJsonDict, PyStreamable};
 #[repr(u8)]
 #[cfg_attr(feature = "py-bindings", derive(PyJsonDict, PyStreamable))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[derive(Streamable, Hash, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ProtocolMessageTypes {
     // Shared protocol (all services)
@@ -151,6 +152,7 @@ pub trait ChiaProtocolMessage {
 #[repr(u8)]
 #[cfg_attr(feature = "py-bindings", derive(PyJsonDict, PyStreamable))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[derive(Streamable, Hash, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum NodeType {
     FullNode = 1,

--- a/crates/chia-protocol/src/program.rs
+++ b/crates/chia-protocol/src/program.rs
@@ -16,6 +16,7 @@ use std::io::Cursor;
 use std::ops::Deref;
 
 #[cfg_attr(feature = "py-bindings", pyclass, derive(PyStreamable))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Program(Bytes);
 

--- a/crates/chia-protocol/src/wallet_protocol.rs
+++ b/crates/chia-protocol/src/wallet_protocol.rs
@@ -292,6 +292,7 @@ use chia_py_streamable_macro::{PyJsonDict, PyStreamable};
 #[cfg_attr(feature = "py-bindings", derive(PyJsonDict, PyStreamable))]
 #[derive(Streamable, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub enum RejectStateReason {
     Reorg = 0,
     ExceededSubscriptionLimit = 1,

--- a/crates/chia_streamable_macro/src/lib.rs
+++ b/crates/chia_streamable_macro/src/lib.rs
@@ -106,6 +106,7 @@ pub fn streamable(attr: TokenStream, item: TokenStream) -> TokenStream {
             )]
             #main_derives
             #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+            #[cfg_attr(feature = "serde", derive(serde::Serialize))]
         }
     } else {
         main_derives


### PR DESCRIPTION
This pull-request adds a "serde" build feature to chia-protocol. When this build feature is enabled, all chia-protocol types derive Serde's `Serialize`. This allows chia-protocol types to be serialised via Serde to different formats, most notably probably JSON, which can be very helpful for testing or glueing into other systems.

This PR only gets basic Serde serialisation working, without support for deserialisation. Serialisation follows Serde's defaults wherever possible. Fixed-length byte types (bytes48, bytes96, etc) are serialised to an array of bytes (numbers) for a start.

This PR is primarily to start discussion if there's interest in merging this into chia_rs at all. We are currently using this change to use chia_rs to convert from fullblock data to JSON for ad-hoc scripting/reporting. If there's interest in merging this, a next step would probably ensure that the JSON generated by chia_rs matches the JSON generated by chia-blockchain's Python.