### PR TITLE
Parameterize tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ chia-protocol = { version = "=0.2.1", path = "chia-protocol" }
 
 [dev-dependencies]
 num-traits = "=0.2.15"
+rstest = "=0.16.0"
 
 [lib]
 name = "chia"

--- a/src/gen/conditions.rs
+++ b/src/gen/conditions.rs
@@ -1086,6 +1086,22 @@ fn test_seconds_exceed_max(#[case] condition: ConditionOpcode, #[case] expected_
     );
 }
 
+#[cfg(test)]
+#[rstest]
+#[case(ASSERT_HEIGHT_ABSOLUTE, ErrorCode::AssertHeightAbsolute)]
+#[case(ASSERT_HEIGHT_RELATIVE, ErrorCode::AssertHeightRelative)]
+fn test_height_exceed_max(#[case] condition: ConditionOpcode, #[case] expected_error: ErrorCode) {
+    assert_eq!(
+        cond_test(&format!(
+            "((({{h1}} ({{h2}} (123 ((({} (0x0100000000 )))))",
+            condition as u8
+        ))
+        .unwrap_err()
+        .1,
+        expected_error
+    );
+}
+
 #[test]
 fn test_single_seconds_relative() {
     // ASSERT_SECONDS_RELATIVE
@@ -1181,17 +1197,6 @@ fn test_single_height_relative_zero() {
 }
 
 #[test]
-fn test_height_relative_exceed_max() {
-    // ASSERT_HEIGHT_RELATIVE
-    assert_eq!(
-        cond_test("((({h1} ({h2} (123 (((82 (0x0100000000 )))))")
-            .unwrap_err()
-            .1,
-        ErrorCode::AssertHeightRelative
-    );
-}
-
-#[test]
 fn test_multiple_height_relative() {
     // ASSERT_HEIGHT_RELATIVE
     let (a, conds) =
@@ -1221,17 +1226,6 @@ fn test_single_height_absolute() {
     assert_eq!(spend.flags, ELIGIBLE_FOR_DEDUP);
 
     assert_eq!(conds.height_absolute, 100);
-}
-
-#[test]
-fn test_height_absolute_exceed_max() {
-    // ASSERT_HEIGHT_ABSOLUTE
-    assert_eq!(
-        cond_test("((({h1} ({h2} (123 (((83 (0x0100000000 )))))")
-            .unwrap_err()
-            .1,
-        ErrorCode::AssertHeightAbsolute
-    );
 }
 
 #[test]

--- a/src/gen/conditions.rs
+++ b/src/gen/conditions.rs
@@ -1069,6 +1069,23 @@ fn test_extra_arg(
     test(&conds, &spend);
 }
 
+#[cfg(test)]
+#[rstest]
+#[case(ASSERT_SECONDS_ABSOLUTE, ErrorCode::AssertSecondsAbsolute)]
+#[case(ASSERT_SECONDS_RELATIVE, ErrorCode::AssertSecondsRelative)]
+fn test_seconds_exceed_max(#[case] condition: ConditionOpcode, #[case] expected_error: ErrorCode) {
+    // ASSERT_SECONDS_RELATIVE
+    assert_eq!(
+        cond_test(&format!(
+            "((({{h1}} ({{h2}} (123 ((({} (0x010000000000000000 )))))",
+            condition as u8
+        ))
+        .unwrap_err()
+        .1,
+        expected_error
+    );
+}
+
 #[test]
 fn test_single_seconds_relative() {
     // ASSERT_SECONDS_RELATIVE
@@ -1082,17 +1099,6 @@ fn test_single_seconds_relative() {
     assert_eq!(spend.flags, ELIGIBLE_FOR_DEDUP);
 
     assert_eq!(spend.seconds_relative, 101);
-}
-
-#[test]
-fn test_seconds_relative_exceed_max() {
-    // ASSERT_SECONDS_RELATIVE
-    assert_eq!(
-        cond_test("((({h1} ({h2} (123 (((80 (0x010000000000000000 )))))")
-            .unwrap_err()
-            .1,
-        ErrorCode::AssertSecondsRelative
-    );
 }
 
 #[test]
@@ -1125,17 +1131,6 @@ fn test_single_seconds_absolute() {
     assert_eq!(spend.flags, ELIGIBLE_FOR_DEDUP);
 
     assert_eq!(conds.seconds_absolute, 104);
-}
-
-#[test]
-fn test_seconds_absolute_exceed_max() {
-    // ASSERT_SECONDS_ABSOLUTE
-    assert_eq!(
-        cond_test("((({h1} ({h2} (123 (((81 (0x010000000000000000 )))))")
-            .unwrap_err()
-            .1,
-        ErrorCode::AssertSecondsAbsolute
-    );
 }
 
 #[test]


### PR DESCRIPTION
This patch set introduced a dependency on `rstest`, which comes with a few convenient macros to parameterize tests.
It then merges a few test categories into a few parameterized tests. This saves a significant amount of boiler plate code and simplifies the tests. It should also make the tests less error prone since the unique features of the tests are called out in the parameters.

The commits are suitable to be reviewed one at a time.

This patch is in preparation for adding new condition codes, avoiding the test code to blow up in size.

To double check that no test case was dropped by accident, I ran two sanity checks:

```
[main] $ cargo test | wc -l
    Finished test [unoptimized + debuginfo] target(s) in 0.25s
     Running unittests src/lib.rs (target/debug/deps/chia-d65d6a5ec578387a)
   Doc-tests chia
165
```

```
[parameterize-tests]$ cargo test | wc -l
    Updating crates.io index
   Compiling chia v0.2.1 (/home/arvid/dev/chia_rs)
    Finished test [unoptimized + debuginfo] target(s) in 4.30s
     Running unittests src/lib.rs (target/debug/deps/chia-2ddfd7de89e1d6af)
   Doc-tests chia
165
```

And:
```
cargo test | sort | tee main.log
```

comparing it to this patch:

```
cargo test | sort | tee params.log
```

After reordering rows, the files diff:

```diff
$ diff -u main.log param.log 
--- main.log    2023-01-26 18:24:37.241521597 +0100
+++ param.log   2023-01-26 18:21:13.434054127 +0100
@@ -51,39 +51,39 @@
 test gen::conditions::test_duplicate_agg_sig_me ... ok
 test gen::conditions::test_duplicate_agg_sig_unsafe ... ok
 test gen::conditions::test_duplicate_create_coin ... ok
-test gen::conditions::test_assert_coin_announce_extra_arg ... ok
-test gen::conditions::test_assert_puzzle_announces_extra_arg ... ok
-test gen::conditions::test_create_coin_announce_extra_arg ... ok
-test gen::conditions::test_create_puzzle_announces_extra_arg ... ok
-test gen::conditions::test_single_seconds_relative_extra_arg ... ok
-test gen::conditions::test_single_seconds_absolute_extra_arg ... ok
-test gen::conditions::test_single_assert_my_amount_extra_arg ... ok
-test gen::conditions::test_single_assert_my_coin_id_extra_arg ... ok
-test gen::conditions::test_single_assert_my_parent_coin_id_extra_arg ... ok
-test gen::conditions::test_single_assert_my_puzzle_hash_extra_arg ... ok
-test gen::conditions::test_single_height_absolute_extra_arg ... ok
-test gen::conditions::test_single_height_relative_extra_arg ... ok
-test gen::conditions::test_single_reserve_fee_extra_arg ... ok
-test gen::conditions::test_create_puzzle_announces_extra_arg_mempool ... ok
-test gen::conditions::test_create_coin_extra_arg_mempool ... ok
-test gen::conditions::test_create_coin_announce_extra_arg_mempool ... ok
-test gen::conditions::test_agg_sig_me_extra_arg_mempool ... ok
-test gen::conditions::test_agg_sig_unsafe_extra_arg_mempool ... ok
-test gen::conditions::test_assert_coin_announce_extra_arg_mempool ... ok
-test gen::conditions::test_assert_puzzle_announces_extra_arg_mempool ... ok
-test gen::conditions::test_single_assert_my_amount_extra_arg_mempool ... ok
-test gen::conditions::test_single_assert_my_coin_id_extra_arg_mempool ... ok
-test gen::conditions::test_single_assert_my_parent_coin_id_extra_arg_mempool ... ok
-test gen::conditions::test_single_assert_my_puzzle_hash_extra_arg_mempool ... ok
-test gen::conditions::test_single_height_absolute_extra_arg_mempool ... ok
-test gen::conditions::test_single_height_relative_extra_arg_mempool ... ok
-test gen::conditions::test_single_reserve_fee_extra_arg_mempool ... ok
-test gen::conditions::test_single_seconds_absolute_extra_arg_mempool ... ok
-test gen::conditions::test_single_seconds_relative_extra_arg_mempool ... ok
+test gen::conditions::test_extra_arg::case_01 ... ok
+test gen::conditions::test_extra_arg::case_02 ... ok
+test gen::conditions::test_extra_arg::case_03 ... ok
+test gen::conditions::test_extra_arg::case_04 ... ok
+test gen::conditions::test_extra_arg::case_05 ... ok
+test gen::conditions::test_extra_arg::case_06 ... ok
+test gen::conditions::test_extra_arg::case_07 ... ok
+test gen::conditions::test_extra_arg::case_08 ... ok
+test gen::conditions::test_extra_arg::case_09 ... ok
+test gen::conditions::test_extra_arg::case_10 ... ok
+test gen::conditions::test_extra_arg::case_11 ... ok
+test gen::conditions::test_extra_arg::case_12 ... ok
+test gen::conditions::test_extra_arg::case_13 ... ok
+test gen::conditions::test_extra_arg_mempool::case_01 ... ok
+test gen::conditions::test_extra_arg_mempool::case_02 ... ok
+test gen::conditions::test_extra_arg_mempool::case_03 ... ok
+test gen::conditions::test_extra_arg_mempool::case_04 ... ok
+test gen::conditions::test_extra_arg_mempool::case_05 ... ok
+test gen::conditions::test_extra_arg_mempool::case_06 ... ok
+test gen::conditions::test_extra_arg_mempool::case_07 ... ok
+test gen::conditions::test_extra_arg_mempool::case_08 ... ok
+test gen::conditions::test_extra_arg_mempool::case_09 ... ok
+test gen::conditions::test_extra_arg_mempool::case_10 ... ok
+test gen::conditions::test_extra_arg_mempool::case_11 ... ok
+test gen::conditions::test_extra_arg_mempool::case_12 ... ok
+test gen::conditions::test_extra_arg_mempool::case_13 ... ok
+test gen::conditions::test_extra_arg_mempool::case_14 ... ok
+test gen::conditions::test_extra_arg_mempool::case_15 ... ok
+test gen::conditions::test_extra_arg_mempool::case_16 ... ok
 test gen::conditions::test_failing_coin_consume ... ok
 test gen::conditions::test_failing_puzzle_consume ... ok
-test gen::conditions::test_height_absolute_exceed_max ... ok
-test gen::conditions::test_height_relative_exceed_max ... ok
+test gen::conditions::test_height_exceed_max::case_1 ... ok
+test gen::conditions::test_height_exceed_max::case_2 ... ok
 test gen::conditions::test_invalid_condition_args_terminator_mempool ... ok
 test gen::conditions::test_invalid_condition_args_terminator ... ok
 test gen::conditions::test_invalid_condition_list1 ... ok
@@ -113,8 +113,8 @@
 test gen::conditions::test_reserve_fee_exceed_max ... ok
 test gen::conditions::test_reserve_fee_insufficient_fee ... ok
 test gen::conditions::test_reserve_fee_insufficient_spends ... ok
-test gen::conditions::test_seconds_absolute_exceed_max ... ok
-test gen::conditions::test_seconds_relative_exceed_max ... ok
+test gen::conditions::test_seconds_exceed_max::case_1 ... ok
+test gen::conditions::test_seconds_exceed_max::case_2 ... ok
 test gen::conditions::test_single_agg_sig_me ... ok
 test gen::conditions::test_single_agg_sig_unsafe ... ok
 test gen::conditions::test_single_assert_my_amount_exceed_max ... ok
@@ -124,15 +124,15 @@
 test gen::conditions::test_single_assert_my_coin_id_overlong ... ok
 test gen::conditions::test_single_assert_my_parent_coin_id_mismatch ... ok
 test gen::conditions::test_single_assert_my_puzzle_hash_mismatch ... ok
-test gen::conditions::test_single_assert_my_puzzle_hash ... ok
-test gen::conditions::test_single_assert_my_amount ... ok
-test gen::conditions::test_single_assert_my_coin_id ... ok
-test gen::conditions::test_single_assert_my_parent_coin_id ... ok
-test gen::conditions::test_single_height_absolute ... ok
-test gen::conditions::test_single_height_relative ... ok
-test gen::conditions::test_single_reserve_fee ... ok
-test gen::conditions::test_single_seconds_absolute ... ok
-test gen::conditions::test_single_seconds_relative ... ok
+test gen::conditions::test_single_condition::case_1 ... ok
+test gen::conditions::test_single_condition::case_2 ... ok
+test gen::conditions::test_single_condition::case_3 ... ok
+test gen::conditions::test_single_condition::case_4 ... ok
+test gen::conditions::test_single_condition::case_5 ... ok
+test gen::conditions::test_single_condition::case_6 ... ok
+test gen::conditions::test_single_condition::case_7 ... ok
+test gen::conditions::test_single_condition::case_8 ... ok
+test gen::conditions::test_single_condition::case_9 ... ok
 test gen::conditions::test_single_create_coin ... ok
 test gen::conditions::test_single_failing_assert_my_amount ... ok
 test gen::conditions::test_single_height_relative_zero ... ok
```