### PR TITLE
add more checks for impossible constraints

### DIFF
--- a/src/gen/validation_error.rs
+++ b/src/gen/validation_error.rs
@@ -36,6 +36,10 @@ pub enum ErrorCode {
     DoubleSpend,
     CostExceeded,
     MintingCoin,
+    ImpossibleSecondsRelativeConstraints,
+    ImpossibleSecondsAbsoluteConstraints,
+    ImpossibleHeightRelativeConstraints,
+    ImpossibleHeightAbsoluteConstraints,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -98,6 +102,10 @@ impl From<ErrorCode> for u32 {
             ErrorCode::DoubleSpend => 5,
             ErrorCode::CostExceeded => 23,
             ErrorCode::MintingCoin => 20,
+            ErrorCode::ImpossibleSecondsRelativeConstraints => 134,
+            ErrorCode::ImpossibleSecondsAbsoluteConstraints => 135,
+            ErrorCode::ImpossibleHeightRelativeConstraints => 136,
+            ErrorCode::ImpossibleHeightAbsoluteConstraints => 136,
         }
     }
 }


### PR DESCRIPTION
If a single spend bundle has an `ASSERT_BEFORE_HEIGHT_ABSOLUTE` that's lower than or equal to another `ASSERT_HEIGHT_ABSOLUTE`, the spend bundle will never be valid.

This patch checks for cases like this. Also for `_SECONDS_ABSOLUTE`.

The `_RELATIVE` checks can only be made within the same Spend, since we don't actually know any absolute timestamps or confirmation heights for the coins.

This is to catch a few obvious invalid cases early.

This still leaves non-obvious cases as successful (and must fail at a later state in the mempool pipeline).

For example, two *different* coins can have `ASSERT_HEIGHT_RELATIVE` and `ASSERT_BEFORE_HEIGHT_RELATIVE` that turn out to conflict, but we'll only know that once we look those coins up from the coin DB and know their confirmation heights.

Another, more subtle, case of invalid spend bundles is where an `ASSERT_SECONDS_ABSOLUTE` conflicts with an `ASSERT_BEFORE_HEIGHT_ABSOLUTE`. In `chia_rs` we don't have any mapping between block height and (predicted) timestamps. Clearly we couldn't reject spend bundles based on predictions anyway, but there may be cases where a `SECONDS` timestamp is known to refer to an old, existing, block. We won't catch those cases here either.