### PR TITLE
fix edge cases in assert_before parsing

### DIFF
--- a/src/gen/condition_sanitizers.rs
+++ b/src/gen/condition_sanitizers.rs
@@ -61,6 +61,38 @@ pub fn parse_seconds(a: &Allocator, n: NodePtr, code: ErrorCode) -> Result<u64, 
     }
 }
 
+// a negative height is a failure, but exceeding the max is a no-op.
+// This is used for parsing assert_before_height conditions
+pub fn parse_positive_height(
+    a: &Allocator,
+    n: NodePtr,
+    code: ErrorCode,
+) -> Result<Option<u32>, ValidationErr> {
+    // heights are not allowed to exceed 2^32. i.e. 4 bytes
+    match sanitize_uint(a, n, 4, code) {
+        Err(ValidationErr(n, ErrorCode::NegativeAmount)) => Err(ValidationErr(n, code)),
+        Err(ValidationErr(_, ErrorCode::AmountExceedsMaximum)) => Ok(None),
+        Err(r) => Err(r),
+        Ok(r) => Ok(Some(u64_from_bytes(r) as u32)),
+    }
+}
+
+// negative seconds are a failure, exceeding the max limit is no-op.
+// this is used for parsing assert_before_seconds conditions.
+pub fn parse_positive_seconds(
+    a: &Allocator,
+    n: NodePtr,
+    code: ErrorCode,
+) -> Result<Option<u64>, ValidationErr> {
+    // seconds are not allowed to exceed 2^64. i.e. 8 bytes
+    match sanitize_uint(a, n, 8, code) {
+        Err(ValidationErr(n, ErrorCode::NegativeAmount)) => Err(ValidationErr(n, code)),
+        Err(ValidationErr(_, ErrorCode::AmountExceedsMaximum)) => Ok(None),
+        Err(r) => Err(r),
+        Ok(r) => Ok(Some(u64_from_bytes(r))),
+    }
+}
+
 pub fn sanitize_announce_msg(
     a: &Allocator,
     n: NodePtr,
@@ -74,6 +106,9 @@ pub fn sanitize_announce_msg(
         Ok(n)
     }
 }
+
+#[cfg(test)]
+use rstest::rstest;
 
 #[cfg(test)]
 fn zero_vec(len: usize) -> Vec<u8> {
@@ -227,55 +262,133 @@ fn test_sanitize_create_coin_amount() {
 }
 
 #[cfg(test)]
-fn height_tester(buf: &[u8]) -> Result<u32, ValidationErr> {
+fn height_tester(buf: &[u8]) -> Result<Option<u64>, ValidationErr> {
     let mut a = Allocator::new();
     let n = a.new_atom(buf).unwrap();
+    Ok(Some(
+        parse_height(&mut a, n, ErrorCode::AssertHeightAbsolute)? as u64,
+    ))
+}
 
-    parse_height(&mut a, n, ErrorCode::AssertHeightAbsolute)
+#[cfg(test)]
+fn seconds_tester(buf: &[u8]) -> Result<Option<u64>, ValidationErr> {
+    let mut a = Allocator::new();
+    let n = a.new_atom(buf).unwrap();
+    Ok(Some(parse_seconds(
+        &mut a,
+        n,
+        ErrorCode::AssertSecondsAbsolute,
+    )?))
+}
+
+#[cfg(test)]
+fn positive_height_tester(buf: &[u8]) -> Result<Option<u64>, ValidationErr> {
+    let mut a = Allocator::new();
+    let n = a.new_atom(buf).unwrap();
+    Ok(parse_positive_height(&mut a, n, ErrorCode::AssertBeforeHeightAbsolute)?.map(|v| v as u64))
+}
+
+#[cfg(test)]
+fn positive_seconds_tester(buf: &[u8]) -> Result<Option<u64>, ValidationErr> {
+    let mut a = Allocator::new();
+    let n = a.new_atom(buf).unwrap();
+    parse_positive_seconds(&mut a, n, ErrorCode::AssertBeforeSecondsAbsolute)
+}
+
+#[cfg(test)]
+#[rstest]
+// == parse_height
+#[case(height_tester, &[0x80], Some(0))]
+// negative values are no-ops
+#[case(height_tester, &[0xff], Some(0))]
+#[case(height_tester, &[0xff, 0], Some(0))]
+// leading zeros are sometimes necessary to make values positive
+#[case(height_tester, &[0, 0xff], Some(0xff))]
+// this is small enough
+#[case(height_tester, &[0, 0xff, 0xff, 0xff, 0xff], Some(0xffffffff))]
+// == parse_seconds
+#[case(seconds_tester, &[0x80], Some(0))]
+// negative values are no-ops
+#[case(seconds_tester, &[0xff], Some(0))]
+#[case(seconds_tester, &[0xff, 0], Some(0))]
+// leading zeros are sometimes necessary to make values positive
+#[case(seconds_tester, &[0, 0xff], Some(0xff))]
+// this is small enough
+#[case(seconds_tester, &[0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff], Some(0xffffffffffffffff))]
+// == parse_positive_height
+// leading zeros are sometimes necessary to make values positive
+#[case(positive_height_tester, &[0, 0xff], Some(0xff))]
+// this is small enough
+#[case(positive_height_tester, &[0, 0xff, 0xff, 0xff, 0xff], Some(0xffffffff))]
+// positive heights are allowed to be > 2^32 (i.e. 5 bytes). it's a no-op
+#[case(positive_height_tester, &[0x01, 0xff, 0xff, 0xff, 0xff], None)]
+// == parse_positive_seconds
+// leading zeros are sometimes necessary to make values positive
+#[case(positive_seconds_tester, &[0, 0xff], Some(0xff))]
+// this is small enough
+#[case(positive_seconds_tester, &[0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff], Some(0xffffffffffffffff))]
+// before-seconds are allowed to be > 2^64 (i.e. 9 bytes)
+#[case(positive_seconds_tester, &[0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff], None)]
+fn test_parse_ok(
+    #[case] fun: impl Fn(&[u8]) -> Result<Option<u64>, ValidationErr>,
+    #[case] buf: &[u8],
+    #[case] expected: Option<u64>,
+) {
+    println!("test case: {:?} expect: {:?}", buf, expected);
+    // negative heights can be ignored
+    assert_eq!(fun(buf).unwrap(), expected);
+}
+
+#[cfg(test)]
+#[rstest]
+// == parse_height
+#[case(height_tester, &[0, 0, 0, 0xff], ErrorCode::AssertHeightAbsolute)]
+#[case(height_tester, &[0, 0, 0, 0x80], ErrorCode::AssertHeightAbsolute)]
+#[case(height_tester, &[0, 0, 0, 0x7f], ErrorCode::AssertHeightAbsolute)]
+#[case(height_tester, &[0, 0, 0], ErrorCode::AssertHeightAbsolute)]
+#[case(height_tester, &[0], ErrorCode::AssertHeightAbsolute)]
+// heights aren't allowed to be > 2^32 (i.e. 5 bytes)
+#[case(height_tester, &[0x01, 0xff, 0xff, 0xff, 0xff], ErrorCode::AssertHeightAbsolute)]
+// == parse_seconds
+#[case(seconds_tester, &[0, 0, 0, 0xff], ErrorCode::AssertSecondsAbsolute)]
+#[case(seconds_tester, &[0, 0, 0, 0x80], ErrorCode::AssertSecondsAbsolute)]
+#[case(seconds_tester, &[0, 0, 0, 0x7f], ErrorCode::AssertSecondsAbsolute)]
+#[case(seconds_tester, &[0, 0, 0], ErrorCode::AssertSecondsAbsolute)]
+#[case(seconds_tester, &[0], ErrorCode::AssertSecondsAbsolute)]
+// positive seconds are allowed to be > 2^64 (i.e. 9 bytes)
+#[case(seconds_tester, &[0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff], ErrorCode::AssertSecondsAbsolute)]
+// == parse_positive_height
+#[case(positive_height_tester, &[0, 0, 0, 0xff], ErrorCode::AssertBeforeHeightAbsolute)]
+#[case(positive_height_tester, &[0, 0, 0, 0x80], ErrorCode::AssertBeforeHeightAbsolute)]
+#[case(positive_height_tester, &[0, 0, 0, 0x7f], ErrorCode::AssertBeforeHeightAbsolute)]
+#[case(positive_height_tester, &[0, 0, 0], ErrorCode::AssertBeforeHeightAbsolute)]
+#[case(positive_height_tester, &[0], ErrorCode::AssertBeforeHeightAbsolute)]
+// negative values are failures
+#[case(positive_height_tester, &[0x80], ErrorCode::AssertBeforeHeightAbsolute)]
+#[case(positive_height_tester, &[0xff], ErrorCode::AssertBeforeHeightAbsolute)]
+#[case(positive_height_tester, &[0xff, 0], ErrorCode::AssertBeforeHeightAbsolute)]
+// == parse_positive_seconds
+#[case(positive_seconds_tester, &[0, 0, 0, 0xff], ErrorCode::AssertBeforeSecondsAbsolute)]
+#[case(positive_seconds_tester, &[0, 0, 0, 0x80], ErrorCode::AssertBeforeSecondsAbsolute)]
+#[case(positive_seconds_tester, &[0, 0, 0, 0x7f], ErrorCode::AssertBeforeSecondsAbsolute)]
+#[case(positive_seconds_tester, &[0, 0, 0], ErrorCode::AssertBeforeSecondsAbsolute)]
+#[case(positive_seconds_tester, &[0], ErrorCode::AssertBeforeSecondsAbsolute)]
+// negative values are failures
+#[case(positive_seconds_tester, &[0x80], ErrorCode::AssertBeforeSecondsAbsolute)]
+#[case(positive_seconds_tester, &[0xff], ErrorCode::AssertBeforeSecondsAbsolute)]
+#[case(positive_seconds_tester, &[0xff, 0], ErrorCode::AssertBeforeSecondsAbsolute)]
+fn test_parse_fail(
+    #[case] fun: impl Fn(&[u8]) -> Result<Option<u64>, ValidationErr>,
+    #[case] buf: &[u8],
+    #[case] expected: ErrorCode,
+) {
+    println!("test case: {:?} expect: {:?}", buf, expected);
+    // negative heights can be ignored
+    assert_eq!(fun(buf).unwrap_err().1, expected);
 }
 
 #[test]
-fn test_parse_height() {
-    // negative heights can be ignored
-    assert_eq!(height_tester(&[0x80]), Ok(0));
-    assert_eq!(height_tester(&[0xff]), Ok(0));
-    assert_eq!(height_tester(&[0xff, 0]), Ok(0));
-
-    // leading zeros are somtimes necessary to make values positive
-    assert_eq!(height_tester(&[0, 0xff]), Ok(0xff));
-    // but are stripped when they are redundant
-    assert_eq!(
-        height_tester(&[0, 0, 0, 0xff]).unwrap_err().1,
-        ErrorCode::AssertHeightAbsolute
-    );
-    assert_eq!(
-        height_tester(&[0, 0, 0, 0x80]).unwrap_err().1,
-        ErrorCode::AssertHeightAbsolute
-    );
-    assert_eq!(
-        height_tester(&[0, 0, 0, 0x7f]).unwrap_err().1,
-        ErrorCode::AssertHeightAbsolute
-    );
-    assert_eq!(
-        height_tester(&[0, 0, 0]).unwrap_err().1,
-        ErrorCode::AssertHeightAbsolute
-    );
-    assert_eq!(
-        height_tester(&[0]).unwrap_err().1,
-        ErrorCode::AssertHeightAbsolute
-    );
-
-    // heights aren't allowed to be > 2^32 (i.e. 5 bytes)
-    assert_eq!(
-        height_tester(&[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff])
-            .unwrap_err()
-            .1,
-        ErrorCode::AssertHeightAbsolute
-    );
-
-    // this is small enough though
-    assert_eq!(height_tester(&[0, 0xff, 0xff, 0xff, 0xff]), Ok(0xffffffff));
-
+fn test_parse_height_pair() {
     let mut a = Allocator::new();
     let pair = a.new_pair(a.null(), a.null()).unwrap();
     assert_eq!(
@@ -284,63 +397,32 @@ fn test_parse_height() {
     );
 }
 
-#[cfg(test)]
-fn seconds_tester(buf: &[u8]) -> Result<u64, ValidationErr> {
-    let mut a = Allocator::new();
-    let n = a.new_atom(buf).unwrap();
-
-    parse_seconds(&mut a, n, ErrorCode::AssertSecondsAbsolute)
-}
-
 #[test]
-fn test_parse_seconds() {
-    // negative seconds can be ignored
-    assert_eq!(seconds_tester(&[0x80]), Ok(0));
-    assert_eq!(seconds_tester(&[0xff]), Ok(0));
-    assert_eq!(seconds_tester(&[0xff, 0]), Ok(0));
-
-    // leading zeros are somtimes necessary to make values positive
-    assert_eq!(seconds_tester(&[0, 0xff]), Ok(0xff));
-    // but are stripped when they are redundant
-    assert_eq!(
-        seconds_tester(&[0, 0, 0, 0xff]).unwrap_err().1,
-        ErrorCode::AssertSecondsAbsolute
-    );
-    assert_eq!(
-        seconds_tester(&[0, 0, 0, 0x80]).unwrap_err().1,
-        ErrorCode::AssertSecondsAbsolute
-    );
-    assert_eq!(
-        seconds_tester(&[0, 0, 0, 0x7f]).unwrap_err().1,
-        ErrorCode::AssertSecondsAbsolute
-    );
-    assert_eq!(
-        seconds_tester(&[0, 0, 0]).unwrap_err().1,
-        ErrorCode::AssertSecondsAbsolute
-    );
-    assert_eq!(
-        seconds_tester(&[0]).unwrap_err().1,
-        ErrorCode::AssertSecondsAbsolute
-    );
-
-    // seconds aren't allowed to be > 2^64 (i.e. 9 bytes)
-    assert_eq!(
-        seconds_tester(&[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],)
-            .unwrap_err()
-            .1,
-        ErrorCode::AssertSecondsAbsolute
-    );
-
-    // this is small enough though
-    assert_eq!(
-        seconds_tester(&[0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
-        Ok(0xffffffffffffffff)
-    );
-
+fn test_parse_seconds_pair() {
     let mut a = Allocator::new();
     let pair = a.new_pair(a.null(), a.null()).unwrap();
     assert_eq!(
         parse_seconds(&mut a, pair, ErrorCode::AssertSecondsAbsolute),
+        Err(ValidationErr(pair, ErrorCode::AssertSecondsAbsolute))
+    );
+}
+
+#[test]
+fn test_parse_positive_height_pair() {
+    let mut a = Allocator::new();
+    let pair = a.new_pair(a.null(), a.null()).unwrap();
+    assert_eq!(
+        parse_positive_height(&mut a, pair, ErrorCode::AssertHeightAbsolute),
+        Err(ValidationErr(pair, ErrorCode::AssertHeightAbsolute))
+    );
+}
+
+#[test]
+fn test_parse_positive_seconds_pair() {
+    let mut a = Allocator::new();
+    let pair = a.new_pair(a.null(), a.null()).unwrap();
+    assert_eq!(
+        parse_positive_seconds(&mut a, pair, ErrorCode::AssertSecondsAbsolute),
         Err(ValidationErr(pair, ErrorCode::AssertSecondsAbsolute))
     );
 }


### PR DESCRIPTION
Specifically, assert_before a negative value is an automatic fail. assert_before a value exceeding the max is an automatic pass.

The two functions used to parse block height and timestamps (seconds) for the original `ASSERT_HEIGHT_*` and `ASSERT_SECONDS_*` has edge-case behavior tailored to those conditions. Those conditions requires the block height or timestamp to exceed the specified limit. If the limit is 0 or negative, the condition is always true. If the limit exceeds the max value however (uint32 and uint64 respectively), the conditions always fail.

Since the `ASSERT_BEFORE_*` conditions have the inverse semantics, the edge case behavior also need to be inverse. This patch introduces `parse_positive_height()` and `parse_positive_seconds()` with the inverse behavior for values outside the limits.

The bulk of this patch is to fix up the unit tests to explicitly cover these cases, both for the existing `parse_height()` and the new `parse_positive_height()` (as well as the "seconds" counterpart).