### PR TITLE
cargo fmt for wheel

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -299,7 +299,10 @@ jobs:
             components: rustfmt, clippy
             override: true
       - name: fmt
-        run: cargo fmt --all -- --files-with-diff --check
+        run: |
+            cargo fmt --all -- --files-with-diff --check
+            cd wheel
+            cargo fmt -- --files-with-diff --check
 
   clippy:
     runs-on: ubuntu-latest

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -2,11 +2,11 @@ use super::adapt_response::eval_err_to_pyresult;
 use chia_protocol::from_json_dict::FromJsonDict;
 use chia_protocol::to_json_dict::ToJsonDict;
 
-use chia::gen::conditions::{parse_spends, Spend, SpendBundleConditions};
-use chia::gen::validation_error::{ErrorCode, ValidationErr};
-use chia::gen::run_block_generator::run_block_generator as native_run_block_generator;
-use chia_protocol::bytes::{Bytes, Bytes32, Bytes48};
 use chia::allocator::make_allocator;
+use chia::gen::conditions::{parse_spends, Spend, SpendBundleConditions};
+use chia::gen::run_block_generator::run_block_generator as native_run_block_generator;
+use chia::gen::validation_error::{ErrorCode, ValidationErr};
+use chia_protocol::bytes::{Bytes, Bytes32, Bytes48};
 
 use clvmr::allocator::Allocator;
 use clvmr::chia_dialect::ChiaDialect;
@@ -95,7 +95,10 @@ fn convert_spend(a: &Allocator, spend: Spend) -> PySpend {
     }
 }
 
-pub fn convert_spend_bundle_conds(a: &Allocator, sb: SpendBundleConditions) -> PySpendBundleConditions {
+pub fn convert_spend_bundle_conds(
+    a: &Allocator,
+    sb: SpendBundleConditions,
+) -> PySpendBundleConditions {
     let mut spends = Vec::<PySpend>::new();
     for s in sb.spends {
         spends.push(convert_spend(a, s));
@@ -130,7 +133,7 @@ pub fn run_generator(
     max_cost: Cost,
     flags: u32,
 ) -> PyResult<(Option<u32>, Option<PySpendBundleConditions>)> {
-	let mut allocator = make_allocator(flags);
+    let mut allocator = make_allocator(flags);
     let program = node_from_bytes(&mut allocator, program)?;
     let args = node_from_bytes(&mut allocator, args)?;
     let dialect = &ChiaDialect::new(flags);
@@ -160,7 +163,7 @@ pub fn run_generator(
                 None,
                 Some(convert_spend_bundle_conds(&allocator, spend_bundle_conds)),
             ))
-        },
+        }
         Ok((error_code, _)) => {
             // a validation error occurred
             Ok((error_code.map(|x| x.into()), None))
@@ -177,7 +180,7 @@ pub fn run_block_generator(
     max_cost: Cost,
     flags: u32,
 ) -> PyResult<(Option<u32>, Option<PySpendBundleConditions>)> {
-	let mut allocator = make_allocator(flags);
+    let mut allocator = make_allocator(flags);
 
     let mut refs = Vec::<Vec<u8>>::new();
     for g in block_refs {
@@ -191,7 +194,7 @@ pub fn run_block_generator(
                 None,
                 Some(convert_spend_bundle_conds(&allocator, spend_bundle_conds)),
             ))
-        },
+        }
         Err(ValidationErr(_, error_code)) => {
             // a validation error occurred
             Ok((Some(error_code.into()), None))

--- a/wheel/src/run_program.rs
+++ b/wheel/src/run_program.rs
@@ -80,8 +80,7 @@ pub fn run_chia_program(
         let args = node_from_bytes(&mut allocator, args)?;
         let dialect = ChiaDialect::new(flags);
 
-        Ok(py
-            .allow_threads(|| run_program(&mut allocator, &dialect, program, args, max_cost)))
+        Ok(py.allow_threads(|| run_program(&mut allocator, &dialect, program, args, max_cost)))
     })()?;
     match r {
         Ok(reduction) => {


### PR DESCRIPTION
apply `cargo fmt` to `wheel` crate as well. It's been excluded so far because it's excluded from the workspace in `Cargo.toml` (because pyo3 doesn't like to be built with tests)