### PR TITLE
add new flag, LIMIT_OBJECTS

### DIFF
--- a/chia-tools/graph.gnuplot
+++ b/chia-tools/graph.gnuplot
@@ -59,6 +59,19 @@ plot "chain-resource-usage-cdf.dat" using ($5)*8/1000000:1 with lines title "Ato
 "chain-resource-usage-cdf.dat" using ($6)*8/1000000:1 with lines title "Pair size", \
 "chain-resource-usage-cdf.dat" using ($7)/1000000:1 with lines title "Heap size"
 
+set output "blockchain-object-usage-cdf.png"
+
+set title "block object usage"
+set xlabel "count (million)"
+set xrange [0:*]
+
+plot "chain-resource-usage-cdf.dat" using ($5)/1000000:1 with lines title "Allocated atoms", \
+"chain-resource-usage-cdf.dat" using ($6)/1000000:1 with lines title "Allocated pairs"
+
+set output "blockchain-object-usage-cdf2.png"
+set xrange [0:3]
+replot
+
 set output "block-execution-time-cdf.png"
 set title "block validation time"
 set xlabel "microseconds"

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,9 +1,12 @@
+use crate::gen::flags::LIMIT_OBJECTS;
 use clvmr::allocator::Allocator;
 use clvmr::chia_dialect::LIMIT_HEAP;
 
 pub fn make_allocator(flags: u32) -> Allocator {
     if flags & LIMIT_HEAP != 0 {
         Allocator::new_limited(500000000, 62500000, 62500000)
+    } else if flags & LIMIT_OBJECTS != 0 {
+        Allocator::new_limited(u32::MAX as usize, 62500000, 62500000)
     } else {
         Allocator::new()
     }

--- a/src/gen/flags.rs
+++ b/src/gen/flags.rs
@@ -2,6 +2,12 @@ use clvmr::MEMPOOL_MODE as CLVM_MEMPOOL_MODE;
 
 // flags controlling to condition parsing
 
+// When set, limit the number of atoms allowed to be allocated to 62'500'000
+// Also limit the number of pairs allowed to be allocated to the same limit
+// This is similar to LIMIT_HEAP, except this flag only limits the total number
+// of pairs and atoms we allow to be allocated, not the total heap size
+pub const LIMIT_OBJECTS: u32 = 0x10000;
+
 // unknown condition codes are disallowed
 pub const NO_UNKNOWN_CONDS: u32 = 0x20000;
 

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -7,6 +7,7 @@ use chia::allocator::make_allocator;
 use chia::gen::flags::COND_ARGS_NIL;
 use chia::gen::flags::ENABLE_ASSERT_BEFORE;
 use chia::gen::flags::ENABLE_SOFTFORK_CONDITION;
+use chia::gen::flags::LIMIT_OBJECTS;
 use chia::gen::flags::MEMPOOL_MODE;
 use chia::gen::flags::NO_RELATIVE_CONDITIONS_ON_EPHEMERAL;
 use chia::gen::flags::NO_UNKNOWN_CONDS;
@@ -157,6 +158,7 @@ pub fn chia_rs(py: Python, m: &PyModule) -> PyResult<()> {
         NO_RELATIVE_CONDITIONS_ON_EPHEMERAL,
     )?;
     m.add("MEMPOOL_MODE", MEMPOOL_MODE)?;
+    m.add("LIMIT_OBJECTS", LIMIT_OBJECTS)?;
 
     // Chia classes
     m.add_class::<Coin>()?;


### PR DESCRIPTION
to restrict the number of atoms and pairs we allow allocating. This overlaps with `LIMIT_HEAP` which also limits the total heap size and is used in mempool-mode.

The intention of this flag is to prepare for soft-forking on just the limit on the number of atoms and pairs.