### PR TITLE
split up parse_single_spend() into smaller parts

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -60,3 +60,9 @@ name = "sanitize-uint"
 path = "fuzz_targets/sanitize-uint.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "process-spend"
+path = "fuzz_targets/process-spend.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/process-spend.rs
+++ b/fuzz/fuzz_targets/process-spend.rs
@@ -1,0 +1,33 @@
+#![no_main]
+use chia::fuzzing_utils::{make_tree, BitCursor};
+use chia::gen::conditions::{process_single_spend, ParseState, SpendBundleConditions};
+use chia::gen::flags::{COND_ARGS_NIL, NO_UNKNOWN_CONDS, STRICT_ARGS_COUNT};
+use clvmr::allocator::Allocator;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut a = Allocator::new();
+    let mut ret = SpendBundleConditions::default();
+    let mut state = ParseState::default();
+
+    let parent_id = a.new_atom(&[0_u8; 32]).unwrap();
+    let puzzle_hash = a.new_atom(&[0_u8; 32]).unwrap();
+    let amount = a.new_atom(&[100_u8]).unwrap();
+
+    let conds = make_tree(&mut a, &mut BitCursor::new(data), false);
+
+    for flags in &[0, COND_ARGS_NIL, STRICT_ARGS_COUNT, NO_UNKNOWN_CONDS] {
+        let mut cost_left = 11000000;
+        let _ = process_single_spend(
+            &mut a,
+            &mut ret,
+            &mut state,
+            parent_id,
+            puzzle_hash,
+            amount,
+            conds,
+            *flags,
+            &mut cost_left,
+        );
+    }
+});


### PR DESCRIPTION
This opens an opportunity fuzz the internal `process_single_spend()`.
This is a step towards porting the generator ROM to rust, since it allows a way into the condition parsing and validation without first creating the CLVM structure that would have been created by the generator ROM.