### PR TITLE
stress tests take forever to run in debug mode

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -388,7 +388,7 @@ jobs:
           git clone https://github.com/Chia-Network/clvm_tools.git --branch=main --single-branch
           pip install ./clvm_tools
           pip install colorama maturin pytest
-          maturin develop -m wheel/Cargo.toml
+          maturin develop --release -m wheel/Cargo.toml
           cd tests
           python generate-programs.py
           python run-programs.py || true


### PR DESCRIPTION
Build in release mode when running them under test coverage.