### PR TITLE
make Bytes types implement PartialEq

### DIFF
--- a/chia-protocol/Cargo.toml
+++ b/chia-protocol/Cargo.toml
@@ -19,5 +19,8 @@ chia_streamable_macro = { version = "=0.2.4", path = "../chia_streamable_macro" 
 chia_py_streamable_macro = { path = "../chia_py_streamable_macro", version = "=0.1.3", optional = true }
 clvmr = "=0.2.6"
 
+[dev-dependencies]
+rstest = "=0.16.0"
+
 [lib]
 crate-type = ["rlib"]

--- a/chia-protocol/src/bytes.rs
+++ b/chia-protocol/src/bytes.rs
@@ -48,6 +48,54 @@ impl Streamable for Bytes {
     }
 }
 
+impl PartialEq<Bytes> for Vec<u8> {
+    fn eq(&self, lhs: &Bytes) -> bool {
+        *self == lhs.0
+    }
+}
+
+impl PartialEq<Vec<u8>> for Bytes {
+    fn eq(&self, lhs: &Vec<u8>) -> bool {
+        self.0 == *lhs
+    }
+}
+
+impl PartialEq<&[u8]> for Bytes {
+    fn eq(&self, lhs: &&[u8]) -> bool {
+        &self.0 == lhs
+    }
+}
+
+impl PartialEq<Bytes> for &[u8] {
+    fn eq(&self, lhs: &Bytes) -> bool {
+        self == &lhs.0
+    }
+}
+
+impl<const N: usize> PartialEq<[u8; N]> for Bytes {
+    fn eq(&self, lhs: &[u8; N]) -> bool {
+        self.0 == lhs
+    }
+}
+
+impl<const N: usize> PartialEq<&[u8; N]> for Bytes {
+    fn eq(&self, lhs: &&[u8; N]) -> bool {
+        self.0 == *lhs
+    }
+}
+
+impl<const N: usize> PartialEq<Bytes> for &[u8; N] {
+    fn eq(&self, lhs: &Bytes) -> bool {
+        lhs.0 == *self
+    }
+}
+
+impl<const N: usize> PartialEq<Bytes> for [u8; N] {
+    fn eq(&self, lhs: &Bytes) -> bool {
+        lhs.0 == self
+    }
+}
+
 impl From<&[u8]> for Bytes {
     fn from(v: &[u8]) -> Bytes {
         Bytes(v.to_vec())
@@ -109,13 +157,13 @@ impl<const N: usize> From<&[u8]> for BytesImpl<N> {
         ret
     }
 }
-impl<const N: usize> From<Vec<u8>> for BytesImpl<N> {
-    fn from(v: Vec<u8>) -> BytesImpl<N> {
+impl<const N: usize> From<&Vec<u8>> for BytesImpl<N> {
+    fn from(v: &Vec<u8>) -> BytesImpl<N> {
         if v.len() != N {
             panic!("invalid atom, expected {} bytes (got {})", N, v.len());
         }
         let mut ret = BytesImpl::<N>([0; N]);
-        ret.0.copy_from_slice(&v);
+        ret.0.copy_from_slice(v);
         ret
     }
 }
@@ -156,6 +204,42 @@ impl<const N: usize> Debug for BytesImpl<N> {
 impl<const N: usize> fmt::Display for BytesImpl<N> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str(&hex::encode(self.0))
+    }
+}
+
+impl<const N: usize> PartialEq<&[u8]> for BytesImpl<N> {
+    fn eq(&self, lhs: &&[u8]) -> bool {
+        self.0 == *lhs
+    }
+}
+
+impl<const N: usize> PartialEq<BytesImpl<N>> for &[u8] {
+    fn eq(&self, lhs: &BytesImpl<N>) -> bool {
+        self == &lhs.0
+    }
+}
+
+impl<const N: usize> PartialEq<&[u8; N]> for BytesImpl<N> {
+    fn eq(&self, lhs: &&[u8; N]) -> bool {
+        &self.0 == *lhs
+    }
+}
+
+impl<const N: usize> PartialEq<BytesImpl<N>> for &[u8; N] {
+    fn eq(&self, lhs: &BytesImpl<N>) -> bool {
+        *self == &lhs.0
+    }
+}
+
+impl<const N: usize> PartialEq<[u8; N]> for BytesImpl<N> {
+    fn eq(&self, lhs: &[u8; N]) -> bool {
+        &self.0 == lhs
+    }
+}
+
+impl<const N: usize> PartialEq<BytesImpl<N>> for [u8; N] {
+    fn eq(&self, lhs: &BytesImpl<N>) -> bool {
+        self == &lhs.0
     }
 }
 
@@ -207,5 +291,147 @@ impl<'py> FromPyObject<'py> for Bytes {
     fn extract(obj: &'py PyAny) -> PyResult<Self> {
         let b = <PyBytes as PyTryFrom>::try_from(obj)?;
         Ok(Bytes(b.as_bytes().to_vec()))
+    }
+}
+
+#[cfg(test)]
+use rstest::rstest;
+
+#[cfg(test)]
+#[rstest]
+// Bytess32
+#[case(
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    true
+)]
+#[case(
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    "0000000000000000000000000000000000000000000000000000000000000100",
+    false
+)]
+#[case(
+    "fff0000000000000000000000000000000000000000000000000000000000100",
+    "fff0000000000000000000000000000000000000000000000000000000000100",
+    true
+)]
+// Bytes
+#[case("000000", "000000", true)]
+#[case("123456", "125456", false)]
+#[case("000001", "00000001", false)]
+#[case("00000001", "000001", false)]
+#[case("ffff01", "ffff01", true)]
+#[case("", "", true)]
+fn test_bytes_comparisons(#[case] lhs: &str, #[case] rhs: &str, #[case] expect_equal: bool) {
+    let lhs_vec: Vec<u8> = hex::decode(lhs).expect("hex::decode");
+    let rhs_vec: Vec<u8> = hex::decode(rhs).expect("hex::decode");
+    let lhs_slice = &lhs_vec[..];
+    let rhs_slice = &rhs_vec[..];
+    if lhs_vec.len() == 32 && rhs_vec.len() == 32 {
+        let lhs = Bytes32::from(&lhs_vec);
+        let rhs = Bytes32::from(&rhs_vec);
+
+        assert_eq!(lhs.len(), 32);
+        assert_eq!(rhs.len(), 32);
+
+        assert_eq!(lhs.is_empty(), lhs_vec.is_empty());
+        assert_eq!(rhs.is_empty(), rhs_vec.is_empty());
+
+        // Bytes32 compare against arrays of the same size, not slices
+        let lhs_array: &[u8; 32] = lhs_slice.try_into().unwrap();
+        let rhs_array: &[u8; 32] = rhs_slice.try_into().unwrap();
+        if expect_equal {
+            assert_eq!(lhs, rhs);
+            assert_eq!(rhs, lhs);
+
+            // array comparisons
+            assert_eq!(lhs, rhs_array);
+            assert_eq!(rhs, lhs_array);
+            assert_eq!(lhs_array, rhs);
+            assert_eq!(rhs_array, lhs);
+
+            assert_eq!(lhs, *rhs_array);
+            assert_eq!(rhs, *lhs_array);
+            assert_eq!(*lhs_array, rhs);
+            assert_eq!(*rhs_array, lhs);
+
+            // slice comparisona
+            assert_eq!(lhs, rhs_slice);
+            assert_eq!(rhs, lhs_slice);
+            assert_eq!(lhs_slice, rhs);
+            assert_eq!(rhs_slice, lhs);
+        } else {
+            assert!(lhs != rhs);
+            assert!(rhs != lhs);
+
+            // array comparisons
+            assert!(lhs != rhs_array);
+            assert!(rhs != lhs_array);
+            assert!(lhs_array != rhs);
+            assert!(rhs_array != lhs);
+
+            assert!(lhs != *rhs_array);
+            assert!(rhs != *lhs_array);
+            assert!(*lhs_array != rhs);
+            assert!(*rhs_array != lhs);
+
+            // slice comparisons
+            assert!(lhs != rhs_slice);
+            assert!(rhs != lhs_slice);
+            assert!(lhs_slice != rhs);
+            assert!(rhs_slice != lhs);
+        }
+    } else {
+        let lhs = Bytes::from(lhs_vec.clone());
+        let rhs = Bytes::from(rhs_vec.clone());
+
+        assert_eq!(lhs.len(), lhs_vec.len());
+        assert_eq!(rhs.len(), rhs_vec.len());
+
+        assert_eq!(lhs.is_empty(), lhs_vec.is_empty());
+        assert_eq!(rhs.is_empty(), rhs_vec.is_empty());
+
+        // array comparisons
+        let array: &[u8; 3] = &[1, 2, 3];
+        assert!(lhs != array);
+        assert!(rhs != array);
+        assert!(array != lhs);
+        assert!(array != rhs);
+        assert!(lhs != *array);
+        assert!(rhs != *array);
+        assert!(*array != lhs);
+        assert!(*array != rhs);
+
+        if expect_equal {
+            assert_eq!(lhs, rhs);
+            assert_eq!(rhs, lhs);
+
+            // slice comparisons
+            assert_eq!(lhs, rhs_slice);
+            assert_eq!(rhs, lhs_slice);
+            assert_eq!(lhs_slice, rhs);
+            assert_eq!(rhs_slice, lhs);
+
+            // vec comparisons
+            assert_eq!(lhs, rhs_vec);
+            assert_eq!(rhs, lhs_vec);
+            assert_eq!(lhs_vec, rhs);
+            assert_eq!(rhs_vec, lhs);
+        } else {
+            assert!(lhs != rhs);
+            assert!(rhs != lhs);
+
+            // slice comparisons
+            assert!(lhs != rhs_slice);
+            assert!(rhs != lhs_slice);
+            assert!(lhs_slice != rhs);
+            assert!(rhs_slice != lhs);
+
+            // vec comparisons
+            assert!(lhs != rhs_vec);
+            assert!(rhs != lhs_vec);
+            assert!(lhs_vec != rhs);
+            assert!(rhs_vec != lhs);
+        }
     }
 }

--- a/chia-protocol/src/from_json_dict.rs
+++ b/chia-protocol/src/from_json_dict.rs
@@ -34,7 +34,7 @@ impl<const N: usize> FromJsonDict for BytesImpl<N> {
                 N
             )));
         }
-        Ok(buf.try_into()?)
+        Ok((&buf).try_into()?)
     }
 }
 

--- a/src/gen/conditions.rs
+++ b/src/gen/conditions.rs
@@ -2279,7 +2279,7 @@ fn test_single_create_coin() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(c.puzzle_hash, H2.into());
+        assert_eq!(c.puzzle_hash, H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.null());
     }
@@ -2302,7 +2302,7 @@ fn test_create_coin_max_amount() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(c.puzzle_hash, H2.into());
+        assert_eq!(c.puzzle_hash, H2);
         assert_eq!(c.amount, 0xffffffffffffffff_u64);
         assert_eq!(c.hint, a.null());
     }
@@ -2368,7 +2368,7 @@ fn test_create_coin_with_hint() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert!(c.puzzle_hash == H2.into());
+        assert!(c.puzzle_hash == H2);
         assert!(c.amount == 42_u64);
         assert!(a.atom(c.hint) == H1.to_vec());
     }
@@ -2391,7 +2391,7 @@ fn test_create_coin_extra_arg() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert!(c.puzzle_hash == H2.into());
+        assert!(c.puzzle_hash == H2);
         assert!(c.amount == 42_u64);
         assert!(a.atom(c.hint) == H1.to_vec());
     }
@@ -2412,7 +2412,7 @@ fn test_create_coin_with_multiple_hints() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert!(c.puzzle_hash == H2.into());
+        assert!(c.puzzle_hash == H2);
         assert!(c.amount == 42_u64);
         assert!(a.atom(c.hint) == H1.to_vec());
     }
@@ -2434,7 +2434,7 @@ fn test_create_coin_with_hint_as_atom() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(c.puzzle_hash, H2.into());
+        assert_eq!(c.puzzle_hash, H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.null());
     }
@@ -2455,7 +2455,7 @@ fn test_create_coin_with_invalid_hint_as_terminator() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(c.puzzle_hash, H2.into());
+        assert_eq!(c.puzzle_hash, H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.null());
     }
@@ -2489,7 +2489,7 @@ fn test_create_coin_with_short_hint() {
     assert_eq!(spend.create_coin.len(), 1);
 
     for c in &spend.create_coin {
-        assert!(c.puzzle_hash == H2.into());
+        assert!(c.puzzle_hash == H2);
         assert!(c.amount == 42_u64);
         assert!(a.atom(c.hint) == MSG1.to_vec());
     }
@@ -2511,7 +2511,7 @@ fn test_create_coin_with_long_hint() {
     assert_eq!(spend.create_coin.len(), 1);
 
     for c in &spend.create_coin {
-        assert_eq!(c.puzzle_hash, H2.into());
+        assert_eq!(c.puzzle_hash, H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.null());
     }
@@ -2534,7 +2534,7 @@ fn test_create_coin_with_pair_hint() {
     assert_eq!(spend.create_coin.len(), 1);
 
     for c in &spend.create_coin {
-        assert_eq!(c.puzzle_hash, H2.into());
+        assert_eq!(c.puzzle_hash, H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(a.atom(c.hint), H1.to_vec());
     }
@@ -2556,7 +2556,7 @@ fn test_create_coin_with_cons_hint() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(c.puzzle_hash, H2.into());
+        assert_eq!(c.puzzle_hash, H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.null());
     }


### PR DESCRIPTION
this make the `Bytes` and `BytesN`-types a bit easier to use, and simplifies some of the test code