### PR TITLE
Unpin dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+target/
 Cargo.lock

--- a/chia-bls/Cargo.toml
+++ b/chia-bls/Cargo.toml
@@ -9,19 +9,19 @@ homepage = "https://github.com/Chia-Network/chia_rs/chia-bls/"
 repository = "https://github.com/Chia-Network/chia_rs/chia-bls/"
 
 [dependencies]
-tiny-bip39 = "=1.0.0"
-anyhow = "=1.0.65"
+tiny-bip39 = "1.0.0"
+anyhow = "1.0.71"
 # the newer sha2 crate doesn't implement the digest traits required by hkdf
-sha2 = "=0.9.9"
-bls12_381_plus = "=0.7.0"
-num-bigint = "=0.4.3"
-hkdf = "=0.11.0"
-group = "=0.12.0"
+sha2 = "0.9.9"
+bls12_381_plus = "0.7.0"
+num-bigint = "0.4.3"
+hkdf = "0.11.0"
+group = "0.12.0"
 
 [dev-dependencies]
-hex = "^0.4.3"
-rand = "^0.8.5"
-criterion = "^0.4"
+hex = "0.4.3"
+rand = "0.8.5"
+criterion = "0.5.1"
 
 [lib]
 crate-type = ["rlib"]

--- a/chia-protocol/Cargo.toml
+++ b/chia-protocol/Cargo.toml
@@ -12,15 +12,15 @@ repository = "https://github.com/Chia-Network/chia_rs/chia-protocol/"
 py-bindings = ["dep:pyo3", "dep:chia_py_streamable_macro"]
 
 [dependencies]
-pyo3 = { version = ">=0.19.0", features = ["extension-module", "multiple-pymethods"], optional = true }
-sha2 = "=0.9.9"
-hex = "=0.4.3"
-chia_streamable_macro = { version = "=0.2.4", path = "../chia_streamable_macro" }
-chia_py_streamable_macro = { path = "../chia_py_streamable_macro", version = "=0.1.3", optional = true }
-clvmr = "=0.2.6"
+pyo3 = { version = "0.19.0", features = ["extension-module", "multiple-pymethods"], optional = true }
+sha2 = "0.9.9"
+hex = "0.4.3"
+chia_streamable_macro = { version = "0.2.4", path = "../chia_streamable_macro" }
+chia_py_streamable_macro = { version = "0.1.3", path = "../chia_py_streamable_macro", optional = true }
+clvmr = "0.2.6"
 
 [dev-dependencies]
-rstest = "=0.16.0"
+rstest = "0.17.0"
 
 [lib]
 crate-type = ["rlib"]

--- a/chia-tools/Cargo.toml
+++ b/chia-tools/Cargo.toml
@@ -9,12 +9,12 @@ homepage = "https://github.com/Chia-Network/chia_rs/chia-tools"
 repository = "https://github.com/Chia-Network/chia_rs/chia-tools"
 
 [dependencies]
-chia-protocol = { version = ">=0.2.0", path = "../chia-protocol" }
-clvmr = { version = ">=0.2.5", features = ["counters"] }
-chia = { path = "..", version = ">=0.2.0" }
-sqlite = "=0.30.3"
-clap = { version = "=4.0.29", features = ["derive"] }
-zstd = "=0.12.1"
+chia-protocol = { version = "=0.2.7", path = "../chia-protocol" }
+clvmr = { version = "=0.2.6", features = ["counters"] }
+chia = { version = "=0.2.8", path = ".." }
+sqlite = "=0.31.0"
+clap = { version = "=4.3.9", features = ["derive"] }
+zstd = "=0.12.3+zstd.1.5.2"
 threadpool = "=1.8.1"
 hex = "=0.4.3"
 

--- a/chia_py_streamable_macro/Cargo.toml
+++ b/chia_py_streamable_macro/Cargo.toml
@@ -12,5 +12,5 @@ repository = "https://github.com/Chia-Network/chia_rs/chia_py_streamable_macro/"
 proc-macro = true
 
 [dependencies]
-syn = ">1.0.86"
-quote = ">1.0.15"
+syn = "2.0.22"
+quote = "1.0.28"

--- a/chia_streamable_macro/Cargo.toml
+++ b/chia_streamable_macro/Cargo.toml
@@ -12,5 +12,5 @@ repository = "https://github.com/Chia-Network/chia_rs/"
 proc-macro = true
 
 [dependencies]
-syn = { version = ">1.0.86", features = ["full"] }
-quote = ">1.0.15"
+syn = { version = "2.0.22", features = ["full"] }
+quote = "1.0.28"

--- a/clvm-utils/Cargo.toml
+++ b/clvm-utils/Cargo.toml
@@ -9,4 +9,4 @@ homepage = "https://github.com/Chia-Network/chia_rs/"
 repository = "https://github.com/Chia-Network/chia_rs/clvm-utils"
 
 [dependencies]
-clvmr = "=0.2.6"
+clvmr = "0.2.6"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -17,5 +17,5 @@ path = "src/lib.rs"
 [dependencies]
 chia = { path = ".." }
 wasm-bindgen = "=0.2.87"
-wasm-bindgen-test = "=0.3.25"
+wasm-bindgen-test = "=0.3.37"
 js-sys = "=0.3.64"

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -15,10 +15,10 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
+clvmr = "=0.2.6"
+hex = "=0.4.3"
+pyo3 = { version = "=0.19.0", features = ["extension-module", "multiple-pymethods"] }
 chia = { path = "..", features = ["py-bindings"] }
 chia-protocol = { path = "../chia-protocol", features = ["py-bindings"]  }
-clvmr = "=0.2.6"
-pyo3 = { version = "=0.19.0", features = ["extension-module", "multiple-pymethods"] }
-chia_py_streamable_macro = { version= "0.1.3", path = "../chia_py_streamable_macro" }
-chia_streamable_macro = { version = "0.2.4", path = "../chia_streamable_macro" }
-hex = "=0.4.3"
+chia_py_streamable_macro = { path = "../chia_py_streamable_macro" }
+chia_streamable_macro = { path = "../chia_streamable_macro" }


### PR DESCRIPTION
Relax the version pinning on the Rust crates, except for `wheel` and `wasm`.