### PR TITLE
include fuzz in workspace

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -301,8 +301,6 @@ jobs:
             cargo fmt --all -- --files-with-diff --check
             cd wheel
             cargo fmt -- --files-with-diff --check
-            cd ../fuzz
-            cargo fmt -- --files-with-diff --check
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # the "wheel" crate is excluded from the workspace because pyo3 has problems with
 # "cargo test" and "cargo bench"
 [workspace]
-members = ["wasm", "chia_streamable_macro", "chia-bls", "clvm-utils", "chia-protocol", "chia_py_streamable_macro", "chia-tools"]
+members = ["wasm", "chia_streamable_macro", "chia-bls", "clvm-utils", "chia-protocol", "chia_py_streamable_macro", "chia-tools", "fuzz", "clvm-utils/fuzz"]
 exclude = ["wheel"]
 
 [package]

--- a/chia-tools/src/bin/test-block-generators.rs
+++ b/chia-tools/src/bin/test-block-generators.rs
@@ -142,7 +142,7 @@ fn main() {
 
     let pool = ThreadPool::new(
         args.num_jobs
-            .unwrap_or(available_parallelism().unwrap().into()),
+            .unwrap_or_else(|| available_parallelism().unwrap().into()),
     );
 
     let flags = if args.mempool { MEMPOOL_MODE } else { 0 }

--- a/clvm-utils/fuzz/Cargo.toml
+++ b/clvm-utils/fuzz/Cargo.toml
@@ -11,25 +11,20 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 clvmr = "=0.2.6"
-
-[dependencies.clvm-utils]
-path = ".."
-
-[dependencies.chia]
-path = "../.."
-
-# Prevent this from interfering with workspaces
-[workspace]
-members = ["."]
+chia-fuzz = { path = "../../fuzz" }
+clvm-utils = { path = ".." }
+chia = { path = "../.." }
 
 [[bin]]
 name = "tree-hash"
 path = "fuzz_targets/tree-hash.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "uncurry"
 path = "fuzz_targets/uncurry.rs"
 test = false
 doc = false
+bench = false

--- a/clvm-utils/fuzz/fuzz_targets/tree-hash.rs
+++ b/clvm-utils/fuzz/fuzz_targets/tree-hash.rs
@@ -1,9 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use chia::fuzzing_utils::{make_tree, BitCursor};
 use clvm_utils::tree_hash::tree_hash;
 use clvmr::allocator::Allocator;
+use fuzzing_utils::{make_tree, BitCursor};
 
 fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();

--- a/clvm-utils/fuzz/fuzz_targets/uncurry.rs
+++ b/clvm-utils/fuzz/fuzz_targets/uncurry.rs
@@ -1,9 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use chia::fuzzing_utils::{make_tree, BitCursor};
 use clvm_utils::uncurry::uncurry;
 use clvmr::allocator::Allocator;
+use fuzzing_utils::{make_tree, BitCursor};
 
 fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,60 +15,69 @@ clvm-utils = { path = "../clvm-utils" }
 chia-protocol = { path = "../chia-protocol" }
 chia = { path = ".." }
 
-# Prevent this from interfering with workspaces
-[workspace]
-members = ["."]
+[lib]
+name = "fuzzing_utils"
+crate-type = ["rlib"]
 
 [[bin]]
 name = "puzzle-coin-solution"
 path = "fuzz_targets/puzzle-coin-solution.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "parse-spend"
 path = "fuzz_targets/parse-spend.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "parse-cond-args"
 path = "fuzz_targets/parse-cond-args.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "parse-conditions"
 path = "fuzz_targets/parse-conditions.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "self-extractor"
 path = "fuzz_targets/self-extractor.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "parse-spends"
 path = "fuzz_targets/parse-spends.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "sanitize-uint"
 path = "fuzz_targets/sanitize-uint.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "process-spend"
 path = "fuzz_targets/process-spend.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "run-generator"
 path = "fuzz_targets/run-generator.rs"
 test = false
 doc = false
+bench = false

--- a/fuzz/fuzz_targets/parse-cond-args.rs
+++ b/fuzz/fuzz_targets/parse-cond-args.rs
@@ -1,9 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use chia::fuzzing_utils::{make_tree, BitCursor};
 use chia::gen::conditions::parse_args;
 use clvmr::allocator::Allocator;
+use fuzzing_utils::{make_tree, BitCursor};
 
 use chia::gen::flags::{COND_ARGS_NIL, ENABLE_ASSERT_BEFORE, STRICT_ARGS_COUNT};
 

--- a/fuzz/fuzz_targets/parse-conditions.rs
+++ b/fuzz/fuzz_targets/parse-conditions.rs
@@ -1,12 +1,12 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use chia::fuzzing_utils::{make_tree, BitCursor};
 use chia::gen::conditions::{parse_conditions, ParseState, Spend, SpendBundleConditions};
 use chia_protocol::Bytes32;
 use chia_protocol::Coin;
 use clvm_utils::tree_hash::tree_hash;
 use clvmr::allocator::Allocator;
+use fuzzing_utils::{make_tree, BitCursor};
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -26,7 +26,7 @@ fuzz_target!(|data: &[u8]| {
     let puzzle_hash = tree_hash(&a, input);
     let coin_id = Arc::<Bytes32>::new(
         Coin {
-            parent_coin_info: parent_id.into(),
+            parent_coin_info: parent_id,
             puzzle_hash: puzzle_hash.into(),
             amount,
         }

--- a/fuzz/fuzz_targets/parse-spend.rs
+++ b/fuzz/fuzz_targets/parse-spend.rs
@@ -1,9 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use chia::fuzzing_utils::{make_tree, BitCursor};
 use chia::gen::get_puzzle_and_solution::parse_coin_spend;
 use clvmr::allocator::Allocator;
+use fuzzing_utils::{make_tree, BitCursor};
 
 fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();

--- a/fuzz/fuzz_targets/parse-spends.rs
+++ b/fuzz/fuzz_targets/parse-spends.rs
@@ -1,9 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use chia::fuzzing_utils::{make_tree, BitCursor};
 use chia::gen::conditions::parse_spends;
 use clvmr::allocator::Allocator;
+use fuzzing_utils::{make_tree, BitCursor};
 
 use chia::gen::flags::{COND_ARGS_NIL, ENABLE_ASSERT_BEFORE, NO_UNKNOWN_CONDS, STRICT_ARGS_COUNT};
 

--- a/fuzz/fuzz_targets/process-spend.rs
+++ b/fuzz/fuzz_targets/process-spend.rs
@@ -1,8 +1,8 @@
 #![no_main]
-use chia::fuzzing_utils::{make_tree, BitCursor};
 use chia::gen::conditions::{process_single_spend, ParseState, SpendBundleConditions};
 use chia::gen::flags::{COND_ARGS_NIL, NO_UNKNOWN_CONDS, STRICT_ARGS_COUNT};
 use clvmr::allocator::Allocator;
+use fuzzing_utils::{make_tree, BitCursor};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -19,7 +19,7 @@ fuzz_target!(|data: &[u8]| {
     for flags in &[0, COND_ARGS_NIL, STRICT_ARGS_COUNT, NO_UNKNOWN_CONDS] {
         let mut cost_left = 11000000;
         let _ = process_single_spend(
-            &mut a,
+            &a,
             &mut ret,
             &mut state,
             parent_id,

--- a/fuzz/fuzz_targets/puzzle-coin-solution.rs
+++ b/fuzz/fuzz_targets/puzzle-coin-solution.rs
@@ -1,9 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use chia::fuzzing_utils::{make_tree, BitCursor};
 use chia::gen::get_puzzle_and_solution::get_puzzle_and_solution_for_coin;
 use clvmr::allocator::Allocator;
+use fuzzing_utils::{make_tree, BitCursor};
 
 const HASH: [u8; 32] = [
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/fuzz/fuzz_targets/self-extractor.rs
+++ b/fuzz/fuzz_targets/self-extractor.rs
@@ -1,7 +1,6 @@
 #![no_main]
 
 use chia::compression::compressor::wrap_atom_with_decompression_program;
-use chia::fuzzing_utils;
 
 use clvm_utils::tree_hash::tree_hash;
 use clvmr::allocator::Allocator;

--- a/fuzz/src/fuzzing_utils.rs
+++ b/fuzz/src/fuzzing_utils.rs
@@ -27,7 +27,7 @@ impl<'a> BitCursor<'a> {
             Some((self.data[0] & mask(self.bit_offset)) >> (8 - num - self.bit_offset))
         } else if self.data.len() < 2 {
             num = 8 - self.bit_offset;
-            Some(&self.data[0] & mask(self.bit_offset))
+            Some(self.data[0] & mask(self.bit_offset))
         } else {
             let first_byte = 8 - self.bit_offset;
             let second_byte = num - first_byte;

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod fuzzing_utils;
+pub use crate::fuzzing_utils::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,3 @@ pub mod compression;
 pub mod gen;
 pub mod generator_rom;
 pub mod merkle_set;
-
-#[cfg(fuzzing)]
-pub mod fuzzing_utils;


### PR DESCRIPTION
there are two justifications for this:
1. by including the fuzz projects in the main workspace, they share the `Cargo.lock` file with all other build targets, and we ensure that we fuzz the exact same dependencies that we build the production wheel against
2. `cargo fmt --all` and `cargo clippy --workspace` will cover the fuzz targets as well. This lets us simplify the workflow file a bit and also adds new coverage for clippy that we previously did not have