### PR TITLE
new agg-sig conditions

### DIFF
--- a/chia-tools/src/bin/test-block-generators.rs
+++ b/chia-tools/src/bin/test-block-generators.rs
@@ -90,6 +90,12 @@ fn compare_spend(a: &Allocator, lhs: &Spend, rhs: &Spend) {
     assert_eq!(lhs.birth_seconds, rhs.birth_seconds);
     compare_new_coins(a, &lhs.create_coin, &rhs.create_coin);
     compare_agg_sig(a, &lhs.agg_sig_me, &rhs.agg_sig_me);
+    compare_agg_sig(a, &lhs.agg_sig_parent, &rhs.agg_sig_parent);
+    compare_agg_sig(a, &lhs.agg_sig_puzzle, &rhs.agg_sig_puzzle);
+    compare_agg_sig(a, &lhs.agg_sig_amount, &rhs.agg_sig_amount);
+    compare_agg_sig(a, &lhs.agg_sig_puzzle_amount, &rhs.agg_sig_puzzle_amount);
+    compare_agg_sig(a, &lhs.agg_sig_parent_amount, &rhs.agg_sig_parent_amount);
+    compare_agg_sig(a, &lhs.agg_sig_parent_puzzle, &rhs.agg_sig_parent_puzzle);
     assert_eq!(lhs.flags, rhs.flags);
     assert_eq!(a.atom(lhs.puzzle_hash), a.atom(rhs.puzzle_hash));
 }

--- a/fuzz/fuzz_targets/parse-conditions.rs
+++ b/fuzz/fuzz_targets/parse-conditions.rs
@@ -56,6 +56,12 @@ fuzz_target!(|data: &[u8]| {
             birth_seconds: None,
             create_coin: HashSet::new(),
             agg_sig_me: Vec::new(),
+            agg_sig_parent: Vec::new(),
+            agg_sig_puzzle: Vec::new(),
+            agg_sig_amount: Vec::new(),
+            agg_sig_puzzle_amount: Vec::new(),
+            agg_sig_parent_amount: Vec::new(),
+            agg_sig_parent_puzzle: Vec::new(),
             flags: 0_u32,
         };
         let mut max_cost: u64 = 3300000000;

--- a/src/gen/opcodes.rs
+++ b/src/gen/opcodes.rs
@@ -6,6 +6,12 @@ use clvmr::cost::Cost;
 pub type ConditionOpcode = u16;
 
 // AGG_SIG is ascii "1"
+pub const AGG_SIG_PARENT: ConditionOpcode = 43;
+pub const AGG_SIG_PUZZLE: ConditionOpcode = 44;
+pub const AGG_SIG_AMOUNT: ConditionOpcode = 45;
+pub const AGG_SIG_PUZZLE_AMOUNT: ConditionOpcode = 46;
+pub const AGG_SIG_PARENT_AMOUNT: ConditionOpcode = 47;
+pub const AGG_SIG_PARENT_PUZZLE: ConditionOpcode = 48;
 pub const AGG_SIG_UNSAFE: ConditionOpcode = 49;
 pub const AGG_SIG_ME: ConditionOpcode = 50;
 
@@ -134,7 +140,18 @@ pub fn parse_opcode(a: &Allocator, op: NodePtr, flags: u32) -> Option<ConditionO
             | ASSERT_HEIGHT_ABSOLUTE
             | REMARK => Some(b0),
             _ => {
-                if (flags & ENABLE_SOFTFORK_CONDITION) != 0 && b0 == SOFTFORK {
+                if (flags & ENABLE_SOFTFORK_CONDITION) != 0
+                    && [
+                        SOFTFORK,
+                        AGG_SIG_PARENT,
+                        AGG_SIG_PUZZLE,
+                        AGG_SIG_AMOUNT,
+                        AGG_SIG_PUZZLE_AMOUNT,
+                        AGG_SIG_PARENT_AMOUNT,
+                        AGG_SIG_PARENT_PUZZLE,
+                    ]
+                    .contains(&b0)
+                {
                     Some(b0)
                 } else if (flags & ENABLE_ASSERT_BEFORE) != 0 {
                     match b0 {
@@ -231,8 +248,14 @@ fn test_parse_opcode(
 #[case(&[AGG_SIG_UNSAFE as u8], Some(AGG_SIG_UNSAFE), Some(AGG_SIG_UNSAFE))]
 #[case(&[AGG_SIG_ME as u8], Some(AGG_SIG_ME), Some(AGG_SIG_ME))]
 #[case(&[CREATE_COIN as u8], Some(CREATE_COIN), Some(CREATE_COIN))]
-// the SOFTOFORK condition is only recognized when the flag is set
+// the SOFTOFORK and new AGG_SIG_* condition is only recognized when the flag is set
 #[case(&[SOFTFORK as u8], None, Some(SOFTFORK))]
+#[case(&[AGG_SIG_PARENT as u8], None, Some(AGG_SIG_PARENT))]
+#[case(&[AGG_SIG_PUZZLE as u8], None, Some(AGG_SIG_PUZZLE))]
+#[case(&[AGG_SIG_AMOUNT as u8], None, Some(AGG_SIG_AMOUNT))]
+#[case(&[AGG_SIG_PUZZLE_AMOUNT as u8], None, Some(AGG_SIG_PUZZLE_AMOUNT))]
+#[case(&[AGG_SIG_PARENT_AMOUNT as u8], None, Some(AGG_SIG_PARENT_AMOUNT))]
+#[case(&[AGG_SIG_PARENT_PUZZLE as u8], None, Some(AGG_SIG_PARENT_PUZZLE))]
 #[case(&[ASSERT_EPHEMERAL as u8], None, None)]
 #[case(&[ASSERT_BEFORE_SECONDS_RELATIVE as u8], None, None)]
 fn test_parse_opcode_softfork(

--- a/src/gen/run_puzzle.rs
+++ b/src/gen/run_puzzle.rs
@@ -64,6 +64,12 @@ pub fn run_puzzle(
         birth_seconds: None,
         create_coin: HashSet::new(),
         agg_sig_me: Vec::new(),
+        agg_sig_parent: Vec::new(),
+        agg_sig_puzzle: Vec::new(),
+        agg_sig_amount: Vec::new(),
+        agg_sig_puzzle_amount: Vec::new(),
+        agg_sig_parent_amount: Vec::new(),
+        agg_sig_parent_puzzle: Vec::new(),
         // assume it's eligible until we see an agg-sig condition
         flags: ELIGIBLE_FOR_DEDUP,
     };

--- a/tests/test_streamable.py
+++ b/tests/test_streamable.py
@@ -4,14 +4,15 @@ import copy
 
 
 coin = b"bcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbc"
+parent = b"edededededededededededededededed"
 ph = b"abababababababababababababababab"
 ph2 = b"cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
 sig = b"abababababababababababababababababababababababab"
 
 def test_hash_spend() -> None:
 
-    a1 = Spend(coin, ph, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
-    a2 = Spend(coin, ph, None, 1, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
+    a1 = Spend(coin, parent, ph, 123, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
+    a2 = Spend(coin, parent, ph, 123, None, 1, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
     b = hash(a1)
     c = hash(a2)
     assert type(b) is int
@@ -30,11 +31,13 @@ def test_hash_spend_bundle_conditions() -> None:
 
 def test_json_spend() -> None:
 
-    a = Spend(coin, ph, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
+    a = Spend(coin, parent, ph, 123, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
 
     assert a.to_json_dict() == {
         "coin_id": "0x" + coin.hex(),
+        "parent_id": "0x" + parent.hex(),
         "puzzle_hash": "0x" + ph.hex(),
+        "coin_amount": 123,
         "height_relative": None,
         "seconds_relative": 0,
         "before_height_relative": None,
@@ -54,11 +57,13 @@ def test_json_spend() -> None:
 
 def test_from_json_spend() -> None:
 
-    a = Spend(coin, ph, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
+    a = Spend(coin, parent, ph, 123, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
 
     b = Spend.from_json_dict({
         "coin_id": "0x" + coin.hex(),
+        "parent_id": "0x" + parent.hex(),
         "puzzle_hash": "0x" + ph.hex(),
+        "coin_amount": 123,
         "height_relative": None,
         "seconds_relative": 0,
         "before_height_relative": None,
@@ -79,11 +84,13 @@ def test_from_json_spend() -> None:
 
 def test_from_json_spend_set_optional() -> None:
 
-    a = Spend(coin, ph, 1337, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
+    a = Spend(coin, parent, ph, 123, 1337, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
 
     b = Spend.from_json_dict({
         "coin_id": "0x" + coin.hex(),
+        "parent_id": "0x" + parent.hex(),
         "puzzle_hash": "0x" + ph.hex(),
+        "coin_amount": 123,
         "height_relative": 1337,
         "seconds_relative": 0,
         "before_height_relative": None,
@@ -108,7 +115,9 @@ def test_invalid_hex_prefix() -> None:
         a = Spend.from_json_dict({
             # this field is missing the 0x prefix
             "coin_id": coin.hex(),
+            "parent_id": "0x" + parent.hex(),
             "puzzle_hash": "0x" + ph.hex(),
+            "coin_amount": 123,
             "height_relative": None,
             "seconds_relative": 0,
             "before_height_relative": None,
@@ -131,7 +140,9 @@ def test_invalid_hex_prefix_bytes() -> None:
     with pytest.raises(ValueError, match="bytes object is expected to start with 0x"):
         a = Spend.from_json_dict({
             "coin_id": "0x" + coin.hex(),
+            "parent_id": "0x" + parent.hex(),
             "puzzle_hash": "0x" + ph.hex(),
+            "coin_amount": 123,
             "height_relative": None,
             "seconds_relative": 0,
             "before_height_relative": None,
@@ -156,7 +167,9 @@ def test_invalid_hex_digit() -> None:
         a = Spend.from_json_dict({
             # this field is has an invalid hex digit (the last one)
             "coin_id": "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg",
+            "parent_id": "0x" + parent.hex(),
             "puzzle_hash": "0x" + ph.hex(),
+            "coin_amount": 123,
             "height_relative": None,
             "seconds_relative": 0,
             "before_height_relative": None,
@@ -180,7 +193,9 @@ def test_invalid_hex_length() -> None:
         a = Spend.from_json_dict({
             # this field is has invalid length
             "coin_id": "0x" + coin.hex() + "ff",
+            "parent_id": "0x" + parent.hex(),
             "puzzle_hash": "0x" + ph.hex(),
+            "coin_amount": 123,
             "height_relative": None,
             "seconds_relative": 0,
             "before_height_relative": None,
@@ -203,7 +218,9 @@ def test_missing_field() -> None:
     with pytest.raises(KeyError, match="coin_id"):
         a = Spend.from_json_dict({
             # coin_id is missing
+            "parent_id": "0x" + parent.hex(),
             "puzzle_hash": "0x" + ph.hex(),
+            "coin_amount": 123,
             "height_relative": None,
             "seconds_relative": 0,
             "before_height_relative": None,
@@ -259,7 +276,7 @@ def test_from_json_spend_bundle_conditions() -> None:
 
 def test_copy_spend() -> None:
 
-    a = Spend(coin, ph, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
+    a = Spend(coin, parent, ph, 123, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
     b = copy.copy(a)
 
     assert a == b

--- a/tests/test_streamable.py
+++ b/tests/test_streamable.py
@@ -10,8 +10,8 @@ sig = b"abababababababababababababababababababababababab"
 
 def test_hash_spend() -> None:
 
-    a1 = Spend(coin, ph, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], False)
-    a2 = Spend(coin, ph, None, 1, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], False)
+    a1 = Spend(coin, ph, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
+    a2 = Spend(coin, ph, None, 1, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
     b = hash(a1)
     c = hash(a2)
     assert type(b) is int
@@ -30,7 +30,7 @@ def test_hash_spend_bundle_conditions() -> None:
 
 def test_json_spend() -> None:
 
-    a = Spend(coin, ph, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], False)
+    a = Spend(coin, ph, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
 
     assert a.to_json_dict() == {
         "coin_id": "0x" + coin.hex(),
@@ -43,12 +43,18 @@ def test_json_spend() -> None:
         "birth_seconds": None,
         "create_coin": [["0x" + ph2.hex(), 1000000, None]],
         "agg_sig_me": [["0x" + sig.hex(), "0x6d7367"]],
+        "agg_sig_parent": [],
+        "agg_sig_puzzle": [],
+        "agg_sig_amount": [],
+        "agg_sig_puzzle_amount": [],
+        "agg_sig_parent_amount": [],
+        "agg_sig_parent_puzzle": [],
         "flags": 0,
     }
 
 def test_from_json_spend() -> None:
 
-    a = Spend(coin, ph, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], False)
+    a = Spend(coin, ph, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
 
     b = Spend.from_json_dict({
         "coin_id": "0x" + coin.hex(),
@@ -61,13 +67,19 @@ def test_from_json_spend() -> None:
         "birth_seconds": None,
         "create_coin": [["0x" + ph2.hex(), 1000000, None]],
         "agg_sig_me": [["0x" + sig.hex(), "0x6d7367"]],
+        "agg_sig_parent": [],
+        "agg_sig_puzzle": [],
+        "agg_sig_amount": [],
+        "agg_sig_puzzle_amount": [],
+        "agg_sig_parent_amount": [],
+        "agg_sig_parent_puzzle": [],
         "flags": 0,
     })
     assert a == b
 
 def test_from_json_spend_set_optional() -> None:
 
-    a = Spend(coin, ph, 1337, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], False)
+    a = Spend(coin, ph, 1337, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
 
     b = Spend.from_json_dict({
         "coin_id": "0x" + coin.hex(),
@@ -80,6 +92,12 @@ def test_from_json_spend_set_optional() -> None:
         "birth_seconds": None,
         "create_coin": [["0x" + ph2.hex(), 1000000, None]],
         "agg_sig_me": [["0x" + sig.hex(), "0x6d7367"]],
+        "agg_sig_parent": [],
+        "agg_sig_puzzle": [],
+        "agg_sig_amount": [],
+        "agg_sig_puzzle_amount": [],
+        "agg_sig_parent_amount": [],
+        "agg_sig_parent_puzzle": [],
         "flags": 0,
     })
     assert a == b
@@ -99,6 +117,12 @@ def test_invalid_hex_prefix() -> None:
             "birth_seconds": None,
             "create_coin": [["0x" + ph2.hex(), 1000000, None]],
             "agg_sig_me": [["0x" + sig.hex(), "0x6d7367"]],
+            "agg_sig_parent": [],
+            "agg_sig_puzzle": [],
+            "agg_sig_amount": [],
+            "agg_sig_puzzle_amount": [],
+            "agg_sig_parent_amount": [],
+            "agg_sig_parent_puzzle": [],
             "flags": 0,
         })
 
@@ -117,6 +141,12 @@ def test_invalid_hex_prefix_bytes() -> None:
             "create_coin": [["0x" + ph2.hex(), 1000000, None]],
             # the message field is missing the 0x prefix and is variable length bytes
             "agg_sig_me": [["0x" + sig.hex(), "6d7367"]],
+            "agg_sig_parent": [],
+            "agg_sig_puzzle": [],
+            "agg_sig_amount": [],
+            "agg_sig_puzzle_amount": [],
+            "agg_sig_parent_amount": [],
+            "agg_sig_parent_puzzle": [],
             "flags": 0,
         })
 
@@ -135,6 +165,12 @@ def test_invalid_hex_digit() -> None:
             "birth_seconds": None,
             "create_coin": [["0x" + ph2.hex(), 1000000, None]],
             "agg_sig_me": [["0x" + sig.hex(), "0x6d7367"]],
+            "agg_sig_parent": [],
+            "agg_sig_puzzle": [],
+            "agg_sig_amount": [],
+            "agg_sig_puzzle_amount": [],
+            "agg_sig_parent_amount": [],
+            "agg_sig_parent_puzzle": [],
             "flags": 0,
         })
 
@@ -153,6 +189,12 @@ def test_invalid_hex_length() -> None:
             "birth_seconds": None,
             "create_coin": [["0x" + ph2.hex(), 1000000, None]],
             "agg_sig_me": [["0x" + sig.hex(), "0x6d7367"]],
+            "agg_sig_parent": [],
+            "agg_sig_puzzle": [],
+            "agg_sig_amount": [],
+            "agg_sig_puzzle_amount": [],
+            "agg_sig_parent_amount": [],
+            "agg_sig_parent_puzzle": [],
             "flags": 0,
         })
 
@@ -170,6 +212,12 @@ def test_missing_field() -> None:
             "birth_seconds": None,
             "create_coin": [["0x" + ph2.hex(), 1000000, None]],
             "agg_sig_me": [["0x" + sig.hex(), "0x6d7367"]],
+            "agg_sig_parent": [],
+            "agg_sig_puzzle": [],
+            "agg_sig_amount": [],
+            "agg_sig_puzzle_amount": [],
+            "agg_sig_parent_amount": [],
+            "agg_sig_parent_puzzle": [],
             "flags": 0,
         })
 
@@ -211,7 +259,7 @@ def test_from_json_spend_bundle_conditions() -> None:
 
 def test_copy_spend() -> None:
 
-    a = Spend(coin, ph, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], False)
+    a = Spend(coin, ph, None, 0, None, None, None, None, [(ph2, 1000000, None)], [(sig, b"msg")], [], [], [], [], [], [], False)
     b = copy.copy(a)
 
     assert a == b

--- a/wheel/chia_rs.pyi
+++ b/wheel/chia_rs.pyi
@@ -69,6 +69,12 @@ class Spend:
     birth_seconds: Optional[int]
     create_coin: List[Tuple[bytes, int, Optional[bytes]]]
     agg_sig_me: List[Tuple[bytes, bytes]]
+    agg_sig_parent: List[Tuple[bytes, bytes]]
+    agg_sig_puzzle: List[Tuple[bytes, bytes]]
+    agg_sig_amount: List[Tuple[bytes, bytes]]
+    agg_sig_puzzle_amount: List[Tuple[bytes, bytes]]
+    agg_sig_parent_amount: List[Tuple[bytes, bytes]]
+    agg_sig_parent_puzzle: List[Tuple[bytes, bytes]]
     flags: int
     def __init__(
         self,
@@ -82,6 +88,12 @@ class Spend:
         birth_seconds: Optional[int],
         create_coin: Sequence[Tuple[bytes, int, Optional[bytes]]],
         agg_sig_me: Sequence[Tuple[bytes, bytes]],
+        agg_sig_parent: Sequence[Tuple[bytes, bytes]],
+        agg_sig_puzzle: Sequence[Tuple[bytes, bytes]],
+        agg_sig_amount: Sequence[Tuple[bytes, bytes]],
+        agg_sig_puzzle_amount: Sequence[Tuple[bytes, bytes]],
+        agg_sig_parent_amount: Sequence[Tuple[bytes, bytes]],
+        agg_sig_parent_puzzle: Sequence[Tuple[bytes, bytes]],
         flags: int
     ) -> None: ...
     def __hash__(self) -> int: ...

--- a/wheel/chia_rs.pyi
+++ b/wheel/chia_rs.pyi
@@ -60,7 +60,9 @@ def get_puzzle_and_solution_for_coin(program: ReadableBuffer, args: ReadableBuff
 
 class Spend:
     coin_id: bytes
+    parent_id: bytes
     puzzle_hash: bytes
+    coin_amount: int
     height_relative: Optional[int]
     seconds_relative: Optional[int]
     before_height_relative: Optional[int]
@@ -79,7 +81,9 @@ class Spend:
     def __init__(
         self,
         coin_id: bytes,
+        parent_id: bytes,
         puzzle_hash: bytes,
+        coin_amount: int,
         height_relative: Optional[int],
         seconds_relative: Optional[int],
         before_height_relative: Optional[int],

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -216,6 +216,12 @@ def get_puzzle_and_solution_for_coin(program: ReadableBuffer, args: ReadableBuff
             "birth_seconds: Optional[int]",
             "create_coin: List[Tuple[bytes, int, Optional[bytes]]]",
             "agg_sig_me: List[Tuple[bytes, bytes]]",
+            "agg_sig_parent: List[Tuple[bytes, bytes]]",
+            "agg_sig_puzzle: List[Tuple[bytes, bytes]]",
+            "agg_sig_amount: List[Tuple[bytes, bytes]]",
+            "agg_sig_puzzle_amount: List[Tuple[bytes, bytes]]",
+            "agg_sig_parent_amount: List[Tuple[bytes, bytes]]",
+            "agg_sig_parent_puzzle: List[Tuple[bytes, bytes]]",
             "flags: int",
         ],
     )

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -207,7 +207,9 @@ def get_puzzle_and_solution_for_coin(program: ReadableBuffer, args: ReadableBuff
     print_class(f, "Spend",
         [
             "coin_id: bytes",
+            "parent_id: bytes",
             "puzzle_hash: bytes",
+            "coin_amount: int",
             "height_relative: Optional[int]",
             "seconds_relative: Optional[int]",
             "before_height_relative: Optional[int]",

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -24,7 +24,9 @@ use chia_streamable_macro::Streamable;
 #[derive(Streamable, PyStreamable, Hash, Debug, Clone, Eq, PartialEq)]
 pub struct PySpend {
     pub coin_id: Bytes32,
+    pub parent_id: Bytes32,
     pub puzzle_hash: Bytes32,
+    pub coin_amount: u64,
     pub height_relative: Option<u32>,
     pub seconds_relative: Option<u64>,
     pub before_height_relative: Option<u32>,
@@ -89,7 +91,9 @@ fn convert_spend(a: &Allocator, spend: Spend) -> PySpend {
 
     PySpend {
         coin_id: *spend.coin_id,
+        parent_id: a.atom(spend.parent_id).into(),
         puzzle_hash: a.atom(spend.puzzle_hash).into(),
+        coin_amount: spend.coin_amount,
         height_relative: spend.height_relative,
         seconds_relative: spend.seconds_relative,
         before_height_relative: spend.before_height_relative,


### PR DESCRIPTION
This PR adds support for new `AGG_SIG`-conditions in the same family as `AGG_SIG_ME`.
Since these conditions affect the aggregated signature field on the full block, it is a hard-fork, and is only enabled when the `ENABLE_SOFTFORK_CONDITION`-flag is set.

The new conditions are:

| name | code |
| --- | --- |
| `AGG_SIG_PARENT` | 43 |
| `AGG_SIG_PUZZLE` | 44 |
| `AGG_SIG_AMOUNT` | 45 |
| `AGG_SIG_PUZZLE_AMOUNT` | 46 |
| `AGG_SIG_PARENT_AMOUNT` | 47 |
| `AGG_SIG_PARENT_PUZZLE` | 48 |

They all take the same parameters as `AGG_SIG_ME` and `AGG_SIG_UNSAFE`, i.e. `public-key` and `message`.

The cost are the same as `AGG_SIG_ME` and `AGG_SIG_UNSAFE`, i.e. 1200000.

These act the same as `AGG_SIG_ME`, but instead of including the genesis hash and the coin-id in the signed message, they include a different domain separator string and *just* the combination of parent, puzzle and amount.