### PR TITLE
factor out PyJsonDict macro from PyStreamable

### DIFF
--- a/chia-protocol/src/bls.rs
+++ b/chia-protocol/src/bls.rs
@@ -3,6 +3,8 @@ use chia_streamable_macro::Streamable;
 
 #[cfg(feature = "py-bindings")]
 use chia_py_streamable_macro::PyStreamable;
+#[cfg(feature = "py-bindings")]
+use chia_traits::{FromJsonDict, ToJsonDict};
 
 #[cfg(feature = "py-bindings")]
 use pyo3::prelude::*;
@@ -11,6 +13,33 @@ use pyo3::prelude::*;
 #[derive(Streamable, Hash, Debug, Clone, Eq, PartialEq)]
 pub struct G1Element(Bytes48);
 
+#[cfg(feature = "py-bindings")]
+impl ToJsonDict for G1Element {
+    fn to_json_dict(&self, py: Python) -> pyo3::PyResult<PyObject> {
+        self.0.to_json_dict(py)
+    }
+}
+
+#[cfg(feature = "py-bindings")]
+impl FromJsonDict for G1Element {
+    fn from_json_dict(o: &PyAny) -> PyResult<Self> {
+        Ok(Self(Bytes48::from_json_dict(o)?))
+    }
+}
 #[cfg_attr(feature = "py-bindings", pyclass(frozen), derive(PyStreamable))]
 #[derive(Streamable, Hash, Debug, Clone, Eq, PartialEq)]
 pub struct G2Element(Bytes96);
+
+#[cfg(feature = "py-bindings")]
+impl ToJsonDict for G2Element {
+    fn to_json_dict(&self, py: Python) -> pyo3::PyResult<PyObject> {
+        self.0.to_json_dict(py)
+    }
+}
+
+#[cfg(feature = "py-bindings")]
+impl FromJsonDict for G2Element {
+    fn from_json_dict(o: &PyAny) -> PyResult<Self> {
+        Ok(Self(Bytes96::from_json_dict(o)?))
+    }
+}

--- a/chia-protocol/src/chia_protocol.rs
+++ b/chia-protocol/src/chia_protocol.rs
@@ -5,10 +5,10 @@ use crate::streamable_struct;
 use crate::Bytes;
 
 #[cfg(feature = "py-bindings")]
-use chia_py_streamable_macro::PyStreamable;
+use chia_py_streamable_macro::{PyJsonDict, PyStreamable};
 
 #[repr(u8)]
-#[cfg_attr(feature = "py-bindings", derive(PyStreamable))]
+#[cfg_attr(feature = "py-bindings", derive(PyJsonDict, PyStreamable))]
 #[derive(Streamable, Hash, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ProtocolMessageTypes {
     // Shared protocol (all services)
@@ -127,7 +127,7 @@ pub trait ChiaProtocolMessage {
 }
 
 #[repr(u8)]
-#[cfg_attr(feature = "py-bindings", derive(PyStreamable))]
+#[cfg_attr(feature = "py-bindings", derive(PyJsonDict, PyStreamable))]
 #[derive(Streamable, Hash, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum NodeType {
     FullNode = 1,

--- a/chia-protocol/src/message_struct.rs
+++ b/chia-protocol/src/message_struct.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! message_struct {
     ($name:ident {$($field:ident: $t:ty $(,)? )*}) => {
-        #[cfg_attr(feature = "py-bindings", pyo3::pyclass(get_all, frozen), derive(chia_py_streamable_macro::PyStreamable))]
+        #[cfg_attr(feature = "py-bindings", pyo3::pyclass(get_all, frozen), derive(chia_py_streamable_macro::PyJsonDict, chia_py_streamable_macro::PyStreamable))]
         #[derive(Streamable, Hash, Debug, Clone, Eq, PartialEq)]
         pub struct $name {
             $(pub $field: $t),*
@@ -26,7 +26,7 @@ macro_rules! message_struct {
 #[macro_export]
 macro_rules! streamable_struct {
     ($name:ident {$($field:ident: $t:ty $(,)? )*}) => {
-        #[cfg_attr(feature = "py-bindings", pyo3::pyclass(get_all, frozen), derive(chia_py_streamable_macro::PyStreamable))]
+        #[cfg_attr(feature = "py-bindings", pyo3::pyclass(get_all, frozen), derive(chia_py_streamable_macro::PyJsonDict, chia_py_streamable_macro::PyStreamable))]
         #[derive(Streamable, Hash, Debug, Clone, Eq, PartialEq)]
         pub struct $name {
             $(pub $field: $t),*

--- a/chia-protocol/src/program.rs
+++ b/chia-protocol/src/program.rs
@@ -6,6 +6,9 @@ use sha2::{Digest, Sha256};
 use std::io::Cursor;
 
 #[cfg(feature = "py-bindings")]
+use chia_traits::{FromJsonDict, ToJsonDict};
+
+#[cfg(feature = "py-bindings")]
 use chia_py_streamable_macro::PyStreamable;
 
 #[cfg(feature = "py-bindings")]
@@ -45,6 +48,20 @@ impl Streamable for Program {
         let program = buf[..len as usize].to_vec();
         input.set_position(pos + len);
         Ok(Program(program.into()))
+    }
+}
+
+#[cfg(feature = "py-bindings")]
+impl ToJsonDict for Program {
+    fn to_json_dict(&self, py: Python) -> pyo3::PyResult<PyObject> {
+        self.0.to_json_dict(py)
+    }
+}
+
+#[cfg(feature = "py-bindings")]
+impl FromJsonDict for Program {
+    fn from_json_dict(o: &PyAny) -> PyResult<Self> {
+        Ok(Self(Bytes::from_json_dict(o)?))
     }
 }
 

--- a/chia_py_streamable_macro/src/lib.rs
+++ b/chia_py_streamable_macro/src/lib.rs
@@ -23,19 +23,6 @@ pub fn py_streamable_macro(input: proc_macro::TokenStream) -> proc_macro::TokenS
         syn::Data::Struct(s) => s.fields,
         syn::Data::Enum(_) => {
             return quote! {
-                impl #crate_name::to_json_dict::ToJsonDict for #ident {
-                    fn to_json_dict(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::PyObject> {
-                        <u8 as #crate_name::to_json_dict::ToJsonDict>::to_json_dict(&(*self as u8), py)
-                    }
-                }
-
-                impl #crate_name::from_json_dict::FromJsonDict for #ident {
-                    fn from_json_dict(o: &pyo3::PyAny) -> pyo3::PyResult<Self> {
-                        let v = <u8 as #crate_name::from_json_dict::FromJsonDict>::from_json_dict(o)?;
-                        <Self as #crate_name::Streamable>::parse(&mut std::io::Cursor::<&[u8]>::new(&[v])).map_err(|e| e.into())
-                    }
-                }
-
                 impl<'a> pyo3::conversion::FromPyObject<'a> for #ident {
                     fn extract(ob: &'a pyo3::PyAny) -> pyo3::PyResult<Self> {
                         let v: u8 = ob.extract()?;
@@ -100,7 +87,7 @@ pub fn py_streamable_macro(input: proc_macro::TokenStream) -> proc_macro::TokenS
                 ftypes.push(f.ty.clone());
             }
 
-            py_protocol.extend( quote! {
+            py_protocol.extend(quote! {
                 #[pyo3::pymethods]
                 impl #ident {
                     #[allow(too_many_arguments)]
@@ -109,88 +96,28 @@ pub fn py_streamable_macro(input: proc_macro::TokenStream) -> proc_macro::TokenS
                     fn new ( #(#fnames : #ftypes),* ) -> Self {
                         Self { #(#fnames),* }
                     }
-
-                    pub fn to_json_dict(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::PyObject> {
-                        #crate_name::to_json_dict::ToJsonDict::to_json_dict(self, py)
-                    }
-
-                    #[staticmethod]
-                    pub fn from_json_dict(o: &pyo3::PyAny) -> pyo3::PyResult<Self> {
-                        <Self as #crate_name::from_json_dict::FromJsonDict>::from_json_dict(o)
-                    }
-                }
-
-                impl #crate_name::to_json_dict::ToJsonDict for #ident {
-                    fn to_json_dict(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::PyObject> {
-                        let ret = pyo3::types::PyDict::new(py);
-                        #(ret.set_item(stringify!(#fnames), self.#fnames.to_json_dict(py)?)?);*;
-                        Ok(ret.into())
-                    }
-                }
-
-
-                impl #crate_name::from_json_dict::FromJsonDict for #ident {
-                    fn from_json_dict(o: &pyo3::PyAny) -> pyo3::PyResult<Self> {
-                        Ok(Self{
-                            #(#fnames: <#ftypes as #crate_name::from_json_dict::FromJsonDict>::from_json_dict(o.get_item(stringify!(#fnames))?)?,)*
-                        })
-                    }
                 }
             });
         }
-        syn::Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => {
-            let mut fnames = Vec::<syn::Ident>::new();
-            let mut ftypes = Vec::<syn::Type>::new();
-            for (index, f) in unnamed.iter().enumerate() {
-                ftypes.push(f.ty.clone());
-                fnames.push(syn::Ident::new(&format!("a{index}"), Span::call_site()));
-            }
-
-            py_protocol.extend(quote! {
-                #[pyo3::pymethods]
-                impl #ident {
-                    #[new]
-                    fn new ( #(#fnames: #ftypes),* ) -> Self {
-                        Self ( #(#fnames),* )
-                    }
-                }
-            });
-
-            if fnames.len() == 1 {
-                // tuples with a single member support the json protocol by just
-                // behaving as their member
-                py_protocol.extend(quote! {
-                    #[pyo3::pymethods]
-                    impl #ident {
-                        #[staticmethod]
-                        pub fn from_json_dict(o: &pyo3::PyAny) -> pyo3::PyResult<Self> {
-                            <Self as #crate_name::from_json_dict::FromJsonDict>::from_json_dict(o)
-                        }
-
-                        pub fn to_json_dict(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::PyObject> {
-                            #crate_name::to_json_dict::ToJsonDict::to_json_dict(self, py)
-                        }
-                    }
-
-                    // only types with named fields suport the to/from JSON protocol
-                    impl #crate_name::to_json_dict::ToJsonDict for #ident {
-                        fn to_json_dict(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::PyObject> {
-                            self.0.to_json_dict(py)
-                        }
-                    }
-
-                    impl #crate_name::from_json_dict::FromJsonDict for #ident {
-                        fn from_json_dict(o: &pyo3::PyAny) -> pyo3::PyResult<Self> {
-                            Ok(Self(#(<#ftypes as #crate_name::from_json_dict::FromJsonDict>::from_json_dict(o)?)*))
-                        }
-                    }
-                });
-            }
-        }
+        syn::Fields::Unnamed(FieldsUnnamed { .. }) => {}
         syn::Fields::Unit => {
             panic!("PyStreamable does not support the unit type");
         }
     }
+
+    py_protocol.extend(quote! {
+        #[pyo3::pymethods]
+        impl #ident {
+            #[staticmethod]
+            pub fn from_json_dict(o: &pyo3::PyAny) -> pyo3::PyResult<Self> {
+                <Self as #crate_name::from_json_dict::FromJsonDict>::from_json_dict(o)
+            }
+
+            pub fn to_json_dict(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::PyObject> {
+                #crate_name::to_json_dict::ToJsonDict::to_json_dict(self, py)
+            }
+        }
+    });
 
     let streamable = quote! {
         #[pyo3::pymethods]
@@ -239,5 +166,81 @@ pub fn py_streamable_macro(input: proc_macro::TokenStream) -> proc_macro::TokenS
         }
     };
     py_protocol.extend(streamable);
+    py_protocol.into()
+}
+
+#[proc_macro_derive(PyJsonDict)]
+pub fn py_json_dict_macro(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let found_crate = crate_name("chia-traits").expect("chia-traits is present in `Cargo.toml`");
+
+    let crate_name = match found_crate {
+        FoundCrate::Itself => quote!(crate),
+        FoundCrate::Name(name) => {
+            let ident = Ident::new(&name, Span::call_site());
+            quote!(#ident)
+        }
+    };
+
+    let DeriveInput { ident, data, .. } = parse_macro_input!(input);
+
+    let fields = match data {
+        syn::Data::Struct(s) => s.fields,
+        syn::Data::Enum(_) => {
+            return quote! {
+                impl #crate_name::to_json_dict::ToJsonDict for #ident {
+                    fn to_json_dict(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::PyObject> {
+                        <u8 as #crate_name::to_json_dict::ToJsonDict>::to_json_dict(&(*self as u8), py)
+                    }
+                }
+
+                impl #crate_name::from_json_dict::FromJsonDict for #ident {
+                    fn from_json_dict(o: &pyo3::PyAny) -> pyo3::PyResult<Self> {
+                        let v = <u8 as #crate_name::from_json_dict::FromJsonDict>::from_json_dict(o)?;
+                        <Self as #crate_name::Streamable>::parse(&mut std::io::Cursor::<&[u8]>::new(&[v])).map_err(|e| e.into())
+                    }
+                }
+            }
+            .into();
+        }
+        _ => {
+            panic!("PyJsonDict only support struct");
+        }
+    };
+
+    let mut py_protocol = quote! {};
+
+    match fields {
+        syn::Fields::Named(FieldsNamed { named, .. }) => {
+            let mut fnames = Vec::<syn::Ident>::new();
+            let mut ftypes = Vec::<syn::Type>::new();
+            for f in named.iter() {
+                fnames.push(f.ident.as_ref().unwrap().clone());
+                ftypes.push(f.ty.clone());
+            }
+
+            py_protocol.extend( quote! {
+
+                impl #crate_name::to_json_dict::ToJsonDict for #ident {
+                    fn to_json_dict(&self, py: pyo3::Python) -> pyo3::PyResult<pyo3::PyObject> {
+                        let ret = pyo3::types::PyDict::new(py);
+                        #(ret.set_item(stringify!(#fnames), self.#fnames.to_json_dict(py)?)?);*;
+                        Ok(ret.into())
+                    }
+                }
+
+                impl #crate_name::from_json_dict::FromJsonDict for #ident {
+                    fn from_json_dict(o: &pyo3::PyAny) -> pyo3::PyResult<Self> {
+                        Ok(Self{
+                            #(#fnames: <#ftypes as #crate_name::from_json_dict::FromJsonDict>::from_json_dict(o.get_item(stringify!(#fnames))?)?,)*
+                        })
+                    }
+                }
+            });
+        }
+        _ => {
+            panic!("PyJsonDict only supports structs");
+        }
+    }
+
     py_protocol.into()
 }

--- a/tests/test_streamable.py
+++ b/tests/test_streamable.py
@@ -356,7 +356,7 @@ def test_coin_get_hash() -> None:
 
 def test_g1_element() -> None:
 
-    a = G1Element(b"abcdefghijklmnopqrstuvwxabcdefghijklmnopqrstuvwx")
+    a = G1Element.from_bytes(b"abcdefghijklmnopqrstuvwxabcdefghijklmnopqrstuvwx")
     b = bytes(a)
     assert b == b"abcdefghijklmnopqrstuvwxabcdefghijklmnopqrstuvwx"
     c = G1Element.from_bytes(b)
@@ -369,7 +369,7 @@ def test_g1_element() -> None:
 
 def test_g2_element() -> None:
 
-    a = G2Element(b"abcdefghijklmnopqrstuvwxabcdefghijklmnopqrstuvwxabcdefghijklmnopqrstuvwxabcdefghijklmnopqrstuvwx")
+    a = G2Element.from_bytes(b"abcdefghijklmnopqrstuvwxabcdefghijklmnopqrstuvwxabcdefghijklmnopqrstuvwxabcdefghijklmnopqrstuvwx")
     b = bytes(a)
     assert b == b"abcdefghijklmnopqrstuvwxabcdefghijklmnopqrstuvwxabcdefghijklmnopqrstuvwxabcdefghijklmnopqrstuvwx"
     c = G2Element.from_bytes(b)

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -12,14 +12,14 @@ use pyo3::buffer::PyBuffer;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 
-use chia_py_streamable_macro::PyStreamable;
+use chia_py_streamable_macro::{PyJsonDict, PyStreamable};
 use chia_streamable_macro::Streamable;
 
 #[cfg(feature = "py-bindings")]
 use chia_traits::{FromJsonDict, ToJsonDict};
 
 #[pyclass(name = "Spend", get_all, frozen)]
-#[derive(Streamable, PyStreamable, Hash, Debug, Clone, Eq, PartialEq)]
+#[derive(Streamable, PyJsonDict, PyStreamable, Hash, Debug, Clone, Eq, PartialEq)]
 pub struct PySpend {
     pub coin_id: Bytes32,
     pub parent_id: Bytes32,
@@ -43,7 +43,7 @@ pub struct PySpend {
 }
 
 #[pyclass(name = "SpendBundleConditions", get_all, frozen)]
-#[derive(Streamable, PyStreamable, Hash, Debug, Clone, Eq, PartialEq)]
+#[derive(Streamable, PyJsonDict, PyStreamable, Hash, Debug, Clone, Eq, PartialEq)]
 pub struct PySpendBundleConditions {
     pub spends: Vec<PySpend>,
     pub reserve_fee: u64,


### PR DESCRIPTION
This lets types use a custom ToJsonDict and FromJsonDict implementation, but still use the PyStreamable macro.

The PyStreamable macro also used to support 1-tuples and treat them as the underlying type. This special case was also removed in this patch, as it was just there to simplify place-holder types.