### PR TITLE
disable backref encoding for get_puzzle_and_solution_for_coin

### DIFF
--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia_rs"
-version = "0.2.9"
+version = "0.2.10"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -57,7 +57,7 @@ use clvmr::reduction::EvalErr;
 use clvmr::reduction::Reduction;
 use clvmr::run_program;
 use clvmr::serde::node_to_bytes;
-use clvmr::serde::{node_from_bytes, node_from_bytes_backrefs, node_to_bytes_backrefs};
+use clvmr::serde::{node_from_bytes, node_from_bytes_backrefs};
 use clvmr::ChiaDialect;
 
 #[pyfunction]
@@ -125,11 +125,15 @@ pub fn get_puzzle_and_solution_for_coin<'py>(
         }
     });
 
-    let serialize = if (flags & ALLOW_BACKREFS) != 0 {
-        node_to_bytes_backrefs
-    } else {
-        node_to_bytes
-    };
+    // keep serializing normally, until wallets support backrefs
+    let serialize = node_to_bytes;
+    /*
+        let serialize = if (flags & ALLOW_BACKREFS) != 0 {
+            node_to_bytes_backrefs
+        } else {
+            node_to_bytes
+        };
+    */
     match r {
         Err(eval_err) => eval_err_to_pyresult(py, eval_err, allocator),
         Ok((puzzle, solution)) => Ok((


### PR DESCRIPTION
for backwards compatibility.

The target branch `release-0.2.10` is cut from the `0.2.9` release tag.