### PR TITLE
Add clvm-traits and clvm-derive crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -311,7 +311,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -384,7 +384,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -392,6 +392,27 @@ name = "clap_lex"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
+name = "clvm-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "clvm-traits"
+version = "0.1.0"
+dependencies = [
+ "clvm-derive",
+ "clvmr",
+ "hex",
+ "num-bigint",
+ "thiserror",
+]
 
 [[package]]
 name = "clvm-utils"
@@ -761,7 +782,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1631,7 +1652,7 @@ checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1774,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1817,22 +1838,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1987,7 +2008,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -2021,7 +2042,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2210,7 +2231,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,6 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 name = "clvm-derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # the "wheel" crate is excluded from the workspace because pyo3 has problems with
 # "cargo test" and "cargo bench"
 [workspace]
-members = ["wasm", "chia_streamable_macro", "chia-bls", "clvm-utils", "chia-protocol", "chia_py_streamable_macro", "chia-tools", "fuzz", "clvm-utils/fuzz", "chia-traits"]
+members = ["wasm", "chia_streamable_macro", "chia-bls", "clvm-utils", "chia-protocol", "chia_py_streamable_macro", "chia-tools", "fuzz", "clvm-utils/fuzz", "chia-traits", "clvm-traits", "clvm-derive"]
 exclude = ["wheel"]
 
 [package]

--- a/clvm-derive/Cargo.toml
+++ b/clvm-derive/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "clvm-derive"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Derive macros for implementing CLVM traits."
+authors = ["Brandon Haggstrom <b.haggstrom@chia.net>"]
+homepage = "https://github.com/Chia-Network/chia_rs/clvm-derive/"
+repository = "https://github.com/Chia-Network/chia_rs/clvm-derive/"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro-crate = "1.3.1"
+proc-macro2 = "1.0.66"
+quote = "1.0.32"
+syn = "2.0.28"

--- a/clvm-derive/Cargo.toml
+++ b/clvm-derive/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/Chia-Network/chia_rs/clvm-derive/"
 proc-macro = true
 
 [dependencies]
-proc-macro-crate = "1.3.1"
 proc-macro2 = "1.0.66"
 quote = "1.0.32"
 syn = "2.0.28"

--- a/clvm-derive/src/from_clvm.rs
+++ b/clvm-derive/src/from_clvm.rs
@@ -1,0 +1,51 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_quote, Data, DataStruct, DeriveInput, Fields};
+
+use crate::helpers::{add_trait_bounds, crate_ident, parse_args, Repr};
+
+pub fn from_clvm(mut ast: DeriveInput) -> TokenStream {
+    let args = parse_args(&ast.attrs);
+    let crate_name = crate_ident();
+
+    let fields = match &ast.data {
+        Data::Struct(DataStruct {
+            fields: Fields::Named(fields),
+            ..
+        }) => &fields.named,
+        _ => panic!("expected a struct with named fields"),
+    };
+
+    let struct_name = &ast.ident;
+    let field_type = fields.iter().map(|field| &field.ty);
+    let field_names = fields.iter().map(|field| &field.ident);
+    let destructure_names = field_names.clone();
+
+    let (match_macro, destructure_macro) = match args.repr {
+        Repr::ProperList => (
+            quote!( #crate_name::match_list ),
+            quote!( #crate_name::destructure_list ),
+        ),
+        Repr::Tuple => (
+            quote!( #crate_name::match_tuple ),
+            quote!( #crate_name::destructure_tuple ),
+        ),
+        Repr::CurriedArgs => (
+            quote!( #crate_name::match_curried_args ),
+            quote!( #crate_name::destructure_curried_args ),
+        ),
+    };
+
+    add_trait_bounds(&mut ast.generics, parse_quote!(#crate_name::FromClvm));
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    quote! {
+        #[automatically_derived]
+        impl #impl_generics #crate_name::FromClvm for #struct_name #ty_generics #where_clause {
+            fn from_clvm(a: &clvmr::Allocator, node: clvmr::allocator::NodePtr) -> #crate_name::Result<Self> {
+                let #destructure_macro!( #( #destructure_names, )* ) = <#match_macro!( #( #field_type ),* ) as #crate_name::FromClvm>::from_clvm(a, node)?;
+                Ok(Self { #( #field_names, )* })
+            }
+        }
+    }
+}

--- a/clvm-derive/src/from_clvm.rs
+++ b/clvm-derive/src/from_clvm.rs
@@ -2,11 +2,11 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{parse_quote, Data, DataStruct, DeriveInput, Fields};
 
-use crate::helpers::{add_trait_bounds, crate_ident, parse_args, Repr};
+use crate::helpers::{add_trait_bounds, parse_args, Repr};
 
 pub fn from_clvm(mut ast: DeriveInput) -> TokenStream {
     let args = parse_args(&ast.attrs);
-    let crate_name = crate_ident();
+    let crate_name = quote!(clvm_traits);
 
     let fields = match &ast.data {
         Data::Struct(DataStruct {

--- a/clvm-derive/src/from_clvm.rs
+++ b/clvm-derive/src/from_clvm.rs
@@ -21,6 +21,8 @@ pub fn from_clvm(mut ast: DeriveInput) -> TokenStream {
     let field_names = fields.iter().map(|field| &field.ident);
     let destructure_names = field_names.clone();
 
+    // `match_macro` decodes a nested tuple containing each of the struct field types within.
+    // `destructure_macro` destructures the values into the field names, to be stored in the struct.
     let (match_macro, destructure_macro) = match args.repr {
         Repr::ProperList => (
             quote!( #crate_name::match_list ),

--- a/clvm-derive/src/helpers.rs
+++ b/clvm-derive/src/helpers.rs
@@ -1,6 +1,4 @@
-use proc_macro2::{Ident, Span, TokenStream};
-use proc_macro_crate::{crate_name, FoundCrate};
-use quote::quote;
+use proc_macro2::Ident;
 use syn::{punctuated::Punctuated, Attribute, GenericParam, Generics, Token, TypeParamBound};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -65,18 +63,6 @@ pub fn parse_args(attrs: &[Attribute]) -> ClvmDeriveArgs {
         repr: repr.expect(
             "expected clvm attribute parameter of either `tuple`, `proper_list`, or `curried_args`",
         ),
-    }
-}
-
-pub fn crate_ident() -> TokenStream {
-    let found_crate = crate_name("clvm-traits").expect("`clvm-traits` not found in `Cargo.toml`");
-
-    match found_crate {
-        FoundCrate::Itself => quote!(crate),
-        FoundCrate::Name(name) => {
-            let ident = Ident::new(&name, Span::call_site());
-            quote!(#ident)
-        }
     }
 }
 

--- a/clvm-derive/src/helpers.rs
+++ b/clvm-derive/src/helpers.rs
@@ -1,0 +1,89 @@
+use proc_macro2::{Ident, Span, TokenStream};
+use proc_macro_crate::{crate_name, FoundCrate};
+use quote::quote;
+use syn::{punctuated::Punctuated, Attribute, GenericParam, Generics, Token, TypeParamBound};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Repr {
+    Tuple,
+    ProperList,
+    CurriedArgs,
+}
+
+impl ToString for Repr {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Tuple => "tuple".to_string(),
+            Self::ProperList => "proper_list".to_string(),
+            Self::CurriedArgs => "curried_list".to_string(),
+        }
+    }
+}
+
+pub struct ClvmDeriveArgs {
+    pub repr: Repr,
+}
+
+pub fn parse_args(attrs: &[Attribute]) -> ClvmDeriveArgs {
+    let mut repr: Option<Repr> = None;
+
+    for attr in attrs {
+        if let Some(ident) = attr.path().get_ident() {
+            if ident == "clvm" {
+                let args = attr
+                    .parse_args_with(Punctuated::<Ident, Token![,]>::parse_terminated)
+                    .unwrap();
+
+                for arg in args {
+                    match arg.to_string().as_str() {
+                        "tuple" => {
+                            if let Some(existing) = repr {
+                                panic!("`tuple` conflicts with `{}`", existing.to_string());
+                            }
+                            repr = Some(Repr::Tuple);
+                        }
+                        "proper_list" => {
+                            if let Some(existing) = repr {
+                                panic!("`proper_list` conflicts with `{}`", existing.to_string());
+                            }
+                            repr = Some(Repr::ProperList);
+                        }
+                        "curried_args" => {
+                            if let Some(existing) = repr {
+                                panic!("`curried_args` conflicts with `{}`", existing.to_string());
+                            }
+                            repr = Some(Repr::CurriedArgs);
+                        }
+                        ident => panic!("unknown argument `{}`", ident),
+                    }
+                }
+            }
+        }
+    }
+
+    ClvmDeriveArgs {
+        repr: repr.expect(
+            "expected clvm attribute parameter of either `tuple`, `proper_list`, or `curried_args`",
+        ),
+    }
+}
+
+pub fn crate_ident() -> TokenStream {
+    let found_crate = crate_name("clvm-traits").expect("`clvm-traits` not found in `Cargo.toml`");
+
+    match found_crate {
+        FoundCrate::Itself => quote!(crate),
+        FoundCrate::Name(name) => {
+            let ident = Ident::new(&name, Span::call_site());
+            quote!(#ident)
+        }
+    }
+}
+
+pub fn add_trait_bounds(generics: &mut Generics, bound: TypeParamBound) {
+    for param in &mut generics.params {
+        if let GenericParam::Type(ref mut type_param) = *param {
+            type_param.bounds.push(bound.clone());
+        }
+    }
+}

--- a/clvm-derive/src/helpers.rs
+++ b/clvm-derive/src/helpers.rs
@@ -15,7 +15,7 @@ impl ToString for Repr {
         match self {
             Self::Tuple => "tuple".to_string(),
             Self::ProperList => "proper_list".to_string(),
-            Self::CurriedArgs => "curried_list".to_string(),
+            Self::CurriedArgs => "curried_args".to_string(),
         }
     }
 }

--- a/clvm-derive/src/lib.rs
+++ b/clvm-derive/src/lib.rs
@@ -1,0 +1,21 @@
+extern crate proc_macro;
+
+mod from_clvm;
+mod helpers;
+mod to_clvm;
+
+use from_clvm::from_clvm;
+use syn::{parse_macro_input, DeriveInput};
+use to_clvm::to_clvm;
+
+#[proc_macro_derive(ToClvm, attributes(clvm))]
+pub fn to_clvm_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    to_clvm(ast).into()
+}
+
+#[proc_macro_derive(FromClvm, attributes(clvm))]
+pub fn from_clvm_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    from_clvm(ast).into()
+}

--- a/clvm-derive/src/to_clvm.rs
+++ b/clvm-derive/src/to_clvm.rs
@@ -19,6 +19,7 @@ pub fn to_clvm(mut ast: DeriveInput) -> TokenStream {
     let struct_name = &ast.ident;
     let field_name = fields.iter().map(|field| &field.ident);
 
+    // `list_macro` encodes a nested tuple containing each of the struct field values within.
     let list_macro = match args.repr {
         Repr::ProperList => quote!( #crate_name::clvm_list ),
         Repr::Tuple => quote!( #crate_name::clvm_tuple ),

--- a/clvm-derive/src/to_clvm.rs
+++ b/clvm-derive/src/to_clvm.rs
@@ -2,11 +2,11 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{parse_quote, Data, DataStruct, DeriveInput, Fields};
 
-use crate::helpers::{add_trait_bounds, crate_ident, parse_args, Repr};
+use crate::helpers::{add_trait_bounds, parse_args, Repr};
 
 pub fn to_clvm(mut ast: DeriveInput) -> TokenStream {
     let args = parse_args(&ast.attrs);
-    let crate_name = crate_ident();
+    let crate_name = quote!(clvm_traits);
 
     let fields = match &ast.data {
         Data::Struct(DataStruct {

--- a/clvm-derive/src/to_clvm.rs
+++ b/clvm-derive/src/to_clvm.rs
@@ -1,0 +1,40 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_quote, Data, DataStruct, DeriveInput, Fields};
+
+use crate::helpers::{add_trait_bounds, crate_ident, parse_args, Repr};
+
+pub fn to_clvm(mut ast: DeriveInput) -> TokenStream {
+    let args = parse_args(&ast.attrs);
+    let crate_name = crate_ident();
+
+    let fields = match &ast.data {
+        Data::Struct(DataStruct {
+            fields: Fields::Named(fields),
+            ..
+        }) => &fields.named,
+        _ => panic!("expected a struct with named fields"),
+    };
+
+    let struct_name = &ast.ident;
+    let field_name = fields.iter().map(|field| &field.ident);
+
+    let list_macro = match args.repr {
+        Repr::ProperList => quote!( #crate_name::clvm_list ),
+        Repr::Tuple => quote!( #crate_name::clvm_tuple ),
+        Repr::CurriedArgs => quote!( #crate_name::clvm_curried_args ),
+    };
+
+    add_trait_bounds(&mut ast.generics, parse_quote!(#crate_name::ToClvm));
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    quote! {
+        #[automatically_derived]
+        impl #impl_generics #crate_name::ToClvm for #struct_name #ty_generics #where_clause {
+            fn to_clvm(&self, a: &mut clvmr::Allocator) -> #crate_name::Result<clvmr::allocator::NodePtr> {
+                let value = #list_macro!( #( &self.#field_name ),* );
+                #crate_name::ToClvm::to_clvm(&value, a)
+            }
+        }
+    }
+}

--- a/clvm-traits/Cargo.toml
+++ b/clvm-traits/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "clvm-traits"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Traits for encoding and decoding CLVM objects."
+authors = ["Brandon Haggstrom <b.haggstrom@chia.net>"]
+homepage = "https://github.com/Chia-Network/chia_rs/clvm-traits/"
+repository = "https://github.com/Chia-Network/chia_rs/clvm-traits/"
+
+[features]
+derive = ["dep:clvm-derive"]
+
+[dependencies]
+clvm-derive = { version = "0.1.0", path = "../clvm-derive", optional = true }
+clvmr = "0.2.7"
+num-bigint = "0.4.3"
+thiserror = "1.0.44"
+
+[dev-dependencies]
+hex = "0.4.3"

--- a/clvm-traits/Cargo.toml
+++ b/clvm-traits/Cargo.toml
@@ -8,6 +8,9 @@ authors = ["Brandon Haggstrom <b.haggstrom@chia.net>"]
 homepage = "https://github.com/Chia-Network/chia_rs/clvm-traits/"
 repository = "https://github.com/Chia-Network/chia_rs/clvm-traits/"
 
+[package.metadata.docs.rs]
+features = ["derive"]
+
 [features]
 derive = ["dep:clvm-derive"]
 

--- a/clvm-traits/src/error.rs
+++ b/clvm-traits/src/error.rs
@@ -1,0 +1,31 @@
+use clvmr::{allocator::NodePtr, reduction::EvalErr};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum Error {
+    #[error("allocator error {0:?}")]
+    Allocator(EvalErr),
+
+    #[error("expected atom")]
+    ExpectedAtom(NodePtr),
+
+    #[error("expected cons")]
+    ExpectedCons(NodePtr),
+
+    #[error("expected nil")]
+    ExpectedNil(NodePtr),
+
+    #[error("validation failed")]
+    Validation(NodePtr),
+
+    #[error("{0}")]
+    Custom(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl From<EvalErr> for Error {
+    fn from(value: EvalErr) -> Self {
+        Self::Allocator(value)
+    }
+}

--- a/clvm-traits/src/from_clvm.rs
+++ b/clvm-traits/src/from_clvm.rs
@@ -1,0 +1,242 @@
+use std::array::TryFromSliceError;
+
+use clvmr::{
+    allocator::{NodePtr, SExp},
+    op_utils::nullp,
+    Allocator,
+};
+use num_bigint::Sign;
+
+use crate::{Error, Result};
+
+pub trait FromClvm {
+    fn from_clvm(a: &Allocator, ptr: NodePtr) -> Result<Self>
+    where
+        Self: Sized;
+}
+
+macro_rules! clvm_primitive {
+    ($primitive:ty) => {
+        impl FromClvm for $primitive {
+            fn from_clvm(a: &Allocator, ptr: NodePtr) -> Result<Self> {
+                if let SExp::Atom() = a.sexp(ptr) {
+                    let (sign, mut vec) = a.number(ptr).to_bytes_be();
+                    if vec.len() < std::mem::size_of::<$primitive>() {
+                        let mut zeros = vec![0; std::mem::size_of::<$primitive>() - vec.len()];
+                        zeros.extend(vec);
+                        vec = zeros;
+                    }
+                    let value =
+                        <$primitive>::from_be_bytes(vec.as_slice().try_into().map_err(
+                            |error: TryFromSliceError| Error::Custom(error.to_string()),
+                        )?);
+                    Ok(if sign == Sign::Minus {
+                        value.wrapping_neg()
+                    } else {
+                        value
+                    })
+                } else {
+                    Err(Error::ExpectedAtom(ptr))
+                }
+            }
+        }
+    };
+}
+
+clvm_primitive!(u8);
+clvm_primitive!(i8);
+clvm_primitive!(u16);
+clvm_primitive!(i16);
+clvm_primitive!(u32);
+clvm_primitive!(i32);
+clvm_primitive!(u64);
+clvm_primitive!(i64);
+clvm_primitive!(u128);
+clvm_primitive!(i128);
+clvm_primitive!(usize);
+clvm_primitive!(isize);
+
+impl<A, B> FromClvm for (A, B)
+where
+    A: FromClvm,
+    B: FromClvm,
+{
+    fn from_clvm(a: &Allocator, ptr: NodePtr) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        match a.sexp(ptr) {
+            SExp::Pair(first, rest) => Ok((A::from_clvm(a, first)?, B::from_clvm(a, rest)?)),
+            SExp::Atom() => Err(Error::ExpectedCons(ptr)),
+        }
+    }
+}
+
+impl FromClvm for () {
+    fn from_clvm(a: &Allocator, ptr: NodePtr) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        if nullp(a, ptr) {
+            Ok(())
+        } else {
+            Err(Error::ExpectedNil(ptr))
+        }
+    }
+}
+
+impl<T, const N: usize> FromClvm for [T; N]
+where
+    T: FromClvm,
+{
+    fn from_clvm(a: &Allocator, mut ptr: NodePtr) -> Result<Self> {
+        let mut items = Vec::with_capacity(N);
+        loop {
+            match a.sexp(ptr) {
+                SExp::Atom() => {
+                    if nullp(a, ptr) {
+                        return match items.try_into() {
+                            Ok(value) => Ok(value),
+                            Err(_) => Err(Error::ExpectedCons(ptr)),
+                        };
+                    } else {
+                        return Err(Error::ExpectedNil(ptr));
+                    }
+                }
+                SExp::Pair(first, rest) => {
+                    if items.len() >= N {
+                        return Err(Error::ExpectedAtom(ptr));
+                    } else {
+                        items.push(T::from_clvm(a, first)?);
+                        ptr = rest;
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<T> FromClvm for Vec<T>
+where
+    T: FromClvm,
+{
+    fn from_clvm(a: &Allocator, mut ptr: NodePtr) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let mut items = Vec::new();
+        loop {
+            match a.sexp(ptr) {
+                SExp::Atom() => {
+                    if nullp(a, ptr) {
+                        return Ok(items);
+                    } else {
+                        return Err(Error::ExpectedNil(ptr));
+                    }
+                }
+                SExp::Pair(first, rest) => {
+                    items.push(T::from_clvm(a, first)?);
+                    ptr = rest;
+                }
+            }
+        }
+    }
+}
+
+impl<T: FromClvm> FromClvm for Option<T> {
+    fn from_clvm(a: &Allocator, ptr: NodePtr) -> Result<Self> {
+        if nullp(a, ptr) {
+            Ok(None)
+        } else {
+            Ok(Some(T::from_clvm(a, ptr)?))
+        }
+    }
+}
+
+impl FromClvm for String {
+    fn from_clvm(a: &Allocator, ptr: NodePtr) -> Result<Self> {
+        if let SExp::Atom() = a.sexp(ptr) {
+            Self::from_utf8(a.atom(ptr).to_vec()).map_err(|error| Error::Custom(error.to_string()))
+        } else {
+            Err(Error::ExpectedAtom(ptr))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clvmr::serde::node_from_bytes;
+
+    use super::*;
+
+    fn decode<T>(a: &mut Allocator, hex: &str) -> Result<T>
+    where
+        T: FromClvm,
+    {
+        let bytes = hex::decode(hex).unwrap();
+        let actual = node_from_bytes(a, &bytes).unwrap();
+        T::from_clvm(a, actual)
+    }
+
+    #[test]
+    fn test_primitives() {
+        let a = &mut Allocator::new();
+        assert_eq!(decode(a, "80"), Ok(0u8));
+        assert_eq!(decode(a, "80"), Ok(0i8));
+        assert_eq!(decode(a, "05"), Ok(5u8));
+        assert_eq!(decode(a, "05"), Ok(5u32));
+        assert_eq!(decode(a, "05"), Ok(5i32));
+        assert_eq!(decode(a, "81e5"), Ok(-27i32));
+        assert_eq!(decode(a, "80"), Ok(-0));
+        assert_eq!(decode(a, "8180"), Ok(-128i8));
+    }
+
+    #[test]
+    fn test_pair() {
+        let a = &mut Allocator::new();
+        assert_eq!(decode(a, "ff0502"), Ok((5, 2)));
+        assert_eq!(decode(a, "ff81b8ff8301600980"), Ok((-72, (90121, ()))));
+        assert_eq!(
+            decode(a, "ffff80ff80ff80ffff80ff80ff80808080"),
+            Ok((((), ((), ((), (((), ((), ((), ()))), ())))), ()))
+        );
+    }
+
+    #[test]
+    fn test_nil() {
+        let a = &mut Allocator::new();
+        assert_eq!(decode(a, "80"), Ok(()));
+    }
+
+    #[test]
+    fn test_array() {
+        let a = &mut Allocator::new();
+        assert_eq!(decode(a, "ff01ff02ff03ff0480"), Ok([1, 2, 3, 4]));
+        assert_eq!(decode(a, "80"), Ok([0; 0]));
+    }
+
+    #[test]
+    fn test_vec() {
+        let a = &mut Allocator::new();
+        assert_eq!(decode(a, "ff01ff02ff03ff0480"), Ok(vec![1, 2, 3, 4]));
+        assert_eq!(decode(a, "80"), Ok(vec![0; 0]));
+    }
+
+    #[test]
+    fn test_option() {
+        let a = &mut Allocator::new();
+        assert_eq!(decode(a, "8568656c6c6f"), Ok(Some("hello".to_string())));
+        assert_eq!(decode(a, "80"), Ok(None::<String>));
+
+        // Empty strings get decoded as None instead, since both values are represented by nil bytes.
+        // This could be considered either intended behavior or not, depending on the way it's used.
+        assert_ne!(decode(a, "80"), Ok(Some("".to_string())));
+    }
+
+    #[test]
+    fn test_string() {
+        let a = &mut Allocator::new();
+        assert_eq!(decode(a, "8568656c6c6f"), Ok("hello".to_string()));
+        assert_eq!(decode(a, "80"), Ok("".to_string()));
+    }
+}

--- a/clvm-traits/src/from_clvm.rs
+++ b/clvm-traits/src/from_clvm.rs
@@ -212,14 +212,14 @@ mod tests {
     fn test_array() {
         let a = &mut Allocator::new();
         assert_eq!(decode(a, "ff01ff02ff03ff0480"), Ok([1, 2, 3, 4]));
-        assert_eq!(decode(a, "80"), Ok([0; 0]));
+        assert_eq!(decode(a, "80"), Ok([] as [i32; 0]));
     }
 
     #[test]
     fn test_vec() {
         let a = &mut Allocator::new();
         assert_eq!(decode(a, "ff01ff02ff03ff0480"), Ok(vec![1, 2, 3, 4]));
-        assert_eq!(decode(a, "80"), Ok(vec![0; 0]));
+        assert_eq!(decode(a, "80"), Ok(Vec::<i32>::new()));
     }
 
     #[test]

--- a/clvm-traits/src/lib.rs
+++ b/clvm-traits/src/lib.rs
@@ -4,8 +4,12 @@
 //! as well as many other values in the standard library that would be common to encode.
 //!
 //! As well as the built-in implementations, this library exposes two derive macros
-//! for implementing the `ToClvm` and `FromClvm` traits on structs. They can be encoded
-//! as either `tuple`, `proper_list`, or `curried_args`, depending on the `clvm` value set.
+//! for implementing the `ToClvm` and `FromClvm` traits on structs. They be marked
+//! with one of the following encodings:
+//!
+//! * `#[clvm(tuple)]` for unterminated lists such as `(A . (B . C))`.
+//! * `#[clvm(proper_list)]` for proper lists such as `(A B C)`, or in other words `(A . (B . (C . ())))`.
+//! * `#[clvm(curried_args)]` for curried arguments such as `(c (q . A) (c (q . B) (c (q . C) 1)))`.
 
 #![cfg_attr(
     feature = "derive",

--- a/clvm-traits/src/lib.rs
+++ b/clvm-traits/src/lib.rs
@@ -1,3 +1,38 @@
+//! # CLVM Traits
+//! This is a library for encoding and decoding Rust values using a CLVM allocator.
+//! It provides implementations for every fixed-width signed and unsigned integer type,
+//! as well as many other values in the standard library that would be common to encode.
+//!
+//! As well as the built-in implementations, this library exposes two derive macros
+//! for implementing the `ToClvm` and `FromClvm` traits on structs. They can be encoded
+//! as either `tuple`, `proper_list`, or `curried_args`, depending on the `clvm` value set.
+
+#![cfg_attr(
+    feature = "derive",
+    doc = r#"
+## Derive Example
+
+```rust
+use clvmr::Allocator;
+use clvm_traits::{ToClvm, FromClvm};
+
+#[derive(Debug, PartialEq, Eq, ToClvm, FromClvm)]
+#[clvm(tuple)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+let a = &mut Allocator::new();
+
+let point = Point { x: 5, y: 2 };
+let ptr = point.to_clvm(a).unwrap();
+
+assert_eq!(Point::from_clvm(a, ptr).unwrap(), point);
+```
+"#
+)]
+
 #[cfg(feature = "derive")]
 pub use clvm_derive::*;
 
@@ -16,6 +51,8 @@ pub use to_clvm::*;
 #[cfg(test)]
 #[cfg(feature = "derive")]
 mod tests {
+    extern crate self as clvm_traits;
+
     use clvmr::Allocator;
 
     use super::*;

--- a/clvm-traits/src/lib.rs
+++ b/clvm-traits/src/lib.rs
@@ -1,0 +1,70 @@
+#[cfg(feature = "derive")]
+pub use clvm_derive::*;
+
+mod error;
+mod from_clvm;
+mod macros;
+mod match_byte;
+mod to_clvm;
+
+pub use error::*;
+pub use from_clvm::*;
+pub use macros::*;
+pub use match_byte::*;
+pub use to_clvm::*;
+
+#[cfg(test)]
+#[cfg(feature = "derive")]
+mod tests {
+    use clvmr::Allocator;
+
+    use super::*;
+
+    #[derive(Debug, ToClvm, FromClvm, PartialEq, Eq)]
+    #[clvm(tuple)]
+    struct TupleStruct {
+        a: u64,
+        b: i32,
+    }
+
+    #[derive(Debug, ToClvm, FromClvm, PartialEq, Eq)]
+    #[clvm(proper_list)]
+    struct ProperListStruct {
+        a: u64,
+        b: i32,
+    }
+
+    #[derive(Debug, ToClvm, FromClvm, PartialEq, Eq)]
+    #[clvm(curried_args)]
+    struct CurriedArgsStruct {
+        a: u64,
+        b: i32,
+    }
+
+    #[test]
+    fn test_round_trip_tuple() {
+        let mut a = Allocator::new();
+        let value = TupleStruct { a: 52, b: -32 };
+        let node = value.to_clvm(&mut a).unwrap();
+        let round_trip = TupleStruct::from_clvm(&a, node).unwrap();
+        assert_eq!(value, round_trip);
+    }
+
+    #[test]
+    fn test_round_trip_proper_list() {
+        let mut a = Allocator::new();
+        let value = ProperListStruct { a: 52, b: -32 };
+        let node = value.to_clvm(&mut a).unwrap();
+        let round_trip = ProperListStruct::from_clvm(&a, node).unwrap();
+        assert_eq!(value, round_trip);
+    }
+
+    #[test]
+    fn test_round_trip_curried_args() {
+        let mut a = Allocator::new();
+        let value = CurriedArgsStruct { a: 52, b: -32 };
+        let node = value.to_clvm(&mut a).unwrap();
+        let round_trip = CurriedArgsStruct::from_clvm(&a, node).unwrap();
+        assert_eq!(value, round_trip);
+    }
+}

--- a/clvm-traits/src/macros.rs
+++ b/clvm-traits/src/macros.rs
@@ -1,0 +1,122 @@
+#[macro_export]
+macro_rules! clvm_list {
+    () => {
+        ()
+    };
+    ( $first:expr $( , $rest:expr )* $(,)? ) => {
+        ($first, $crate::clvm_list!( $( $rest ),* ))
+    };
+}
+
+#[macro_export]
+macro_rules! clvm_tuple {
+    ( $first:expr $(,)? ) => {
+        $first
+    };
+    ( $first:expr $( , $rest:expr )* $(,)? ) => {
+        ($first, $crate::clvm_tuple!( $( $rest ),* ))
+    };
+}
+
+#[macro_export]
+macro_rules! clvm_quote {
+    ( $value:expr ) => {
+        ($crate::MatchByte::<1>, $value)
+    };
+}
+
+#[macro_export]
+macro_rules! clvm_curried_args {
+    () => {
+        $crate::MatchByte::<1>
+    };
+    ( $first:expr $( , $rest:expr )* $(,)? ) => {
+        ($crate::MatchByte::<4>, ($crate::clvm_quote!($first), ($crate::clvm_curried_args!( $( $rest ),* ), ())))
+    };
+}
+
+#[macro_export]
+macro_rules! match_list {
+    () => {
+        $crate::MatchByte::<0>
+    };
+    ( $first:ty $( , $rest:ty )* $(,)? ) => {
+        ($first, $crate::match_list!( $( $rest ),* ))
+    };
+}
+
+#[macro_export]
+macro_rules! match_tuple {
+    ( $first:ty $(,)? ) => {
+        $first
+    };
+    ( $first:ty $( , $rest:ty )* $(,)? ) => {
+        ($first, $crate::match_tuple!( $( $rest ),* ))
+    };
+}
+
+#[macro_export]
+macro_rules! match_quote {
+    ( $type:ty ) => {
+        ($crate::MatchByte::<1>, $type)
+    };
+}
+
+#[macro_export]
+macro_rules! match_curried_args {
+    () => {
+        $crate::MatchByte::<1>
+    };
+    ( $first:ty $( , $rest:ty )* $(,)? ) => {
+        (
+            $crate::MatchByte::<4>,
+            (
+                $crate::match_quote!($first),
+                ($crate::match_curried_args!( $( $rest ),* ), ()),
+            ),
+        )
+    };
+}
+
+#[macro_export]
+macro_rules! destructure_list {
+    () => {
+        $crate::MatchByte::<0>
+    };
+    ( $first:ident $( , $rest:ident )* $(,)? ) => {
+        ($first, $crate::destructure_list!( $( $rest ),* ))
+    };
+}
+
+#[macro_export]
+macro_rules! destructure_tuple {
+    ( $first:ident $(,)? ) => {
+        $first
+    };
+    ( $first:ident $( , $rest:ident )* $(,)? ) => {
+        ($first, $crate::destructure_tuple!( $( $rest ),* ))
+    };
+}
+
+#[macro_export]
+macro_rules! destructure_quote {
+    ( $name:ident ) => {
+        ($crate::MatchByte::<1>, $name)
+    };
+}
+
+#[macro_export]
+macro_rules! destructure_curried_args {
+    () => {
+        $crate::MatchByte::<1>
+    };
+    ( $first:ident $( , $rest:ident )* $(,)? ) => {
+        (
+            $crate::MatchByte::<4>,
+            (
+                $crate::destructure_quote!($first),
+                ($crate::destructure_curried_args!( $( $rest ),* ), ()),
+            ),
+        )
+    };
+}

--- a/clvm-traits/src/macros.rs
+++ b/clvm-traits/src/macros.rs
@@ -21,24 +21,24 @@ macro_rules! clvm_tuple {
 #[macro_export]
 macro_rules! clvm_quote {
     ( $value:expr ) => {
-        ($crate::MatchByte::<1>, $value)
+        (1, $value)
     };
 }
 
 #[macro_export]
 macro_rules! clvm_curried_args {
     () => {
-        $crate::MatchByte::<1>
+        1
     };
     ( $first:expr $( , $rest:expr )* $(,)? ) => {
-        ($crate::MatchByte::<4>, ($crate::clvm_quote!($first), ($crate::clvm_curried_args!( $( $rest ),* ), ())))
+        (4, ($crate::clvm_quote!($first), ($crate::clvm_curried_args!( $( $rest ),* ), ())))
     };
 }
 
 #[macro_export]
 macro_rules! match_list {
     () => {
-        $crate::MatchByte::<0>
+        ()
     };
     ( $first:ty $( , $rest:ty )* $(,)? ) => {
         ($first, $crate::match_list!( $( $rest ),* ))
@@ -81,7 +81,7 @@ macro_rules! match_curried_args {
 #[macro_export]
 macro_rules! destructure_list {
     () => {
-        $crate::MatchByte::<0>
+        _
     };
     ( $first:ident $( , $rest:ident )* $(,)? ) => {
         ($first, $crate::destructure_list!( $( $rest ),* ))
@@ -101,18 +101,18 @@ macro_rules! destructure_tuple {
 #[macro_export]
 macro_rules! destructure_quote {
     ( $name:ident ) => {
-        ($crate::MatchByte::<1>, $name)
+        (_, $name)
     };
 }
 
 #[macro_export]
 macro_rules! destructure_curried_args {
     () => {
-        $crate::MatchByte::<1>
+        _
     };
     ( $first:ident $( , $rest:ident )* $(,)? ) => {
         (
-            $crate::MatchByte::<4>,
+            _,
             (
                 $crate::destructure_quote!($first),
                 ($crate::destructure_curried_args!( $( $rest ),* ), ()),

--- a/clvm-traits/src/match_byte.rs
+++ b/clvm-traits/src/match_byte.rs
@@ -10,7 +10,11 @@ pub struct MatchByte<const BYTE: u8>;
 
 impl<const BYTE: u8> ToClvm for MatchByte<BYTE> {
     fn to_clvm(&self, a: &mut Allocator) -> Result<NodePtr> {
-        a.new_number(BYTE.into()).map_err(Error::Allocator)
+        match BYTE {
+            0 => Ok(a.null()),
+            1 => Ok(a.one()),
+            _ => Ok(a.new_number(BYTE.into())?),
+        }
     }
 }
 

--- a/clvm-traits/src/match_byte.rs
+++ b/clvm-traits/src/match_byte.rs
@@ -19,7 +19,7 @@ impl<const BYTE: u8> FromClvm for MatchByte<BYTE> {
         if let SExp::Atom() = a.sexp(node) {
             match a.atom(node) {
                 [] if BYTE == 0 => Ok(Self),
-                [byte] if *byte == BYTE => Ok(Self),
+                [byte] if *byte == BYTE && BYTE > 0 => Ok(Self),
                 _ => Err(Error::Custom(format!(
                     "expected an atom with a value of {}",
                     BYTE

--- a/clvm-traits/src/match_byte.rs
+++ b/clvm-traits/src/match_byte.rs
@@ -1,0 +1,45 @@
+use clvmr::{
+    allocator::{NodePtr, SExp},
+    Allocator,
+};
+use num_bigint::{BigInt, Sign};
+
+use crate::{Error, FromClvm, Result, ToClvm};
+
+#[derive(Debug, Copy, Clone)]
+pub struct MatchByte<const BYTE: u8>;
+
+impl<const BYTE: u8> ToClvm for MatchByte<BYTE> {
+    fn to_clvm(&self, a: &mut Allocator) -> Result<NodePtr> {
+        a.new_number(BYTE.into()).map_err(Error::Allocator)
+    }
+}
+
+impl<const BYTE: u8> FromClvm for MatchByte<BYTE> {
+    fn from_clvm(a: &Allocator, node: NodePtr) -> Result<Self> {
+        if let SExp::Atom() = a.sexp(node) {
+            let value: u8 = to_unsigned(a.number(node)).try_into().map_err(
+                |error: <u8 as TryFrom<BigInt>>::Error| Error::Custom(error.to_string()),
+            )?;
+
+            if value == BYTE {
+                Ok(Self)
+            } else {
+                Err(Error::Custom(format!(
+                    "expected an atom with a value of {}",
+                    BYTE
+                )))
+            }
+        } else {
+            Err(Error::ExpectedAtom(node))
+        }
+    }
+}
+
+fn to_unsigned(value: BigInt) -> BigInt {
+    if value.sign() == Sign::Minus {
+        value + 256
+    } else {
+        value
+    }
+}

--- a/clvm-traits/src/to_clvm.rs
+++ b/clvm-traits/src/to_clvm.rs
@@ -1,0 +1,224 @@
+use clvmr::{allocator::NodePtr, Allocator};
+
+use crate::{Error, Result};
+
+pub trait ToClvm {
+    fn to_clvm(&self, a: &mut Allocator) -> Result<NodePtr>;
+}
+
+macro_rules! clvm_primitive {
+    ($primitive:ty) => {
+        impl ToClvm for $primitive {
+            fn to_clvm(&self, a: &mut Allocator) -> Result<NodePtr> {
+                a.new_number((*self).into()).map_err(Error::Allocator)
+            }
+        }
+    };
+}
+
+clvm_primitive!(u8);
+clvm_primitive!(i8);
+clvm_primitive!(u16);
+clvm_primitive!(i16);
+clvm_primitive!(u32);
+clvm_primitive!(i32);
+clvm_primitive!(u64);
+clvm_primitive!(i64);
+clvm_primitive!(u128);
+clvm_primitive!(i128);
+clvm_primitive!(usize);
+clvm_primitive!(isize);
+
+impl<T> ToClvm for &T
+where
+    T: ToClvm,
+{
+    fn to_clvm(&self, a: &mut Allocator) -> Result<NodePtr> {
+        T::to_clvm(*self, a)
+    }
+}
+
+impl<A, B> ToClvm for (A, B)
+where
+    A: ToClvm,
+    B: ToClvm,
+{
+    fn to_clvm(&self, a: &mut Allocator) -> Result<NodePtr> {
+        let first = self.0.to_clvm(a)?;
+        let rest = self.1.to_clvm(a)?;
+        Ok(a.new_pair(first, rest)?)
+    }
+}
+
+impl ToClvm for () {
+    fn to_clvm(&self, a: &mut Allocator) -> Result<NodePtr> {
+        Ok(a.null())
+    }
+}
+
+impl<T> ToClvm for &[T]
+where
+    T: ToClvm,
+{
+    fn to_clvm(&self, a: &mut Allocator) -> Result<NodePtr> {
+        let mut result = a.null();
+        for item in self.iter().rev() {
+            let value = item.to_clvm(a)?;
+            result = a.new_pair(value, result)?;
+        }
+        Ok(result)
+    }
+}
+
+impl<T, const N: usize> ToClvm for [T; N]
+where
+    T: ToClvm,
+{
+    fn to_clvm(&self, a: &mut Allocator) -> Result<NodePtr> {
+        self.as_slice().to_clvm(a)
+    }
+}
+
+impl<T> ToClvm for Vec<T>
+where
+    T: ToClvm,
+{
+    fn to_clvm(&self, a: &mut Allocator) -> Result<NodePtr> {
+        self.as_slice().to_clvm(a)
+    }
+}
+
+impl<T> ToClvm for Option<T>
+where
+    T: ToClvm,
+{
+    fn to_clvm(&self, a: &mut Allocator) -> Result<NodePtr> {
+        match self {
+            Some(value) => value.to_clvm(a),
+            None => Ok(a.null()),
+        }
+    }
+}
+
+impl ToClvm for &str {
+    fn to_clvm(&self, a: &mut Allocator) -> Result<NodePtr> {
+        Ok(a.new_atom(self.as_bytes())?)
+    }
+}
+
+impl ToClvm for String {
+    fn to_clvm(&self, a: &mut Allocator) -> Result<NodePtr> {
+        self.as_str().to_clvm(a)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clvmr::serde::node_to_bytes;
+    use hex::ToHex;
+
+    use super::*;
+
+    fn encode<T>(a: &mut Allocator, value: T) -> Result<String>
+    where
+        T: ToClvm,
+    {
+        let actual = value.to_clvm(a).unwrap();
+        let actual_bytes = node_to_bytes(a, actual).unwrap();
+        Ok(actual_bytes.encode_hex())
+    }
+
+    #[test]
+    fn test_primitives() {
+        let a = &mut Allocator::new();
+        assert_eq!(encode(a, 0u8), Ok("80".to_owned()));
+        assert_eq!(encode(a, 0i8), Ok("80".to_owned()));
+        assert_eq!(encode(a, 5u8), Ok("05".to_owned()));
+        assert_eq!(encode(a, 5u32), Ok("05".to_owned()));
+        assert_eq!(encode(a, 5i32), Ok("05".to_owned()));
+        assert_eq!(encode(a, -27i32), Ok("81e5".to_owned()));
+        assert_eq!(encode(a, -0), Ok("80".to_owned()));
+        assert_eq!(encode(a, -128i8), Ok("8180".to_owned()));
+    }
+
+    #[test]
+    fn test_reference() {
+        let a = &mut Allocator::new();
+        assert_eq!(encode(a, &[1, 2, 3]), encode(a, [1, 2, 3]));
+        assert_eq!(encode(a, &Some(42)), encode(a, Some(42)));
+        assert_eq!(encode(a, &Some(&42)), encode(a, Some(42)));
+        assert_eq!(encode(a, Some(&42)), encode(a, Some(42)));
+    }
+
+    #[test]
+    fn test_pair() {
+        let a = &mut Allocator::new();
+        assert_eq!(encode(a, (5, 2)), Ok("ff0502".to_owned()));
+        assert_eq!(
+            encode(a, (-72, (90121, ()))),
+            Ok("ff81b8ff8301600980".to_owned())
+        );
+        assert_eq!(
+            encode(a, (((), ((), ((), (((), ((), ((), ()))), ())))), ())),
+            Ok("ffff80ff80ff80ffff80ff80ff80808080".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_nil() {
+        let a = &mut Allocator::new();
+        assert_eq!(encode(a, ()), Ok("80".to_owned()));
+    }
+
+    #[test]
+    fn test_slice() {
+        let a = &mut Allocator::new();
+        assert_eq!(
+            encode(a, [1, 2, 3, 4].as_slice()),
+            Ok("ff01ff02ff03ff0480".to_owned())
+        );
+        assert_eq!(encode(a, [0; 0].as_slice()), Ok("80".to_owned()));
+    }
+
+    #[test]
+    fn test_array() {
+        let a = &mut Allocator::new();
+        assert_eq!(encode(a, [1, 2, 3, 4]), Ok("ff01ff02ff03ff0480".to_owned()));
+        assert_eq!(encode(a, [0; 0]), Ok("80".to_owned()));
+    }
+
+    #[test]
+    fn test_vec() {
+        let a = &mut Allocator::new();
+        assert_eq!(
+            encode(a, vec![1, 2, 3, 4]),
+            Ok("ff01ff02ff03ff0480".to_owned())
+        );
+        assert_eq!(encode(a, vec![0; 0]), Ok("80".to_owned()));
+    }
+
+    #[test]
+    fn test_option() {
+        let a = &mut Allocator::new();
+        assert_eq!(encode(a, Some("hello")), Ok("8568656c6c6f".to_owned()));
+        assert_eq!(encode(a, None::<&str>), Ok("80".to_owned()));
+        assert_eq!(encode(a, Some("")), Ok("80".to_owned()));
+    }
+
+    #[test]
+    fn test_str() {
+        let a = &mut Allocator::new();
+        assert_eq!(encode(a, "hello"), Ok("8568656c6c6f".to_owned()));
+        assert_eq!(encode(a, ""), Ok("80".to_owned()));
+    }
+
+    #[test]
+    fn test_string() {
+        let a = &mut Allocator::new();
+        assert_eq!(
+            encode(a, "hello".to_string()),
+            Ok("8568656c6c6f".to_owned())
+        );
+        assert_eq!(encode(a, "".to_string()), Ok("80".to_owned()));
+    }
+}


### PR DESCRIPTION
This PR adds two crates, one that provides `ToClvm` and `FromClvm` macros and implementations for various common types, and another one that is re-exported in the other that adds derive macros for these traits.