### PR TITLE
add helpful comment to blspy-fidelity fuzzer

### DIFF
--- a/chia-bls/fuzz/fuzz_targets/blspy-fidelity.rs
+++ b/chia-bls/fuzz/fuzz_targets/blspy-fidelity.rs
@@ -26,7 +26,12 @@ fuzz_target!(|data: &[u8]| {
     }
 
     Python::with_gil(|py| {
-
+/*
+        py.run(r#"
+import sys
+print(sys.executable)
+"#, None, None).unwrap();
+*/
         let blspy = py.import("blspy").unwrap();
         let aug = blspy.getattr("AugSchemeMPL").unwrap();
 


### PR DESCRIPTION
to help in understanding which pythin is being used by pyo3