### PR TITLE
implement Streamable for bls types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,7 @@ version = "0.2.7"
 dependencies = [
  "anyhow",
  "bls12_381_plus",
+ "chia-traits",
  "criterion",
  "group 0.12.1",
  "hex",

--- a/chia-bls/Cargo.toml
+++ b/chia-bls/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/Chia-Network/chia_rs/chia-bls/"
 repository = "https://github.com/Chia-Network/chia_rs/chia-bls/"
 
 [dependencies]
+chia-traits = { path = "../chia-traits" }
 tiny-bip39 = "1.0.0"
 anyhow = "1.0.71"
 # the newer sha2 crate doesn't implement the digest traits required by hkdf


### PR DESCRIPTION
This is in preparation for using the `chia-bls` types in the `chia-protocol` message types, as well as preparing them to be usable from python