### PR TITLE
check for canonical representation of G1 points (public keys)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
  "hkdf",
  "num-bigint",
  "rand",
+ "rstest 0.17.0",
  "sha2 0.9.9",
  "tiny-bip39",
 ]

--- a/chia-bls/Cargo.toml
+++ b/chia-bls/Cargo.toml
@@ -23,6 +23,7 @@ group = "0.12.0"
 hex = "0.4.3"
 rand = "0.8.5"
 criterion = "0.5.1"
+rstest = "=0.17.0"
 
 [lib]
 crate-type = ["rlib"]


### PR DESCRIPTION
as well as allow all-zero secret keys. This is to behave the same as `blspy`.

the same logic in blspy here: https://github.com/Chia-Network/bls-signatures/blob/main/src/elements.cpp#L38-L59