### PR TITLE
port BLS primitives to using BLST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,15 +79,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
 
 [[package]]
-name = "atomic-polyfill"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,27 +145,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
 dependencies = [
  "digest 0.9.0",
- "ff 0.13.0",
- "group 0.13.0",
- "pairing 0.23.0",
+ "ff",
+ "group",
+ "pairing",
  "rand_core",
  "subtle",
 ]
 
 [[package]]
-name = "bls12_381_plus"
-version = "0.7.0"
+name = "blst"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c681aa947677ec0c5ccfa6f14c0dd039ddbaa7b12952bf146bd5226a5f9880"
+checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
 dependencies = [
- "digest 0.9.0",
- "ff 0.12.1",
- "group 0.12.1",
- "heapless",
- "pairing 0.22.0",
- "rand_core",
- "serde",
- "subtle",
+ "cc",
+ "glob",
+ "threadpool",
  "zeroize",
 ]
 
@@ -183,12 +169,6 @@ name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cast"
@@ -231,13 +211,11 @@ name = "chia-bls"
 version = "0.2.7"
 dependencies = [
  "anyhow",
- "bls12_381_plus",
+ "blst",
  "chia-traits",
  "criterion",
- "group 0.12.1",
  "hex",
  "hkdf",
- "num-bigint",
  "rand",
  "rstest 0.17.0",
  "sha2 0.9.9",
@@ -442,7 +420,7 @@ checksum = "c2890f01537f1be43d2767ae71bbba0d0b3543dbb1ee892092d0ed4d913227fc"
 dependencies = [
  "bls12_381",
  "getrandom",
- "group 0.13.0",
+ "group",
  "hex",
  "k256",
  "lazy_static",
@@ -519,12 +497,6 @@ dependencies = [
  "cast",
  "itertools",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crossbeam-channel"
@@ -662,9 +634,9 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff 0.13.0",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "pem-rfc7468",
  "pkcs8",
  "rand_core",
@@ -698,17 +670,6 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "bitvec",
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -857,15 +818,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "group"
-version = "0.12.1"
+name = "glob"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core",
- "subtle",
-]
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "group"
@@ -873,7 +829,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.0",
+ "ff",
  "rand_core",
  "subtle",
 ]
@@ -885,32 +841,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
-
-[[package]]
-name = "heapless"
-version = "0.7.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "spin",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "heck"
@@ -1187,20 +1121,11 @@ dependencies = [
 
 [[package]]
 name = "pairing"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
-dependencies = [
- "group 0.12.1",
-]
-
-[[package]]
-name = "pairing"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group 0.13.0",
+ "group",
 ]
 
 [[package]]
@@ -1718,15 +1643,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "spki"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,12 +1681,6 @@ dependencies = [
  "libc",
  "sqlite3-src",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"

--- a/chia-bls/Cargo.toml
+++ b/chia-bls/Cargo.toml
@@ -14,10 +14,8 @@ tiny-bip39 = "1.0.0"
 anyhow = "1.0.71"
 # the newer sha2 crate doesn't implement the digest traits required by hkdf
 sha2 = "0.9.9"
-bls12_381_plus = "0.7.0"
-num-bigint = "0.4.3"
 hkdf = "0.11.0"
-group = "0.12.0"
+blst = "0.3.10"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/chia-bls/src/lib.rs
+++ b/chia-bls/src/lib.rs
@@ -4,3 +4,8 @@ pub mod mnemonic;
 pub mod public_key;
 pub mod secret_key;
 pub mod signature;
+
+pub use derivable_key::DerivableKey;
+pub use public_key::PublicKey;
+pub use secret_key::SecretKey;
+pub use signature::Signature;

--- a/chia-bls/src/public_key.rs
+++ b/chia-bls/src/public_key.rs
@@ -66,7 +66,9 @@ impl PublicKey {
     }
 
     pub fn is_valid(&self) -> bool {
-        unsafe { !blst_p1_is_inf(&self.0) && blst_p1_in_g1(&self.0) }
+        // Infinity was considered a valid G1Element in older Relic versions
+        // For historical compatibililty this behavior is maintained.
+        unsafe { blst_p1_is_inf(&self.0) || blst_p1_in_g1(&self.0) }
     }
 
     pub fn get_fingerprint(&self) -> u32 {
@@ -232,7 +234,7 @@ fn test_roundtrip() {
 #[test]
 fn test_default_is_valid() {
     let pk = PublicKey::default();
-    assert!(!pk.is_valid());
+    assert!(pk.is_valid());
 }
 
 #[test]
@@ -240,7 +242,7 @@ fn test_infinity_is_valid() {
     let mut data = [0u8; 48];
     data[0] = 0xc0;
     let pk = PublicKey::from_bytes(&data).unwrap();
-    assert!(!pk.is_valid());
+    assert!(pk.is_valid());
 }
 
 #[test]

--- a/chia-bls/src/public_key.rs
+++ b/chia-bls/src/public_key.rs
@@ -1,15 +1,14 @@
-use crate::derivable_key::DerivableKey;
 use crate::secret_key::is_all_zero;
-use bls12_381_plus::{G1Affine, G1Projective, Scalar};
+use crate::DerivableKey;
+use blst::*;
 use chia_traits::chia_error::{Error, Result};
 use chia_traits::{read_bytes, Streamable};
-use group::Curve;
-use num_bigint::BigUint;
 use sha2::{digest::FixedOutput, Digest, Sha256};
 use std::io::Cursor;
+use std::mem::MaybeUninit;
 
-#[derive(PartialEq, Eq, Debug)]
-pub struct PublicKey(pub G1Projective);
+#[derive(Debug, Clone)]
+pub struct PublicKey(pub(crate) blst_p1);
 
 impl PublicKey {
     pub fn from_bytes(bytes: &[u8; 48]) -> Result<Self> {
@@ -25,7 +24,7 @@ impl PublicKey {
                 ));
             }
             // return infinity element (point all zero)
-            return Ok(Self(G1Projective::identity()));
+            return Ok(Self::default());
         } else {
             if (bytes[0] & 0xc0) != 0x80 {
                 return Err(Error::Custom(
@@ -39,18 +38,35 @@ impl PublicKey {
             }
         }
 
-        match G1Affine::from_compressed(bytes).into() {
-            Some(p) => Ok(Self(G1Projective::from(&p))),
-            None => Err(Error::Custom("PublicKey is invalid".to_string())),
+        let p1 = unsafe {
+            let mut p1_affine = MaybeUninit::<blst_p1_affine>::uninit();
+            if blst_p1_uncompress(p1_affine.as_mut_ptr(), bytes as *const u8)
+                != BLST_ERROR::BLST_SUCCESS
+            {
+                return Err(Error::Custom("PublicKey is invalid".to_string()));
+            }
+            let mut p1 = MaybeUninit::<blst_p1>::uninit();
+            blst_p1_from_affine(p1.as_mut_ptr(), &p1_affine.assume_init());
+            p1.assume_init()
+        };
+        let ret = Self(p1);
+        if !ret.is_valid() {
+            Err(Error::Custom("PublicKey is invalid".to_string()))
+        } else {
+            Ok(ret)
         }
     }
 
     pub fn to_bytes(&self) -> [u8; 48] {
-        self.0.to_affine().to_compressed()
+        unsafe {
+            let mut bytes = MaybeUninit::<[u8; 48]>::uninit();
+            blst_p1_compress(bytes.as_mut_ptr() as *mut u8, &self.0);
+            bytes.assume_init()
+        }
     }
 
     pub fn is_valid(&self) -> bool {
-        self.0.is_identity().unwrap_u8() == 0 && self.0.is_on_curve().unwrap_u8() == 1
+        unsafe { !blst_p1_is_inf(&self.0) && blst_p1_in_g1(&self.0) }
     }
 
     pub fn get_fingerprint(&self) -> u32 {
@@ -60,6 +76,13 @@ impl PublicKey {
         u32::from_be_bytes(hash[0..4].try_into().unwrap())
     }
 }
+
+impl PartialEq for PublicKey {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { blst_p1_is_equal(&self.0, &other.0) }
+    }
+}
+impl Eq for PublicKey {}
 
 impl Streamable for PublicKey {
     fn update_digest(&self, digest: &mut Sha256) {
@@ -76,6 +99,15 @@ impl Streamable for PublicKey {
     }
 }
 
+impl Default for PublicKey {
+    fn default() -> Self {
+        unsafe {
+            let p1 = MaybeUninit::<blst_p1>::zeroed();
+            Self(p1.assume_init())
+        }
+    }
+}
+
 impl DerivableKey for PublicKey {
     fn derive_unhardened(&self, idx: u32) -> Self {
         let mut hasher = Sha256::new();
@@ -83,30 +115,22 @@ impl DerivableKey for PublicKey {
         hasher.update(idx.to_be_bytes());
         let digest: [u8; 32] = hasher.finalize_fixed().into();
 
-        // in an ideal world, we would not need to reach for the sledge-hammer of
-        // num-bigint here. This would most likely be faster if implemented in
-        // Scalar directly.
-
-        // interpret the hash as an unsigned big-endian number
-        let mut nounce = BigUint::from_bytes_be(digest.as_slice());
-
-        let q = BigUint::from_bytes_be(&[
-            0x73, 0xed, 0xa7, 0x53, 0x29, 0x9d, 0x7d, 0x48, 0x33, 0x39, 0xd8, 0x08, 0x09, 0xa1,
-            0xd8, 0x05, 0x53, 0xbd, 0xa4, 0x02, 0xff, 0xfe, 0x5b, 0xfe, 0xff, 0xff, 0xff, 0xff,
-            0x00, 0x00, 0x00, 0x01,
-        ]);
-
-        // mod by G1 Order
-        nounce %= q;
-
-        let raw_bytes = nounce.to_bytes_be();
-        let mut bytes = [0_u8; 32];
-        bytes[32 - raw_bytes.len()..].copy_from_slice(&raw_bytes);
-        bytes.reverse();
-
-        let nounce = Scalar::from_bytes(&bytes).unwrap();
-
-        PublicKey(self.0 + G1Projective::generator() * nounce)
+        let p1 = unsafe {
+            let mut nonce = MaybeUninit::<blst_scalar>::uninit();
+            blst_scalar_from_lendian(nonce.as_mut_ptr(), digest.as_ptr());
+            let mut bte = MaybeUninit::<[u8; 48]>::uninit();
+            blst_bendian_from_scalar(bte.as_mut_ptr() as *mut u8, nonce.as_ptr());
+            let mut p1 = MaybeUninit::<blst_p1>::uninit();
+            blst_p1_mult(
+                p1.as_mut_ptr(),
+                blst_p1_generator(),
+                bte.as_ptr() as *const u8,
+                256,
+            );
+            blst_p1_add(p1.as_mut_ptr(), p1.as_mut_ptr(), &self.0);
+            p1.assume_init()
+        };
+        PublicKey(p1)
     }
 }
 
@@ -114,7 +138,7 @@ impl DerivableKey for PublicKey {
 use hex::FromHex;
 
 #[cfg(test)]
-use crate::secret_key::SecretKey;
+use crate::SecretKey;
 
 #[test]
 fn test_derive_unhardened() {
@@ -177,7 +201,7 @@ fn test_from_bytes_failures(#[case] input: &str, #[case()] error: &str) {
 fn test_from_bytes_infinity() {
     let bytes: [u8; 48] = hex::decode("c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap().try_into().unwrap();
     let pk = PublicKey::from_bytes(&bytes).unwrap();
-    assert!(pk.0.is_identity().unwrap_u8() != 0);
+    assert_eq!(pk, PublicKey::default());
 }
 
 #[test]
@@ -207,7 +231,7 @@ fn test_roundtrip() {
 
 #[test]
 fn test_default_is_valid() {
-    let pk = PublicKey(G1Projective::identity());
+    let pk = PublicKey::default();
     assert!(!pk.is_valid());
 }
 

--- a/chia-bls/src/signature.rs
+++ b/chia-bls/src/signature.rs
@@ -1,44 +1,67 @@
-use crate::public_key::PublicKey;
-use crate::secret_key::SecretKey;
-use bls12_381_plus::{
-    multi_miller_loop, ExpandMsgXmd, G1Affine, G2Affine, G2Prepared, G2Projective,
-};
+use crate::{PublicKey, SecretKey};
+use blst::*;
 use chia_traits::chia_error::{Error, Result};
 use chia_traits::{read_bytes, Streamable};
-use group::{Curve, Group};
 use sha2::{Digest, Sha256};
 use std::borrow::Borrow;
 use std::convert::AsRef;
 use std::io::Cursor;
-use std::ops::Neg;
+use std::mem::MaybeUninit;
 
-#[derive(PartialEq, Eq, Debug)]
-pub struct Signature(pub(crate) G2Projective);
+// we use the augmented scheme
+pub const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_";
+
+#[derive(Debug, Clone)]
+pub struct Signature(pub(crate) blst_p2);
 
 impl Signature {
     pub fn from_bytes(buf: &[u8; 96]) -> Result<Self> {
-        match G2Affine::from_compressed(buf).into() {
-            Some(p) => Ok(Self(G2Projective::from(&p))),
-            None => Err(Error::Custom("Signature is invalid".to_string())),
+        let p2 = unsafe {
+            let mut p2_affine = MaybeUninit::<blst_p2_affine>::uninit();
+            if blst_p2_uncompress(p2_affine.as_mut_ptr(), buf as *const u8)
+                != BLST_ERROR::BLST_SUCCESS
+            {
+                return Err(Error::Custom("Signature is invalid".to_string()));
+            }
+            let mut p2 = MaybeUninit::<blst_p2>::uninit();
+            blst_p2_from_affine(p2.as_mut_ptr(), &p2_affine.assume_init());
+            p2.assume_init()
+        };
+        let ret = Self(p2);
+        if !ret.is_valid() {
+            Err(Error::Custom("Signature is invalid".to_string()))
+        } else {
+            Ok(ret)
         }
     }
 
     pub fn to_bytes(&self) -> [u8; 96] {
-        self.0.to_affine().to_compressed()
+        unsafe {
+            let mut bytes = MaybeUninit::<[u8; 96]>::uninit();
+            blst_p2_compress(bytes.as_mut_ptr() as *mut u8, &self.0);
+            bytes.assume_init()
+        }
     }
 
     pub fn aggregate(&mut self, sig: &Signature) {
-        self.0 += sig.0;
+        unsafe {
+            blst_p2_add(&mut self.0, &self.0, &sig.0);
+        }
     }
 
     pub fn is_valid(&self) -> bool {
-        self.0.is_on_curve().unwrap_u8() == 1
+        // Infinity was considered a valid G2Element in older Relic versions
+        // For historical compatibililty this behavior is maintained.
+        unsafe { blst_p2_is_inf(&self.0) || blst_p2_in_g2(&self.0) }
     }
 }
 
 impl Default for Signature {
     fn default() -> Self {
-        Signature(G2Projective::identity())
+        unsafe {
+            let p2 = MaybeUninit::<blst_p2>::zeroed();
+            Self(p2.assume_init())
+        }
     }
 }
 
@@ -57,12 +80,28 @@ impl Streamable for Signature {
     }
 }
 
-fn hash_msg<Msg: AsRef<[u8]>>(pk: &PublicKey, msg: Msg) -> G2Projective {
-    let mut prepended_msg = pk.to_bytes().to_vec();
-    prepended_msg.extend_from_slice(msg.as_ref());
-    // domain separation tag
-    const CIPHER_SUITE: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_";
-    G2Projective::hash::<ExpandMsgXmd<sha2::Sha256>>(&prepended_msg, CIPHER_SUITE)
+impl PartialEq for Signature {
+    fn eq(&self, other: &Self) -> bool {
+        unsafe { blst_p2_is_equal(&self.0, &other.0) }
+    }
+}
+impl Eq for Signature {}
+
+pub fn hash_to_g2(msg: &[u8]) -> Signature {
+    let p2 = unsafe {
+        let mut p2 = MaybeUninit::<blst_p2>::uninit();
+        blst_hash_to_g2(
+            p2.as_mut_ptr(),
+            msg.as_ptr(),
+            msg.len(),
+            DST.as_ptr(),
+            DST.len(),
+            std::ptr::null(),
+            0,
+        );
+        p2.assume_init()
+    };
+    Signature(p2)
 }
 
 pub fn aggregate<Sig: Borrow<Signature>, I>(sigs: I) -> Signature
@@ -78,19 +117,30 @@ where
 }
 
 pub fn verify<Msg: AsRef<[u8]>>(sig: &Signature, key: &PublicKey, msg: Msg) -> bool {
-    if !key.is_valid() || !sig.is_valid() {
-        return false;
-    }
-    let a = hash_msg(key, msg);
-    let g1 = G1Affine::generator().neg();
+    unsafe {
+        let mut pubkey_affine = MaybeUninit::<blst_p1_affine>::uninit();
+        let mut sig_affine = MaybeUninit::<blst_p2_affine>::uninit();
 
-    multi_miller_loop(&[
-        (&key.0.to_affine(), &G2Prepared::from(a.to_affine())),
-        (&g1, &G2Prepared::from(sig.0.to_affine())),
-    ])
-    .final_exponentiation()
-    .is_identity()
-    .into()
+        blst_p1_to_affine(pubkey_affine.as_mut_ptr(), &key.0);
+        blst_p2_to_affine(sig_affine.as_mut_ptr(), &sig.0);
+
+        let mut augmented_msg = key.to_bytes().to_vec();
+        augmented_msg.extend_from_slice(msg.as_ref());
+
+        let err = blst_core_verify_pk_in_g1(
+            &pubkey_affine.assume_init(),
+            &sig_affine.assume_init(),
+            true, // hash
+            augmented_msg.as_ptr(),
+            augmented_msg.len(),
+            DST.as_ptr(),
+            DST.len(),
+            std::ptr::null(),
+            0,
+        );
+
+        err == BLST_ERROR::BLST_SUCCESS
+    }
 }
 
 pub fn aggregate_verify<Pk: Borrow<PublicKey>, Msg: Borrow<[u8]>, I>(
@@ -103,48 +153,89 @@ where
     if !sig.is_valid() {
         return false;
     }
-    let mut store = Vec::<(G1Affine, G2Prepared)>::new();
 
-    for (key, msg) in data.into_iter() {
-        let key = key.borrow();
-        if !key.is_valid() {
+    let mut data = data.into_iter().peekable();
+    if data.peek().is_none() {
+        return *sig == Signature::default();
+    }
+
+    let sig_gt = unsafe {
+        let mut sig_affine = MaybeUninit::<blst_p2_affine>::uninit();
+        let mut sig_gt = MaybeUninit::<blst_fp12>::uninit();
+        blst_p2_to_affine(sig_affine.as_mut_ptr(), &sig.0);
+        blst_aggregated_in_g2(sig_gt.as_mut_ptr(), sig_affine.as_ptr());
+        sig_gt.assume_init()
+    };
+
+    let mut v: Vec<u64> = vec![0; unsafe { blst_pairing_sizeof() } / 8];
+    let ctx = unsafe {
+        let ctx = v.as_mut_slice().as_mut_ptr() as *mut blst_pairing;
+        blst_pairing_init(
+            ctx,
+            true, // hash
+            DST.as_ptr(),
+            DST.len(),
+        );
+        ctx
+    };
+
+    let mut aug_msg = Vec::<u8>::new();
+    for (pk, msg) in data {
+        if !pk.borrow().is_valid() {
             return false;
         }
-        store.push((
-            key.0.to_affine(),
-            G2Prepared::from(hash_msg(key, msg.borrow()).to_affine()),
-        ));
+
+        let pk_affine = unsafe {
+            let mut pk_affine = MaybeUninit::<blst_p1_affine>::uninit();
+            blst_p1_to_affine(pk_affine.as_mut_ptr(), &pk.borrow().0);
+            pk_affine.assume_init()
+        };
+
+        aug_msg.clear();
+        aug_msg.extend_from_slice(&pk.borrow().to_bytes());
+        aug_msg.extend_from_slice(msg.borrow());
+
+        let err = unsafe {
+            blst_pairing_aggregate_pk_in_g1(
+                ctx,
+                &pk_affine,
+                std::ptr::null(),
+                aug_msg.as_ptr(),
+                aug_msg.len(),
+                std::ptr::null(),
+                0,
+            )
+        };
+
+        if err != BLST_ERROR::BLST_SUCCESS {
+            return false;
+        }
     }
 
-    if store.is_empty() {
-        // if we have exactly zero messages to verify, the only correct
-        // signature is the identity
-        // This is an optimization for the edge case of having 0 messages
-        return sig == &Signature::default();
+    unsafe {
+        blst_pairing_commit(ctx);
+        blst_pairing_finalverify(ctx, &sig_gt)
     }
-
-    store.push((
-        G1Affine::generator().neg(),
-        G2Prepared::from(sig.0.to_affine()),
-    ));
-
-    let mut terms = Vec::<(&G1Affine, &G2Prepared)>::new();
-    for (g1, g2) in &store {
-        terms.push((g1, g2));
-    }
-
-    // multi_miller_loop takes a slice of *references*, which means we need to build
-    // both a vector owning the elements (G1Affine and G2Prepared) in addition to a
-    // vector holding references into it.
-    multi_miller_loop(terms.as_slice())
-        .final_exponentiation()
-        .is_identity()
-        .into()
 }
 
 pub fn sign<Msg: AsRef<[u8]>>(sk: &SecretKey, msg: Msg) -> Signature {
-    let g2 = hash_msg(&sk.public_key(), msg);
-    Signature(g2 * sk.0)
+    let mut aug_msg = sk.public_key().to_bytes().to_vec();
+    aug_msg.extend_from_slice(msg.as_ref());
+    let p2 = unsafe {
+        let mut p2 = MaybeUninit::<blst_p2>::uninit();
+        blst_hash_to_g2(
+            p2.as_mut_ptr(),
+            aug_msg.as_ptr(),
+            aug_msg.len(),
+            DST.as_ptr(),
+            DST.len(),
+            std::ptr::null(),
+            0,
+        );
+        blst_sign_pk_in_g1(p2.as_mut_ptr(), p2.as_ptr(), &sk.0);
+        p2.assume_init()
+    };
+    Signature(p2)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
testing this on Apple M1 yields a material speedup:
```
     Running benches/derive_key.rs (/Users/arvid/Documents/dev/chia_rs/target/release/deps/derive_key-319a95fb53fa0c95)
secret key, unhardened  time:   [87.483 µs 87.737 µs 88.046 µs]
                        change: [-71.923% -71.826% -71.742%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

secret key, hardened    time:   [440.89 µs 441.48 µs 442.14 µs]
                        change: [+1.3383% +1.9851% +2.7497%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

public key, unhardened  time:   [92.672 µs 92.827 µs 93.004 µs]
                        change: [-70.570% -70.500% -70.433%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe

     Running benches/sign.rs (/Users/arvid/Documents/dev/chia_rs/target/release/deps/sign-c9c2e6b916894092)
sign, small msg         time:   [389.90 µs 390.18 µs 390.48 µs]
                        change: [-81.308% -81.285% -81.259%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

sign, 4kiB msg          time:   [391.07 µs 391.59 µs 392.15 µs]
                        change: [-81.351% -81.325% -81.297%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

     Running benches/verify.rs (/Users/arvid/Documents/dev/chia_rs/target/release/deps/verify-0b14704012d8afbf)
verify, small msg       time:   [947.90 µs 948.84 µs 949.80 µs]
                        change: [-59.673% -59.624% -59.570%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

verify, 4kiB msg        time:   [948.81 µs 949.77 µs 950.79 µs]
                        change: [-59.875% -59.826% -59.775%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
```