### PR TITLE
blspy fixups

### DIFF
--- a/chia-bls/src/public_key.rs
+++ b/chia-bls/src/public_key.rs
@@ -27,7 +27,7 @@ use pyo3::{pyclass, pymethods, IntoPy, PyAny, PyObject, PyResult, Python};
     pyclass(name = "G1Element"),
     derive(PyStreamable)
 )]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct PublicKey(pub(crate) blst_p1);
 
 impl PublicKey {
@@ -168,15 +168,6 @@ impl Streamable for PublicKey {
 impl Hash for PublicKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write(&self.to_bytes())
-    }
-}
-
-impl Default for PublicKey {
-    fn default() -> Self {
-        unsafe {
-            let p1 = MaybeUninit::<blst_p1>::zeroed();
-            Self(p1.assume_init())
-        }
     }
 }
 

--- a/chia-bls/src/public_key.rs
+++ b/chia-bls/src/public_key.rs
@@ -299,223 +299,218 @@ impl ToClvm for PublicKey {
 }
 
 #[cfg(test)]
-use hex::FromHex;
+mod tests {
+    use super::*;
+    use crate::SecretKey;
+    use hex::FromHex;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+    use rstest::rstest;
 
-#[cfg(test)]
-use crate::SecretKey;
+    #[test]
+    fn test_derive_unhardened() {
+        let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
+        let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
+        let pk = sk.public_key();
 
-#[test]
-fn test_derive_unhardened() {
-    let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
-    let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
-    let pk = sk.public_key();
-
-    // make sure deriving the secret keys produce the same public keys as
-    // deriving the public key
-    for idx in 0..4_usize {
-        let derived_sk = sk.derive_unhardened(idx as u32);
-        let derived_pk = pk.derive_unhardened(idx as u32);
-        assert_eq!(derived_pk.to_bytes(), derived_sk.public_key().to_bytes());
+        // make sure deriving the secret keys produce the same public keys as
+        // deriving the public key
+        for idx in 0..4_usize {
+            let derived_sk = sk.derive_unhardened(idx as u32);
+            let derived_pk = pk.derive_unhardened(idx as u32);
+            assert_eq!(derived_pk.to_bytes(), derived_sk.public_key().to_bytes());
+        }
     }
-}
 
-#[test]
-#[cfg(feature = "py-bindings")]
-fn test_generator() {
-    assert_eq!(
-        hex::encode(&PublicKey::generator().to_bytes()),
-        "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"
-    );
-}
-
-#[cfg(test)]
-use rand::{Rng, SeedableRng};
-
-#[cfg(test)]
-use rand::rngs::StdRng;
-
-#[cfg(test)]
-use rstest::rstest;
-
-#[test]
-fn test_from_bytes() {
-    let mut rng = StdRng::seed_from_u64(1337);
-    let mut data = [0u8; 48];
-    for _i in 0..50 {
-        rng.fill(data.as_mut_slice());
-        // clear the bits that mean infinity
-        data[0] = 0x80;
-        // just any random bytes are not a valid key and should fail
-        match PublicKey::from_bytes(&data) {
-            Err(Error::InvalidPublicKey(err)) => {
-                assert!([
-                    BLST_ERROR::BLST_BAD_ENCODING,
-                    BLST_ERROR::BLST_POINT_NOT_ON_CURVE
-                ]
-                .contains(&err));
-            }
-            Err(e) => {
-                panic!("unexpected error from_bytes(): {e}");
-            }
-            Ok(v) => {
-                panic!("unexpected value from_bytes(): {v:?}");
+    #[test]
+    fn test_from_bytes() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 48];
+        for _i in 0..50 {
+            rng.fill(data.as_mut_slice());
+            // clear the bits that mean infinity
+            data[0] = 0x80;
+            // just any random bytes are not a valid key and should fail
+            match PublicKey::from_bytes(&data) {
+                Err(Error::InvalidPublicKey(err)) => {
+                    assert!([
+                        BLST_ERROR::BLST_BAD_ENCODING,
+                        BLST_ERROR::BLST_POINT_NOT_ON_CURVE
+                    ]
+                    .contains(&err));
+                }
+                Err(e) => {
+                    panic!("unexpected error from_bytes(): {e}");
+                }
+                Ok(v) => {
+                    panic!("unexpected value from_bytes(): {v:?}");
+                }
             }
         }
     }
-}
 
-#[cfg(test)]
-#[rstest]
-#[case("c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001", Error::G1NotCanonical)]
-#[case("c08000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Error::G1NotCanonical)]
-#[case("c80000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Error::G1NotCanonical)]
-#[case("e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Error::G1NotCanonical)]
-#[case("d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Error::G1NotCanonical)]
-#[case("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Error::G1InfinityNotZero)]
-#[case("400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Error::G1InfinityInvalidBits)]
-fn test_from_bytes_failures(#[case] input: &str, #[case()] error: Error) {
-    let bytes: [u8; 48] = hex::decode(input).unwrap().try_into().unwrap();
-    assert_eq!(PublicKey::from_bytes(&bytes).unwrap_err(), error);
-}
+    #[rstest]
+    #[case("c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001", Error::G1NotCanonical)]
+    #[case("c08000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Error::G1NotCanonical)]
+    #[case("c80000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Error::G1NotCanonical)]
+    #[case("e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Error::G1NotCanonical)]
+    #[case("d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Error::G1NotCanonical)]
+    #[case("800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Error::G1InfinityNotZero)]
+    #[case("400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Error::G1InfinityInvalidBits)]
+    fn test_from_bytes_failures(#[case] input: &str, #[case()] error: Error) {
+        let bytes: [u8; 48] = hex::decode(input).unwrap().try_into().unwrap();
+        assert_eq!(PublicKey::from_bytes(&bytes).unwrap_err(), error);
+    }
 
-#[test]
-fn test_from_bytes_infinity() {
-    let bytes: [u8; 48] = hex::decode("c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap().try_into().unwrap();
-    let pk = PublicKey::from_bytes(&bytes).unwrap();
-    assert_eq!(pk, PublicKey::default());
-}
+    #[test]
+    fn test_from_bytes_infinity() {
+        let bytes: [u8; 48] = hex::decode("c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap().try_into().unwrap();
+        let pk = PublicKey::from_bytes(&bytes).unwrap();
+        assert_eq!(pk, PublicKey::default());
+    }
 
-#[test]
-fn test_get_fingerprint() {
-    let bytes: [u8; 48] = hex::decode("997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2")
+    #[test]
+    fn test_get_fingerprint() {
+        let bytes: [u8; 48] = hex::decode("997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2")
         .unwrap()
         .as_slice()
         .try_into()
         .unwrap();
-    let pk = PublicKey::from_bytes(&bytes).unwrap();
-    assert_eq!(pk.get_fingerprint(), 651010559);
-}
-
-#[test]
-fn test_aggregate_pubkey() {
-    // from blspy import PrivateKey
-    // from blspy import AugSchemeMPL
-    // sk = PrivateKey.from_bytes(bytes.fromhex("52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb"))
-    // pk = sk.get_g1()
-    // pk + pk
-    // <G1Element b1b8033286299e7f238aede0d3fea48d133a1e233139085f72c102c2e6cc1f8a4ea64ed2838c10bbd2ef8f78ef271bf3>
-    // pk + pk + pk
-    // <G1Element a8bc2047d90c04a12e8c38050ec0feb4417b4d5689165cd2cea8a7903aad1778e36548a46d427b5ec571364515e456d6>
-
-    let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
-    let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
-    let pk = sk.public_key();
-    let pk2 = &pk + &pk;
-    let pk3 = &pk + &pk + &pk;
-
-    assert_eq!(pk2, PublicKey::from_bytes(&<[u8; 48]>::from_hex("b1b8033286299e7f238aede0d3fea48d133a1e233139085f72c102c2e6cc1f8a4ea64ed2838c10bbd2ef8f78ef271bf3").unwrap()).unwrap());
-    assert_eq!(pk3, PublicKey::from_bytes(&<[u8; 48]>::from_hex("a8bc2047d90c04a12e8c38050ec0feb4417b4d5689165cd2cea8a7903aad1778e36548a46d427b5ec571364515e456d6").unwrap()).unwrap());
-}
-
-#[test]
-fn test_roundtrip() {
-    let mut rng = StdRng::seed_from_u64(1337);
-    let mut data = [0u8; 32];
-    for _i in 0..50 {
-        rng.fill(data.as_mut_slice());
-        let sk = SecretKey::from_seed(&data);
-        let pk = sk.public_key();
-        let bytes = pk.to_bytes();
-        let pk2 = PublicKey::from_bytes(&bytes).unwrap();
-        assert_eq!(pk, pk2);
+        let pk = PublicKey::from_bytes(&bytes).unwrap();
+        assert_eq!(pk.get_fingerprint(), 651010559);
     }
-}
 
-#[test]
-fn test_default_is_valid() {
-    let pk = PublicKey::default();
-    assert!(pk.is_valid());
-}
+    #[test]
+    fn test_aggregate_pubkey() {
+        // from blspy import PrivateKey
+        // from blspy import AugSchemeMPL
+        // sk = PrivateKey.from_bytes(bytes.fromhex("52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb"))
+        // pk = sk.get_g1()
+        // pk + pk
+        // <G1Element b1b8033286299e7f238aede0d3fea48d133a1e233139085f72c102c2e6cc1f8a4ea64ed2838c10bbd2ef8f78ef271bf3>
+        // pk + pk + pk
+        // <G1Element a8bc2047d90c04a12e8c38050ec0feb4417b4d5689165cd2cea8a7903aad1778e36548a46d427b5ec571364515e456d6>
 
-#[test]
-fn test_infinity_is_valid() {
-    let mut data = [0u8; 48];
-    data[0] = 0xc0;
-    let pk = PublicKey::from_bytes(&data).unwrap();
-    assert!(pk.is_valid());
-}
-
-#[test]
-fn test_is_valid() {
-    let mut rng = StdRng::seed_from_u64(1337);
-    let mut data = [0u8; 32];
-    for _i in 0..50 {
-        rng.fill(data.as_mut_slice());
-        let sk = SecretKey::from_seed(&data);
+        let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
+        let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
         let pk = sk.public_key();
+        let pk2 = &pk + &pk;
+        let pk3 = &pk + &pk + &pk;
+
+        assert_eq!(pk2, PublicKey::from_bytes(&<[u8; 48]>::from_hex("b1b8033286299e7f238aede0d3fea48d133a1e233139085f72c102c2e6cc1f8a4ea64ed2838c10bbd2ef8f78ef271bf3").unwrap()).unwrap());
+        assert_eq!(pk3, PublicKey::from_bytes(&<[u8; 48]>::from_hex("a8bc2047d90c04a12e8c38050ec0feb4417b4d5689165cd2cea8a7903aad1778e36548a46d427b5ec571364515e456d6").unwrap()).unwrap());
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        for _i in 0..50 {
+            rng.fill(data.as_mut_slice());
+            let sk = SecretKey::from_seed(&data);
+            let pk = sk.public_key();
+            let bytes = pk.to_bytes();
+            let pk2 = PublicKey::from_bytes(&bytes).unwrap();
+            assert_eq!(pk, pk2);
+        }
+    }
+
+    #[test]
+    fn test_default_is_valid() {
+        let pk = PublicKey::default();
         assert!(pk.is_valid());
     }
-}
 
-#[test]
-fn test_hash() {
-    fn hash<T: std::hash::Hash>(v: T) -> u64 {
-        use std::collections::hash_map::DefaultHasher;
-        let mut h = DefaultHasher::new();
-        v.hash(&mut h);
-        h.finish()
+    #[test]
+    fn test_infinity_is_valid() {
+        let mut data = [0u8; 48];
+        data[0] = 0xc0;
+        let pk = PublicKey::from_bytes(&data).unwrap();
+        assert!(pk.is_valid());
     }
 
-    let mut rng = StdRng::seed_from_u64(1337);
-    let mut data = [0u8; 32];
-    rng.fill(data.as_mut_slice());
+    #[test]
+    fn test_is_valid() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        for _i in 0..50 {
+            rng.fill(data.as_mut_slice());
+            let sk = SecretKey::from_seed(&data);
+            let pk = sk.public_key();
+            assert!(pk.is_valid());
+        }
+    }
 
-    let sk = SecretKey::from_seed(&data);
-    let pk1 = sk.public_key();
-    let pk2 = pk1.derive_unhardened(1);
-    let pk3 = pk1.derive_unhardened(2);
+    #[test]
+    fn test_hash() {
+        fn hash<T: std::hash::Hash>(v: T) -> u64 {
+            use std::collections::hash_map::DefaultHasher;
+            let mut h = DefaultHasher::new();
+            v.hash(&mut h);
+            h.finish()
+        }
 
-    assert!(hash(pk2) != hash(pk3));
-    assert!(hash(pk1.derive_unhardened(42)) == hash(pk1.derive_unhardened(42)));
-}
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        rng.fill(data.as_mut_slice());
 
-#[test]
-fn test_debug() {
-    let mut data = [0u8; 48];
-    data[0] = 0xc0;
-    let pk = PublicKey::from_bytes(&data).unwrap();
-    assert_eq!(format!("{:?}", pk), hex::encode(data));
-}
+        let sk = SecretKey::from_seed(&data);
+        let pk1 = sk.public_key();
+        let pk2 = pk1.derive_unhardened(1);
+        let pk3 = pk1.derive_unhardened(2);
 
-#[test]
-fn test_to_from_clvm() {
-    let mut a = Allocator::new();
-    let bytes = hex::decode("997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2").expect("hex::decode()");
-    let ptr = a.new_atom(&bytes).expect("new_atom");
+        assert!(hash(pk2) != hash(pk3));
+        assert!(hash(pk1.derive_unhardened(42)) == hash(pk1.derive_unhardened(42)));
+    }
 
-    let pk = PublicKey::from_clvm(&a, ptr).expect("from_clvm");
-    assert_eq!(pk.to_bytes(), &bytes[..]);
+    #[test]
+    fn test_debug() {
+        let mut data = [0u8; 48];
+        data[0] = 0xc0;
+        let pk = PublicKey::from_bytes(&data).unwrap();
+        assert_eq!(format!("{:?}", pk), hex::encode(data));
+    }
 
-    let pk_ptr = pk.to_clvm(&mut a).expect("to_clvm");
-    assert!(a.atom_eq(pk_ptr, ptr));
-}
+    #[test]
+    fn test_to_from_clvm() {
+        let mut a = Allocator::new();
+        let bytes = hex::decode("997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2").expect("hex::decode()");
+        let ptr = a.new_atom(&bytes).expect("new_atom");
 
-#[test]
-fn test_from_clvm_failure() {
-    let mut a = Allocator::new();
-    let ptr = a.new_pair(a.one(), a.one()).expect("new_pair");
-    assert_eq!(
-        PublicKey::from_clvm(&a, ptr).unwrap_err(),
-        clvm_traits::Error::ExpectedAtom(ptr)
-    );
+        let pk = PublicKey::from_clvm(&a, ptr).expect("from_clvm");
+        assert_eq!(pk.to_bytes(), &bytes[..]);
+
+        let pk_ptr = pk.to_clvm(&mut a).expect("to_clvm");
+        assert!(a.atom_eq(pk_ptr, ptr));
+    }
+
+    #[test]
+    fn test_from_clvm_failure() {
+        let mut a = Allocator::new();
+        let ptr = a.new_pair(a.one(), a.one()).expect("new_pair");
+        assert_eq!(
+            PublicKey::from_clvm(&a, ptr).unwrap_err(),
+            clvm_traits::Error::ExpectedAtom(ptr)
+        );
+    }
 }
 
 #[cfg(test)]
 #[cfg(feature = "py-bindings")]
 mod pytests {
-
     use super::*;
+    use crate::SecretKey;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
     use rstest::rstest;
+
+    #[test]
+    fn test_generator() {
+        assert_eq!(
+            hex::encode(&PublicKey::generator().to_bytes()),
+            "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"
+        );
+    }
 
     #[test]
     fn test_json_dict_roundtrip() {

--- a/chia-bls/src/secret_key.rs
+++ b/chia-bls/src/secret_key.rs
@@ -240,16 +240,20 @@ impl SecretKey {
 }
 
 #[cfg(test)]
-use hex::FromHex;
+mod tests {
+    use super::*;
+    use hex::FromHex;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
 
-#[test]
-fn test_make_key() {
-    // test vectors from:
-    // from chia.util.keychain import KeyDataSecrets
-    // print(KeyDataSecrets.from_mnemonic(phrase)["privatekey"])
+    #[test]
+    fn test_make_key() {
+        // test vectors from:
+        // from chia.util.keychain import KeyDataSecrets
+        // print(KeyDataSecrets.from_mnemonic(phrase)["privatekey"])
 
-    // (seed, secret-key)
-    let test_cases = &[
+        // (seed, secret-key)
+        let test_cases = &[
         ("fc795be0c3f18c50dddb34e72179dc597d64055497ecc1e69e2e56a5409651bc139aae8070d4df0ea14d8d2a518a9a00bb1cc6e92e053fe34051f6821df9164c",
             "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb"),
         ("b873212f885ccffbf4692afcb84bc2e55886de2dfa07d90f5c3c239abc31c0a6ce047e30fd8bf6a281e71389aa82d73df74c7bbfb3b06b4639a5cee775cccd3c",
@@ -258,62 +262,62 @@ fn test_make_key() {
             "59095c391107936599b7ee6f09067979b321932bd62e23c7f53ed5fb19f851f6")
     ];
 
-    for (seed, sk) in test_cases {
-        assert_eq!(
-            SecretKey::from_seed(&<[u8; 64]>::from_hex(seed).unwrap())
-                .to_bytes()
-                .to_vec(),
-            Vec::<u8>::from_hex(sk).unwrap()
-        );
+        for (seed, sk) in test_cases {
+            assert_eq!(
+                SecretKey::from_seed(&<[u8; 64]>::from_hex(seed).unwrap())
+                    .to_bytes()
+                    .to_vec(),
+                Vec::<u8>::from_hex(sk).unwrap()
+            );
+        }
     }
-}
 
-#[test]
-fn test_derive_unhardened() {
-    // test vectors from:
-    // from blspy import AugSchemeMPL
-    // from blspy import PrivateKey
-    // sk = PrivateKey.from_bytes(bytes.fromhex("52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb"))
-    // AugSchemeMPL.derive_child_sk_unhardened(sk, 0)
-    // AugSchemeMPL.derive_child_sk_unhardened(sk, 1)
-    // AugSchemeMPL.derive_child_sk_unhardened(sk, 2)
-    // AugSchemeMPL.derive_child_sk_unhardened(sk, 3)
-    // <PrivateKey 399638f99d446500f3c3a363f24c2b0634ad7caf646f503455093f35f29290bd>
-    // <PrivateKey 3dcb4098ad925d8940e2f516d2d5a4dbab393db928a8c6cb06b93066a09a843a>
-    // <PrivateKey 13115c8fb68a3d667938dac2ffc6b867a4a0f216bbb228aa43d6bdde14245575>
-    // <PrivateKey 52e7e9f2fb51f2c5705aea8e11ac82737b95e664ae578f015af22031d956f92b>
+    #[test]
+    fn test_derive_unhardened() {
+        // test vectors from:
+        // from blspy import AugSchemeMPL
+        // from blspy import PrivateKey
+        // sk = PrivateKey.from_bytes(bytes.fromhex("52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb"))
+        // AugSchemeMPL.derive_child_sk_unhardened(sk, 0)
+        // AugSchemeMPL.derive_child_sk_unhardened(sk, 1)
+        // AugSchemeMPL.derive_child_sk_unhardened(sk, 2)
+        // AugSchemeMPL.derive_child_sk_unhardened(sk, 3)
+        // <PrivateKey 399638f99d446500f3c3a363f24c2b0634ad7caf646f503455093f35f29290bd>
+        // <PrivateKey 3dcb4098ad925d8940e2f516d2d5a4dbab393db928a8c6cb06b93066a09a843a>
+        // <PrivateKey 13115c8fb68a3d667938dac2ffc6b867a4a0f216bbb228aa43d6bdde14245575>
+        // <PrivateKey 52e7e9f2fb51f2c5705aea8e11ac82737b95e664ae578f015af22031d956f92b>
 
-    let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
-    let derived_hex = [
-        "399638f99d446500f3c3a363f24c2b0634ad7caf646f503455093f35f29290bd",
-        "3dcb4098ad925d8940e2f516d2d5a4dbab393db928a8c6cb06b93066a09a843a",
-        "13115c8fb68a3d667938dac2ffc6b867a4a0f216bbb228aa43d6bdde14245575",
-        "52e7e9f2fb51f2c5705aea8e11ac82737b95e664ae578f015af22031d956f92b",
-    ];
-    let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
+        let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
+        let derived_hex = [
+            "399638f99d446500f3c3a363f24c2b0634ad7caf646f503455093f35f29290bd",
+            "3dcb4098ad925d8940e2f516d2d5a4dbab393db928a8c6cb06b93066a09a843a",
+            "13115c8fb68a3d667938dac2ffc6b867a4a0f216bbb228aa43d6bdde14245575",
+            "52e7e9f2fb51f2c5705aea8e11ac82737b95e664ae578f015af22031d956f92b",
+        ];
+        let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
 
-    for idx in 0..4_usize {
-        let derived = sk.derive_unhardened(idx as u32);
-        assert_eq!(
-            derived.to_bytes(),
-            <[u8; 32]>::from_hex(derived_hex[idx]).unwrap()
-        )
+        for idx in 0..4_usize {
+            let derived = sk.derive_unhardened(idx as u32);
+            assert_eq!(
+                derived.to_bytes(),
+                <[u8; 32]>::from_hex(derived_hex[idx]).unwrap()
+            )
+        }
     }
-}
 
-#[test]
-fn test_public_key() {
-    // test vectors from:
-    // from blspy import PrivateKey
-    // from blspy import AugSchemeMPL
-    // sk = PrivateKey.from_bytes(bytes.fromhex("52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb"))
-    // for i in [100, 52312, 352350, 316]:
-    //         sk0 = AugSchemeMPL.derive_child_sk_unhardened(sk, i)
-    //         print(bytes(sk0).hex())
-    //         print(bytes(sk0.get_g1()).hex())
+    #[test]
+    fn test_public_key() {
+        // test vectors from:
+        // from blspy import PrivateKey
+        // from blspy import AugSchemeMPL
+        // sk = PrivateKey.from_bytes(bytes.fromhex("52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb"))
+        // for i in [100, 52312, 352350, 316]:
+        //         sk0 = AugSchemeMPL.derive_child_sk_unhardened(sk, i)
+        //         print(bytes(sk0).hex())
+        //         print(bytes(sk0.get_g1()).hex())
 
-    // secret key, public key
-    let test_cases = [
+        // secret key, public key
+        let test_cases = [
         ("5aac8405befe4cb3748a67177c56df26355f1f98d979afdb0b2f97858d2f71c3",
         "b9de000821a610ef644d160c810e35113742ff498002c2deccd8f1a349e423047e9b3fc17ebfc733dbee8fd902ba2961"),
         ("23f1fb291d3bd7434282578b842d5ea4785994bb89bd2c94896d1b4be6c70ba2",
@@ -326,126 +330,122 @@ fn test_public_key() {
         "928ea102b5a3e3efe4f4c240d3458a568dfeb505e02901a85ed70a384944b0c08c703a35245322709921b8f2b7f5e54a"),
         ];
 
-    for (sk_hex, pk_hex) in test_cases {
+        for (sk_hex, pk_hex) in test_cases {
+            let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
+            let pk = sk.public_key();
+            assert_eq!(
+                pk,
+                PublicKey::from_bytes(&<[u8; 48]>::from_hex(pk_hex).unwrap()).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn test_derive_hardened() {
+        // test vectors from:
+        // from blspy import AugSchemeMPL
+        // from blspy import PrivateKey
+        // sk = PrivateKey.from_bytes(bytes.fromhex("52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb"))
+        // AugSchemeMPL.derive_child_sk(sk, 0)
+        // AugSchemeMPL.derive_child_sk(sk, 1)
+        // AugSchemeMPL.derive_child_sk(sk, 2)
+        // AugSchemeMPL.derive_child_sk(sk, 3)
+        // <PrivateKey 05eccb2d70e814f51a30d8b9965505605c677afa97228fa2419db583a8121db9>
+        // <PrivateKey 612ae96bdce2e9bc01693ac579918fbb559e04ec365cce9b66bb80e328f62c46>
+        // <PrivateKey 5df14a0a34fd6c30a80136d4103f0a93422ce82d5c537bebbecbc56e19fee5b9>
+        // <PrivateKey 3ea55db88d9a6bf5f1d9c9de072e3c9a56b13f4156d72fca7880cd39b4bd4fdc>
+
+        let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
+        let derived_hex = [
+            "05eccb2d70e814f51a30d8b9965505605c677afa97228fa2419db583a8121db9",
+            "612ae96bdce2e9bc01693ac579918fbb559e04ec365cce9b66bb80e328f62c46",
+            "5df14a0a34fd6c30a80136d4103f0a93422ce82d5c537bebbecbc56e19fee5b9",
+            "3ea55db88d9a6bf5f1d9c9de072e3c9a56b13f4156d72fca7880cd39b4bd4fdc",
+        ];
         let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
-        let pk = sk.public_key();
-        assert_eq!(
-            pk,
-            PublicKey::from_bytes(&<[u8; 48]>::from_hex(pk_hex).unwrap()).unwrap()
-        );
-    }
-}
 
-#[test]
-fn test_derive_hardened() {
-    // test vectors from:
-    // from blspy import AugSchemeMPL
-    // from blspy import PrivateKey
-    // sk = PrivateKey.from_bytes(bytes.fromhex("52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb"))
-    // AugSchemeMPL.derive_child_sk(sk, 0)
-    // AugSchemeMPL.derive_child_sk(sk, 1)
-    // AugSchemeMPL.derive_child_sk(sk, 2)
-    // AugSchemeMPL.derive_child_sk(sk, 3)
-    // <PrivateKey 05eccb2d70e814f51a30d8b9965505605c677afa97228fa2419db583a8121db9>
-    // <PrivateKey 612ae96bdce2e9bc01693ac579918fbb559e04ec365cce9b66bb80e328f62c46>
-    // <PrivateKey 5df14a0a34fd6c30a80136d4103f0a93422ce82d5c537bebbecbc56e19fee5b9>
-    // <PrivateKey 3ea55db88d9a6bf5f1d9c9de072e3c9a56b13f4156d72fca7880cd39b4bd4fdc>
-
-    let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
-    let derived_hex = [
-        "05eccb2d70e814f51a30d8b9965505605c677afa97228fa2419db583a8121db9",
-        "612ae96bdce2e9bc01693ac579918fbb559e04ec365cce9b66bb80e328f62c46",
-        "5df14a0a34fd6c30a80136d4103f0a93422ce82d5c537bebbecbc56e19fee5b9",
-        "3ea55db88d9a6bf5f1d9c9de072e3c9a56b13f4156d72fca7880cd39b4bd4fdc",
-    ];
-    let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
-
-    for idx in 0..derived_hex.len() {
-        let derived = sk.derive_hardened(idx as u32);
-        assert_eq!(
-            derived.to_bytes(),
-            <[u8; 32]>::from_hex(derived_hex[idx]).unwrap()
-        )
-    }
-}
-
-#[cfg(test)]
-use rand::{Rng, SeedableRng};
-
-#[cfg(test)]
-use rand::rngs::StdRng;
-
-#[test]
-fn test_debug() {
-    let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
-    let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
-    assert_eq!(format!("{:?}", sk), sk_hex);
-}
-
-#[test]
-fn test_hash() {
-    fn hash<T: std::hash::Hash>(v: &T) -> u64 {
-        use std::collections::hash_map::DefaultHasher;
-        let mut h = DefaultHasher::new();
-        v.hash(&mut h);
-        h.finish()
+        for idx in 0..derived_hex.len() {
+            let derived = sk.derive_hardened(idx as u32);
+            assert_eq!(
+                derived.to_bytes(),
+                <[u8; 32]>::from_hex(derived_hex[idx]).unwrap()
+            )
+        }
     }
 
-    let mut rng = StdRng::seed_from_u64(1337);
-    let mut data = [0u8; 32];
-    rng.fill(data.as_mut_slice());
+    #[test]
+    fn test_debug() {
+        let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
+        let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
+        assert_eq!(format!("{:?}", sk), sk_hex);
+    }
 
-    let sk1 = SecretKey::from_seed(&data);
-    let sk2 = SecretKey::from_seed(&data);
+    #[test]
+    fn test_hash() {
+        fn hash<T: std::hash::Hash>(v: &T) -> u64 {
+            use std::collections::hash_map::DefaultHasher;
+            let mut h = DefaultHasher::new();
+            v.hash(&mut h);
+            h.finish()
+        }
 
-    rng.fill(data.as_mut_slice());
-    let sk3 = SecretKey::from_seed(&data);
-
-    assert!(hash(&sk1) == hash(&sk2));
-    assert!(hash(&sk1) != hash(&sk3));
-}
-
-#[test]
-fn test_from_bytes() {
-    let mut rng = StdRng::seed_from_u64(1337);
-    let mut data = [0u8; 32];
-    for _i in 0..50 {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
         rng.fill(data.as_mut_slice());
-        // make the bytes exceed q
-        data[0] |= 0x80;
-        // just any random bytes are not a valid key and should fail
-        assert_eq!(
-            SecretKey::from_bytes(&data).unwrap_err(),
-            Error::SecretKeyGroupOrder
-        );
-    }
-}
 
-#[test]
-fn test_from_bytes_zero() {
-    let data = [0u8; 32];
-    let _sk = SecretKey::from_bytes(&data).unwrap();
-}
+        let sk1 = SecretKey::from_seed(&data);
+        let sk2 = SecretKey::from_seed(&data);
 
-#[test]
-fn test_roundtrip() {
-    let mut rng = StdRng::seed_from_u64(1337);
-    let mut data = [0u8; 32];
-    for _i in 0..50 {
         rng.fill(data.as_mut_slice());
-        let sk = SecretKey::from_seed(&data);
-        let bytes = sk.to_bytes();
-        let sk2 = SecretKey::from_bytes(&bytes).unwrap();
-        assert_eq!(sk, sk2);
-        assert_eq!(sk.public_key(), sk2.public_key());
+        let sk3 = SecretKey::from_seed(&data);
+
+        assert!(hash(&sk1) == hash(&sk2));
+        assert!(hash(&sk1) != hash(&sk3));
+    }
+
+    #[test]
+    fn test_from_bytes() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        for _i in 0..50 {
+            rng.fill(data.as_mut_slice());
+            // make the bytes exceed q
+            data[0] |= 0x80;
+            // just any random bytes are not a valid key and should fail
+            assert_eq!(
+                SecretKey::from_bytes(&data).unwrap_err(),
+                Error::SecretKeyGroupOrder
+            );
+        }
+    }
+
+    #[test]
+    fn test_from_bytes_zero() {
+        let data = [0u8; 32];
+        let _sk = SecretKey::from_bytes(&data).unwrap();
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        for _i in 0..50 {
+            rng.fill(data.as_mut_slice());
+            let sk = SecretKey::from_seed(&data);
+            let bytes = sk.to_bytes();
+            let sk2 = SecretKey::from_bytes(&bytes).unwrap();
+            assert_eq!(sk, sk2);
+            assert_eq!(sk.public_key(), sk2.public_key());
+        }
     }
 }
 
 #[cfg(test)]
 #[cfg(feature = "py-bindings")]
 mod pytests {
-
     use super::*;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
     use rstest::rstest;
 
     #[test]

--- a/chia-bls/src/secret_key.rs
+++ b/chia-bls/src/secret_key.rs
@@ -456,14 +456,12 @@ mod pytests {
         for _i in 0..50 {
             rng.fill(data.as_mut_slice());
             let sk = SecretKey::from_seed(&data);
-            let ret = Python::with_gil(|py| -> PyResult<()> {
-                let string = sk.to_json_dict(py)?;
+            Python::with_gil(|py| {
+                let string = sk.to_json_dict(py).expect("to_json_dict");
                 let sk2 = SecretKey::from_json_dict(string.as_ref(py)).unwrap();
                 assert_eq!(sk, sk2);
                 assert_eq!(sk.public_key(), sk2.public_key());
-                Ok(())
             });
-            assert!(ret.is_ok())
         }
     }
 
@@ -490,12 +488,10 @@ mod pytests {
     )]
     fn test_json_dict(#[case] input: &str, #[case] msg: &str) {
         pyo3::prepare_freethreaded_python();
-        let ret = Python::with_gil(|py| -> PyResult<()> {
+        Python::with_gil(|py| {
             let err =
                 SecretKey::from_json_dict(input.to_string().into_py(py).as_ref(py)).unwrap_err();
             assert_eq!(err.value(py).to_string(), msg.to_string());
-            Ok(())
         });
-        assert!(ret.is_ok())
     }
 }

--- a/chia-bls/src/signature.rs
+++ b/chia-bls/src/signature.rs
@@ -403,526 +403,527 @@ pub fn sign<Msg: AsRef<[u8]>>(sk: &SecretKey, msg: Msg) -> Signature {
 }
 
 #[cfg(test)]
-use rand::{Rng, SeedableRng};
+mod tests {
+    use super::*;
+    use hex::FromHex;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
 
-#[cfg(test)]
-use rand::rngs::StdRng;
-
-#[test]
-#[cfg(feature = "py-bindings")]
-fn test_generator() {
-    assert_eq!(
-        hex::encode(&Signature::generator().to_bytes()),
-        "93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
-    );
-}
-
-#[test]
-fn test_from_bytes() {
-    let mut rng = StdRng::seed_from_u64(1337);
-    let mut data = [0u8; 96];
-    for _i in 0..50 {
-        rng.fill(data.as_mut_slice());
-        // just any random bytes are not a valid signature and should fail
-        match Signature::from_bytes(&data) {
-            Err(Error::InvalidSignature(err)) => {
-                assert!([
-                    BLST_ERROR::BLST_BAD_ENCODING,
-                    BLST_ERROR::BLST_POINT_NOT_ON_CURVE
-                ]
-                .contains(&err));
-            }
-            Err(e) => {
-                panic!("unexpected error from_bytes(): {e}");
-            }
-            Ok(v) => {
-                panic!("unexpected value from_bytes(): {v:?}");
+    #[test]
+    fn test_from_bytes() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 96];
+        for _i in 0..50 {
+            rng.fill(data.as_mut_slice());
+            // just any random bytes are not a valid signature and should fail
+            match Signature::from_bytes(&data) {
+                Err(Error::InvalidSignature(err)) => {
+                    assert!([
+                        BLST_ERROR::BLST_BAD_ENCODING,
+                        BLST_ERROR::BLST_POINT_NOT_ON_CURVE
+                    ]
+                    .contains(&err));
+                }
+                Err(e) => {
+                    panic!("unexpected error from_bytes(): {e}");
+                }
+                Ok(v) => {
+                    panic!("unexpected value from_bytes(): {v:?}");
+                }
             }
         }
     }
-}
 
-#[test]
-fn test_default_is_valid() {
-    let sig = Signature::default();
-    assert!(sig.is_valid());
-}
-
-#[test]
-fn test_infinity_is_valid() {
-    let mut data = [0u8; 96];
-    data[0] = 0xc0;
-    let sig = Signature::from_bytes(&data).unwrap();
-    assert!(sig.is_valid());
-}
-
-#[test]
-fn test_is_valid() {
-    let mut rng = StdRng::seed_from_u64(1337);
-    let mut data = [0u8; 32];
-    let msg = [0u8; 32];
-    for _i in 0..50 {
-        rng.fill(data.as_mut_slice());
-        let sk = SecretKey::from_seed(&data);
-        let sig = sign(&sk, msg);
+    #[test]
+    fn test_default_is_valid() {
+        let sig = Signature::default();
         assert!(sig.is_valid());
     }
-}
 
-#[test]
-fn test_roundtrip() {
-    let mut rng = StdRng::seed_from_u64(1337);
-    let mut data = [0u8; 32];
-    let mut msg = [0u8; 32];
-    rng.fill(msg.as_mut_slice());
-    for _i in 0..50 {
-        rng.fill(data.as_mut_slice());
-        let sk = SecretKey::from_seed(&data);
-        let sig = sign(&sk, msg);
-        let bytes = sig.to_bytes();
-        let sig2 = Signature::from_bytes(&bytes).unwrap();
-        assert_eq!(sig, sig2);
+    #[test]
+    fn test_infinity_is_valid() {
+        let mut data = [0u8; 96];
+        data[0] = 0xc0;
+        let sig = Signature::from_bytes(&data).unwrap();
+        assert!(sig.is_valid());
     }
-}
 
-#[test]
-fn test_random_verify() {
-    let mut rng = StdRng::seed_from_u64(1337);
-    let mut data = [0u8; 32];
-    let mut msg = [0u8; 32];
-    rng.fill(msg.as_mut_slice());
-    for _i in 0..20 {
-        rng.fill(data.as_mut_slice());
-        let sk = SecretKey::from_seed(&data);
-        let pk = sk.public_key();
-        let sig = sign(&sk, msg);
-        assert!(verify(&sig, &pk, msg));
-
-        let bytes = sig.to_bytes();
-        let sig2 = Signature::from_bytes(&bytes).unwrap();
-        assert!(verify(&sig2, &pk, msg));
+    #[test]
+    fn test_is_valid() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        let msg = [0u8; 32];
+        for _i in 0..50 {
+            rng.fill(data.as_mut_slice());
+            let sk = SecretKey::from_seed(&data);
+            let sig = sign(&sk, msg);
+            assert!(sig.is_valid());
+        }
     }
-}
 
-#[cfg(test)]
-use hex::FromHex;
+    #[test]
+    fn test_roundtrip() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        let mut msg = [0u8; 32];
+        rng.fill(msg.as_mut_slice());
+        for _i in 0..50 {
+            rng.fill(data.as_mut_slice());
+            let sk = SecretKey::from_seed(&data);
+            let sig = sign(&sk, msg);
+            let bytes = sig.to_bytes();
+            let sig2 = Signature::from_bytes(&bytes).unwrap();
+            assert_eq!(sig, sig2);
+        }
+    }
 
-#[test]
-fn test_verify() {
-    // test case from:
-    // from blspy import PrivateKey
-    // from blspy import AugSchemeMPL
-    // sk = PrivateKey.from_bytes(bytes.fromhex("52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb"))
-    // data = b"foobar"
-    // print(AugSchemeMPL.sign(sk, data))
-    let msg = b"foobar";
-    let sk = SecretKey::from_bytes(
-        &<[u8; 32]>::from_hex("52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb")
+    #[test]
+    fn test_random_verify() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        let mut msg = [0u8; 32];
+        rng.fill(msg.as_mut_slice());
+        for _i in 0..20 {
+            rng.fill(data.as_mut_slice());
+            let sk = SecretKey::from_seed(&data);
+            let pk = sk.public_key();
+            let sig = sign(&sk, msg);
+            assert!(verify(&sig, &pk, msg));
+
+            let bytes = sig.to_bytes();
+            let sig2 = Signature::from_bytes(&bytes).unwrap();
+            assert!(verify(&sig2, &pk, msg));
+        }
+    }
+
+    #[test]
+    fn test_verify() {
+        // test case from:
+        // from blspy import PrivateKey
+        // from blspy import AugSchemeMPL
+        // sk = PrivateKey.from_bytes(bytes.fromhex("52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb"))
+        // data = b"foobar"
+        // print(AugSchemeMPL.sign(sk, data))
+        let msg = b"foobar";
+        let sk = SecretKey::from_bytes(
+            &<[u8; 32]>::from_hex(
+                "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb",
+            )
             .unwrap(),
-    )
-    .unwrap();
+        )
+        .unwrap();
 
-    let sig = sign(&sk, msg);
-    assert!(verify(&sig, &sk.public_key(), msg));
+        let sig = sign(&sk, msg);
+        assert!(verify(&sig, &sk.public_key(), msg));
 
-    assert_eq!(sig.to_bytes(), <[u8; 96]>::from_hex("b45825c0ee7759945c0189b4c38b7e54231ebadc83a851bec3bb7cf954a124ae0cc8e8e5146558332ea152f63bf8846e04826185ef60e817f271f8d500126561319203f9acb95809ed20c193757233454be1562a5870570941a84605bd2c9c9a").unwrap());
-}
-
-#[test]
-fn test_aggregate_signature() {
-    // from blspy import PrivateKey
-    // from blspy import AugSchemeMPL
-    // sk = PrivateKey.from_bytes(bytes.fromhex("52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb"))
-    // data = b"foobar"
-    // sk0 = AugSchemeMPL.derive_child_sk(sk, 0)
-    // sk1 = AugSchemeMPL.derive_child_sk(sk, 1)
-    // sk2 = AugSchemeMPL.derive_child_sk(sk, 2)
-    // sk3 = AugSchemeMPL.derive_child_sk(sk, 3)
-
-    // sig0 = AugSchemeMPL.sign(sk0, data)
-    // sig1 = AugSchemeMPL.sign(sk1, data)
-    // sig2 = AugSchemeMPL.sign(sk2, data)
-    // sig3 = AugSchemeMPL.sign(sk3, data)
-
-    // agg = AugSchemeMPL.aggregate([sig0, sig1, sig2, sig3])
-
-    // 87bce2c588f4257e2792d929834548c7d3af679272cb4f8e1d24cf4bf584dd287aa1d9f5e53a86f288190db45e1d100d0a5e936079a66a709b5f35394cf7d52f49dd963284cb5241055d54f8cf48f61bc1037d21cae6c025a7ea5e9f4d289a18
-
-    let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
-    let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
-    let msg = b"foobar";
-    let mut agg1 = Signature::default();
-    let mut agg2 = Signature::default();
-    let mut sigs = Vec::<Signature>::new();
-    let mut data = Vec::<(PublicKey, &[u8])>::new();
-    for idx in 0..4 {
-        let derived = sk.derive_hardened(idx as u32);
-        data.push((derived.public_key(), msg));
-        let sig = sign(&derived, msg);
-        agg1.aggregate(&sig);
-        agg2 += &sig;
-        sigs.push(sig);
-    }
-    let agg3 = aggregate(&sigs);
-    let agg4 = &sigs[0] + &sigs[1] + &sigs[2] + &sigs[3];
-
-    assert_eq!(agg1.to_bytes(), <[u8; 96]>::from_hex("87bce2c588f4257e2792d929834548c7d3af679272cb4f8e1d24cf4bf584dd287aa1d9f5e53a86f288190db45e1d100d0a5e936079a66a709b5f35394cf7d52f49dd963284cb5241055d54f8cf48f61bc1037d21cae6c025a7ea5e9f4d289a18").unwrap());
-    assert_eq!(agg1, agg2);
-    assert_eq!(agg1, agg3);
-    assert_eq!(agg1, agg4);
-
-    // ensure the aggregate signature verifies OK
-    assert!(aggregate_verify(&agg1, data.clone()));
-    assert!(aggregate_verify(&agg2, data.clone()));
-    assert!(aggregate_verify(&agg3, data.clone()));
-    assert!(aggregate_verify(&agg4, data.clone()));
-}
-
-#[test]
-fn test_aggregate_duplicate_signature() {
-    let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
-    let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
-    let msg = b"foobar";
-    let mut agg = Signature::default();
-    let mut data = Vec::<(PublicKey, &[u8])>::new();
-    for _idx in 0..2 {
-        data.push((sk.public_key(), msg));
-        agg.aggregate(&sign(&sk, msg));
+        assert_eq!(sig.to_bytes(), <[u8; 96]>::from_hex("b45825c0ee7759945c0189b4c38b7e54231ebadc83a851bec3bb7cf954a124ae0cc8e8e5146558332ea152f63bf8846e04826185ef60e817f271f8d500126561319203f9acb95809ed20c193757233454be1562a5870570941a84605bd2c9c9a").unwrap());
     }
 
-    assert_eq!(agg.to_bytes(), <[u8; 96]>::from_hex("a1cca6540a4a06d096cb5b5fc76af5fd099476e70b623b8c6e4cf02ffde94fc0f75f4e17c67a9e350940893306798a3519368b02dc3464b7270ea4ca233cfa85a38da9e25c9314e81270b54d1e773a2ec5c3e14c62dac7abdebe52f4688310d3").unwrap());
+    #[test]
+    fn test_aggregate_signature() {
+        // from blspy import PrivateKey
+        // from blspy import AugSchemeMPL
+        // sk = PrivateKey.from_bytes(bytes.fromhex("52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb"))
+        // data = b"foobar"
+        // sk0 = AugSchemeMPL.derive_child_sk(sk, 0)
+        // sk1 = AugSchemeMPL.derive_child_sk(sk, 1)
+        // sk2 = AugSchemeMPL.derive_child_sk(sk, 2)
+        // sk3 = AugSchemeMPL.derive_child_sk(sk, 3)
 
-    assert!(aggregate_verify(&agg, data));
-}
+        // sig0 = AugSchemeMPL.sign(sk0, data)
+        // sig1 = AugSchemeMPL.sign(sk1, data)
+        // sig2 = AugSchemeMPL.sign(sk2, data)
+        // sig3 = AugSchemeMPL.sign(sk3, data)
 
-#[cfg(test)]
-fn random_sk<R: Rng>(rng: &mut R) -> SecretKey {
-    let mut data = [0u8; 64];
-    rng.fill(data.as_mut_slice());
-    SecretKey::from_seed(&data)
-}
+        // agg = AugSchemeMPL.aggregate([sig0, sig1, sig2, sig3])
 
-#[test]
-fn test_aggregate_signature_separate_msg() {
-    let mut rng = StdRng::seed_from_u64(1337);
-    let sk = [random_sk(&mut rng), random_sk(&mut rng)];
-    let pk = [sk[0].public_key(), sk[1].public_key()];
-    let msg: [&'static [u8]; 2] = [b"foo", b"foobar"];
-    let sig = [sign(&sk[0], msg[0]), sign(&sk[1], msg[1])];
-    let mut agg = Signature::default();
-    agg.aggregate(&sig[0]);
-    agg.aggregate(&sig[1]);
+        // 87bce2c588f4257e2792d929834548c7d3af679272cb4f8e1d24cf4bf584dd287aa1d9f5e53a86f288190db45e1d100d0a5e936079a66a709b5f35394cf7d52f49dd963284cb5241055d54f8cf48f61bc1037d21cae6c025a7ea5e9f4d289a18
 
-    assert!(aggregate_verify(&agg, pk.iter().zip(msg)));
-    // order does not matter
-    assert!(aggregate_verify(&agg, pk.iter().zip(msg).rev()));
-}
+        let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
+        let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
+        let msg = b"foobar";
+        let mut agg1 = Signature::default();
+        let mut agg2 = Signature::default();
+        let mut sigs = Vec::<Signature>::new();
+        let mut data = Vec::<(PublicKey, &[u8])>::new();
+        for idx in 0..4 {
+            let derived = sk.derive_hardened(idx as u32);
+            data.push((derived.public_key(), msg));
+            let sig = sign(&derived, msg);
+            agg1.aggregate(&sig);
+            agg2 += &sig;
+            sigs.push(sig);
+        }
+        let agg3 = aggregate(&sigs);
+        let agg4 = &sigs[0] + &sigs[1] + &sigs[2] + &sigs[3];
 
-#[test]
-fn test_aggregate_signature_identity() {
-    // when verifying 0 messages, an identity signature is considered valid
-    let empty = Vec::<(PublicKey, &[u8])>::new();
-    assert!(aggregate_verify(&Signature::default(), empty));
-}
+        assert_eq!(agg1.to_bytes(), <[u8; 96]>::from_hex("87bce2c588f4257e2792d929834548c7d3af679272cb4f8e1d24cf4bf584dd287aa1d9f5e53a86f288190db45e1d100d0a5e936079a66a709b5f35394cf7d52f49dd963284cb5241055d54f8cf48f61bc1037d21cae6c025a7ea5e9f4d289a18").unwrap());
+        assert_eq!(agg1, agg2);
+        assert_eq!(agg1, agg3);
+        assert_eq!(agg1, agg4);
 
-#[test]
-fn test_invalid_aggregate_signature() {
-    let mut rng = StdRng::seed_from_u64(1337);
-    let sk = [random_sk(&mut rng), random_sk(&mut rng)];
-    let pk = [sk[0].public_key(), sk[1].public_key()];
-    let msg: [&'static [u8]; 2] = [b"foo", b"foobar"];
-    let sig = [sign(&sk[0], msg[0]), sign(&sk[1], msg[1])];
-    let mut agg = Signature::default();
-    agg.aggregate(&sig[0]);
-    agg.aggregate(&sig[1]);
+        // ensure the aggregate signature verifies OK
+        assert!(aggregate_verify(&agg1, data.clone()));
+        assert!(aggregate_verify(&agg2, data.clone()));
+        assert!(aggregate_verify(&agg3, data.clone()));
+        assert!(aggregate_verify(&agg4, data.clone()));
+    }
 
-    assert!(!aggregate_verify(&agg, [(&pk[0], msg[0])]));
-    assert!(!aggregate_verify(&agg, [(&pk[1], msg[1])]));
-    // public keys mixed with the wrong message
-    assert!(!aggregate_verify(
-        &agg,
-        [(&pk[0], msg[1]), (&pk[1], msg[0])]
-    ));
-    assert!(!aggregate_verify(
-        &agg,
-        [(&pk[1], msg[0]), (&pk[0], msg[1])]
-    ));
-}
+    #[test]
+    fn test_aggregate_duplicate_signature() {
+        let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
+        let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
+        let msg = b"foobar";
+        let mut agg = Signature::default();
+        let mut data = Vec::<(PublicKey, &[u8])>::new();
+        for _idx in 0..2 {
+            data.push((sk.public_key(), msg));
+            agg.aggregate(&sign(&sk, msg));
+        }
 
-#[test]
-fn test_vector_2_aggregate_of_aggregates() {
-    // test case from: bls-signatures/src/test.cpp
-    // "Chia test vector 2 (Augmented, aggregate of aggregates)"
-    let message1 = [1_u8, 2, 3, 40];
-    let message2 = [5_u8, 6, 70, 201];
-    let message3 = [9_u8, 10, 11, 12, 13];
-    let message4 = [15_u8, 63, 244, 92, 0, 1];
+        assert_eq!(agg.to_bytes(), <[u8; 96]>::from_hex("a1cca6540a4a06d096cb5b5fc76af5fd099476e70b623b8c6e4cf02ffde94fc0f75f4e17c67a9e350940893306798a3519368b02dc3464b7270ea4ca233cfa85a38da9e25c9314e81270b54d1e773a2ec5c3e14c62dac7abdebe52f4688310d3").unwrap());
 
-    let sk1 = SecretKey::from_seed(&[2_u8; 32]);
-    let sk2 = SecretKey::from_seed(&[3_u8; 32]);
+        assert!(aggregate_verify(&agg, data));
+    }
 
-    let pk1 = sk1.public_key();
-    let pk2 = sk2.public_key();
+    #[cfg(test)]
+    fn random_sk<R: Rng>(rng: &mut R) -> SecretKey {
+        let mut data = [0u8; 64];
+        rng.fill(data.as_mut_slice());
+        SecretKey::from_seed(&data)
+    }
 
-    let sig1 = sign(&sk1, message1);
-    let sig2 = sign(&sk2, message2);
-    let sig3 = sign(&sk2, message1);
-    let sig4 = sign(&sk1, message3);
-    let sig5 = sign(&sk1, message1);
-    let sig6 = sign(&sk1, message4);
+    #[test]
+    fn test_aggregate_signature_separate_msg() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let sk = [random_sk(&mut rng), random_sk(&mut rng)];
+        let pk = [sk[0].public_key(), sk[1].public_key()];
+        let msg: [&'static [u8]; 2] = [b"foo", b"foobar"];
+        let sig = [sign(&sk[0], msg[0]), sign(&sk[1], msg[1])];
+        let mut agg = Signature::default();
+        agg.aggregate(&sig[0]);
+        agg.aggregate(&sig[1]);
 
-    let agg_sig_l = aggregate([sig1, sig2]);
-    let agg_sig_r = aggregate([sig3, sig4, sig5]);
-    let aggsig = aggregate([agg_sig_l, agg_sig_r, sig6]);
+        assert!(aggregate_verify(&agg, pk.iter().zip(msg)));
+        // order does not matter
+        assert!(aggregate_verify(&agg, pk.iter().zip(msg).rev()));
+    }
 
-    assert!(aggregate_verify(
-        &aggsig,
-        [
-            (&pk1, &message1 as &[u8]),
-            (&pk2, &message2),
-            (&pk2, &message1),
-            (&pk1, &message3),
-            (&pk1, &message1),
-            (&pk1, &message4)
-        ]
-    ));
+    #[test]
+    fn test_aggregate_signature_identity() {
+        // when verifying 0 messages, an identity signature is considered valid
+        let empty = Vec::<(PublicKey, &[u8])>::new();
+        assert!(aggregate_verify(&Signature::default(), empty));
+    }
 
-    assert_eq!(
-        aggsig.to_bytes(),
-        <[u8; 96]>::from_hex(
-            "a1d5360dcb418d33b29b90b912b4accde535cf0e52caf467a005dc632d9f7af44b6c4e9acd4\
+    #[test]
+    fn test_invalid_aggregate_signature() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let sk = [random_sk(&mut rng), random_sk(&mut rng)];
+        let pk = [sk[0].public_key(), sk[1].public_key()];
+        let msg: [&'static [u8]; 2] = [b"foo", b"foobar"];
+        let sig = [sign(&sk[0], msg[0]), sign(&sk[1], msg[1])];
+        let mut agg = Signature::default();
+        agg.aggregate(&sig[0]);
+        agg.aggregate(&sig[1]);
+
+        assert!(!aggregate_verify(&agg, [(&pk[0], msg[0])]));
+        assert!(!aggregate_verify(&agg, [(&pk[1], msg[1])]));
+        // public keys mixed with the wrong message
+        assert!(!aggregate_verify(
+            &agg,
+            [(&pk[0], msg[1]), (&pk[1], msg[0])]
+        ));
+        assert!(!aggregate_verify(
+            &agg,
+            [(&pk[1], msg[0]), (&pk[0], msg[1])]
+        ));
+    }
+
+    #[test]
+    fn test_vector_2_aggregate_of_aggregates() {
+        // test case from: bls-signatures/src/test.cpp
+        // "Chia test vector 2 (Augmented, aggregate of aggregates)"
+        let message1 = [1_u8, 2, 3, 40];
+        let message2 = [5_u8, 6, 70, 201];
+        let message3 = [9_u8, 10, 11, 12, 13];
+        let message4 = [15_u8, 63, 244, 92, 0, 1];
+
+        let sk1 = SecretKey::from_seed(&[2_u8; 32]);
+        let sk2 = SecretKey::from_seed(&[3_u8; 32]);
+
+        let pk1 = sk1.public_key();
+        let pk2 = sk2.public_key();
+
+        let sig1 = sign(&sk1, message1);
+        let sig2 = sign(&sk2, message2);
+        let sig3 = sign(&sk2, message1);
+        let sig4 = sign(&sk1, message3);
+        let sig5 = sign(&sk1, message1);
+        let sig6 = sign(&sk1, message4);
+
+        let agg_sig_l = aggregate([sig1, sig2]);
+        let agg_sig_r = aggregate([sig3, sig4, sig5]);
+        let aggsig = aggregate([agg_sig_l, agg_sig_r, sig6]);
+
+        assert!(aggregate_verify(
+            &aggsig,
+            [
+                (&pk1, &message1 as &[u8]),
+                (&pk2, &message2),
+                (&pk2, &message1),
+                (&pk1, &message3),
+                (&pk1, &message1),
+                (&pk1, &message4)
+            ]
+        ));
+
+        assert_eq!(
+            aggsig.to_bytes(),
+            <[u8; 96]>::from_hex(
+                "a1d5360dcb418d33b29b90b912b4accde535cf0e52caf467a005dc632d9f7af44b6c4e9acd4\
             6eac218b28cdb07a3e3bc087df1cd1e3213aa4e11322a3ff3847bbba0b2fd19ddc25ca964871\
             997b9bceeab37a4c2565876da19382ea32a962200"
-        )
-        .unwrap()
-    );
-}
-
-#[test]
-fn test_signature_zero_key() {
-    // test case from: bls-signatures/src/test.cpp
-    // "Should sign with the zero key"
-    let sk = SecretKey::from_bytes(&[0; 32]).unwrap();
-    assert_eq!(sign(&sk, [1_u8, 2, 3]), Signature::default());
-}
-
-#[test]
-fn test_aggregate_many_g2_elements_diff_message() {
-    // test case from: bls-signatures/src/test.cpp
-    // "Should Aug aggregate many G2Elements, diff message"
-
-    let mut rng = StdRng::seed_from_u64(1337);
-
-    let mut pairs = Vec::<(PublicKey, Vec<u8>)>::new();
-    let mut sigs = Vec::<Signature>::new();
-
-    for i in 0..80 {
-        let message = vec![0_u8, 100, 2, 45, 64, 12, 12, 63, i];
-        let sk = random_sk(&mut rng);
-        let sig = sign(&sk, &message);
-        pairs.push((sk.public_key(), message));
-        sigs.push(sig);
+            )
+            .unwrap()
+        );
     }
 
-    let aggsig = aggregate(sigs);
-
-    assert!(aggregate_verify(&aggsig, pairs));
-}
-
-#[test]
-fn test_aggregate_identity() {
-    // test case from: bls-signatures/src/test.cpp
-    // "Aggregate Verification of zero items with infinity should pass"
-    let sig = Signature::default();
-    let aggsig = aggregate([&sig]);
-    assert_eq!(aggsig, sig);
-    assert_eq!(aggsig, Signature::default());
-
-    assert!(aggregate_verify(&aggsig, [] as [(&PublicKey, &[u8]); 0]));
-}
-
-#[test]
-fn test_aggregate_multiple_levels_degenerate() {
-    // test case from: bls-signatures/src/test.cpp
-    // "Should aggregate with multiple levels, degenerate"
-
-    let mut rng = StdRng::seed_from_u64(1337);
-
-    let message1 = [100_u8, 2, 254, 88, 90, 45, 23];
-    let sk1 = random_sk(&mut rng);
-    let pk1 = sk1.public_key();
-    let mut agg_sig = sign(&sk1, message1);
-    let mut pairs: Vec<(PublicKey, &[u8])> = vec![(pk1, &message1)];
-
-    for _i in 0..10 {
-        let sk = random_sk(&mut rng);
-        let pk = sk.public_key();
-        pairs.push((pk, &message1));
-        let sig = sign(&sk, message1);
-        agg_sig.aggregate(&sig);
-    }
-    assert!(aggregate_verify(&agg_sig, pairs));
-}
-
-#[test]
-fn test_aggregate_multiple_levels_different_messages() {
-    // test case from: bls-signatures/src/test.cpp
-    // "Should aggregate with multiple levels, different messages"
-
-    let mut rng = StdRng::seed_from_u64(1337);
-
-    let message1 = [100_u8, 2, 254, 88, 90, 45, 23];
-    let message2 = [192_u8, 29, 2, 0, 0, 45, 23];
-    let message3 = [52_u8, 29, 2, 0, 0, 45, 102];
-    let message4 = [99_u8, 29, 2, 0, 0, 45, 222];
-
-    let sk1 = random_sk(&mut rng);
-    let sk2 = random_sk(&mut rng);
-
-    let pk1 = sk1.public_key();
-    let pk2 = sk2.public_key();
-
-    let sig1 = sign(&sk1, message1);
-    let sig2 = sign(&sk2, message2);
-    let sig3 = sign(&sk2, message3);
-    let sig4 = sign(&sk1, message4);
-
-    let agg_sig_l = aggregate([sig1, sig2]);
-    let agg_sig_r = aggregate([sig3, sig4]);
-    let agg_sig = aggregate([agg_sig_l, agg_sig_r]);
-
-    let all_pairs: [(&PublicKey, &[u8]); 4] = [
-        (&pk1, &message1),
-        (&pk2, &message2),
-        (&pk2, &message3),
-        (&pk1, &message4),
-    ];
-    assert!(aggregate_verify(&agg_sig, all_pairs));
-}
-
-#[test]
-fn test_aug_scheme() {
-    // test case from: bls-signatures/src/test.cpp
-    // "Aug Scheme"
-
-    let msg1 = [7_u8, 8, 9];
-    let msg2 = [10_u8, 11, 12];
-
-    let sk1 = SecretKey::from_seed(&[4_u8; 32]);
-    let pk1 = sk1.public_key();
-    let pk1v = pk1.to_bytes();
-    let sig1 = sign(&sk1, msg1);
-    let sig1v = sig1.to_bytes();
-
-    assert!(verify(&sig1, &pk1, msg1));
-    assert!(verify(
-        &Signature::from_bytes(&sig1v).unwrap(),
-        &PublicKey::from_bytes(&pk1v).unwrap(),
-        msg1
-    ));
-
-    let sk2 = SecretKey::from_seed(&[5_u8; 32]);
-    let pk2 = sk2.public_key();
-    let pk2v = pk2.to_bytes();
-    let sig2 = sign(&sk2, msg2);
-    let sig2v = sig2.to_bytes();
-
-    assert!(verify(&sig2, &pk2, msg2));
-    assert!(verify(
-        &Signature::from_bytes(&sig2v).unwrap(),
-        &PublicKey::from_bytes(&pk2v).unwrap(),
-        msg2
-    ));
-
-    // Wrong G2Element
-    assert!(!verify(&sig2, &pk1, msg1));
-    assert!(!verify(
-        &Signature::from_bytes(&sig2v).unwrap(),
-        &PublicKey::from_bytes(&pk1v).unwrap(),
-        msg1
-    ));
-    // Wrong msg
-    assert!(!verify(&sig1, &pk1, msg2));
-    assert!(!verify(
-        &Signature::from_bytes(&sig1v).unwrap(),
-        &PublicKey::from_bytes(&pk1v).unwrap(),
-        msg2
-    ));
-    // Wrong pk
-    assert!(!verify(&sig1, &pk2, msg1));
-    assert!(!verify(
-        &Signature::from_bytes(&sig1v).unwrap(),
-        &PublicKey::from_bytes(&pk2v).unwrap(),
-        msg1
-    ));
-
-    let aggsig = aggregate([sig1, sig2]);
-    let aggsigv = aggsig.to_bytes();
-    let pairs: [(&PublicKey, &[u8]); 2] = [(&pk1, &msg1), (&pk2, &msg2)];
-    assert!(aggregate_verify(&aggsig, pairs));
-    assert!(aggregate_verify(
-        &Signature::from_bytes(&aggsigv).unwrap(),
-        pairs
-    ));
-}
-
-#[test]
-fn test_hash() {
-    fn hash<T: std::hash::Hash>(v: T) -> u64 {
-        use std::collections::hash_map::DefaultHasher;
-        let mut h = DefaultHasher::new();
-        v.hash(&mut h);
-        h.finish()
+    #[test]
+    fn test_signature_zero_key() {
+        // test case from: bls-signatures/src/test.cpp
+        // "Should sign with the zero key"
+        let sk = SecretKey::from_bytes(&[0; 32]).unwrap();
+        assert_eq!(sign(&sk, [1_u8, 2, 3]), Signature::default());
     }
 
-    let mut rng = StdRng::seed_from_u64(1337);
-    let mut data = [0u8; 32];
-    rng.fill(data.as_mut_slice());
-    let sk = SecretKey::from_seed(&data);
-    let sig1 = sign(&sk, &[0, 1, 2]);
-    let sig2 = sign(&sk, &[0, 1, 2, 3]);
+    #[test]
+    fn test_aggregate_many_g2_elements_diff_message() {
+        // test case from: bls-signatures/src/test.cpp
+        // "Should Aug aggregate many G2Elements, diff message"
 
-    assert!(hash(sig1) != hash(sig2));
-    assert_eq!(hash(sign(&sk, &[0, 1, 2])), hash(sign(&sk, &[0, 1, 2])));
-}
+        let mut rng = StdRng::seed_from_u64(1337);
 
-#[test]
-fn test_debug() {
-    let mut data = [0u8; 96];
-    data[0] = 0xc0;
-    let sig = Signature::from_bytes(&data).unwrap();
-    assert_eq!(format!("{:?}", sig), hex::encode(data));
-}
+        let mut pairs = Vec::<(PublicKey, Vec<u8>)>::new();
+        let mut sigs = Vec::<Signature>::new();
 
-#[test]
-fn test_to_from_clvm() {
-    let mut a = Allocator::new();
-    let bytes = hex::decode("b45825c0ee7759945c0189b4c38b7e54231ebadc83a851bec3bb7cf954a124ae0cc8e8e5146558332ea152f63bf8846e04826185ef60e817f271f8d500126561319203f9acb95809ed20c193757233454be1562a5870570941a84605bd2c9c9a").expect("hex::decode()");
-    let ptr = a.new_atom(&bytes).expect("new_atom");
+        for i in 0..80 {
+            let message = vec![0_u8, 100, 2, 45, 64, 12, 12, 63, i];
+            let sk = random_sk(&mut rng);
+            let sig = sign(&sk, &message);
+            pairs.push((sk.public_key(), message));
+            sigs.push(sig);
+        }
 
-    let sig = Signature::from_clvm(&a, ptr).expect("from_clvm");
-    assert_eq!(&sig.to_bytes()[..], &bytes[..]);
+        let aggsig = aggregate(sigs);
 
-    let sig_ptr = sig.to_clvm(&mut a).expect("to_clvm");
-    assert!(a.atom_eq(sig_ptr, ptr));
-}
+        assert!(aggregate_verify(&aggsig, pairs));
+    }
 
-#[test]
-fn test_from_clvm_failure() {
-    let mut a = Allocator::new();
-    let ptr = a.new_pair(a.one(), a.one()).expect("new_pair");
-    assert_eq!(
-        Signature::from_clvm(&a, ptr).unwrap_err(),
-        clvm_traits::Error::ExpectedAtom(ptr)
-    );
+    #[test]
+    fn test_aggregate_identity() {
+        // test case from: bls-signatures/src/test.cpp
+        // "Aggregate Verification of zero items with infinity should pass"
+        let sig = Signature::default();
+        let aggsig = aggregate([&sig]);
+        assert_eq!(aggsig, sig);
+        assert_eq!(aggsig, Signature::default());
+
+        assert!(aggregate_verify(&aggsig, [] as [(&PublicKey, &[u8]); 0]));
+    }
+
+    #[test]
+    fn test_aggregate_multiple_levels_degenerate() {
+        // test case from: bls-signatures/src/test.cpp
+        // "Should aggregate with multiple levels, degenerate"
+
+        let mut rng = StdRng::seed_from_u64(1337);
+
+        let message1 = [100_u8, 2, 254, 88, 90, 45, 23];
+        let sk1 = random_sk(&mut rng);
+        let pk1 = sk1.public_key();
+        let mut agg_sig = sign(&sk1, message1);
+        let mut pairs: Vec<(PublicKey, &[u8])> = vec![(pk1, &message1)];
+
+        for _i in 0..10 {
+            let sk = random_sk(&mut rng);
+            let pk = sk.public_key();
+            pairs.push((pk, &message1));
+            let sig = sign(&sk, message1);
+            agg_sig.aggregate(&sig);
+        }
+        assert!(aggregate_verify(&agg_sig, pairs));
+    }
+
+    #[test]
+    fn test_aggregate_multiple_levels_different_messages() {
+        // test case from: bls-signatures/src/test.cpp
+        // "Should aggregate with multiple levels, different messages"
+
+        let mut rng = StdRng::seed_from_u64(1337);
+
+        let message1 = [100_u8, 2, 254, 88, 90, 45, 23];
+        let message2 = [192_u8, 29, 2, 0, 0, 45, 23];
+        let message3 = [52_u8, 29, 2, 0, 0, 45, 102];
+        let message4 = [99_u8, 29, 2, 0, 0, 45, 222];
+
+        let sk1 = random_sk(&mut rng);
+        let sk2 = random_sk(&mut rng);
+
+        let pk1 = sk1.public_key();
+        let pk2 = sk2.public_key();
+
+        let sig1 = sign(&sk1, message1);
+        let sig2 = sign(&sk2, message2);
+        let sig3 = sign(&sk2, message3);
+        let sig4 = sign(&sk1, message4);
+
+        let agg_sig_l = aggregate([sig1, sig2]);
+        let agg_sig_r = aggregate([sig3, sig4]);
+        let agg_sig = aggregate([agg_sig_l, agg_sig_r]);
+
+        let all_pairs: [(&PublicKey, &[u8]); 4] = [
+            (&pk1, &message1),
+            (&pk2, &message2),
+            (&pk2, &message3),
+            (&pk1, &message4),
+        ];
+        assert!(aggregate_verify(&agg_sig, all_pairs));
+    }
+
+    #[test]
+    fn test_aug_scheme() {
+        // test case from: bls-signatures/src/test.cpp
+        // "Aug Scheme"
+
+        let msg1 = [7_u8, 8, 9];
+        let msg2 = [10_u8, 11, 12];
+
+        let sk1 = SecretKey::from_seed(&[4_u8; 32]);
+        let pk1 = sk1.public_key();
+        let pk1v = pk1.to_bytes();
+        let sig1 = sign(&sk1, msg1);
+        let sig1v = sig1.to_bytes();
+
+        assert!(verify(&sig1, &pk1, msg1));
+        assert!(verify(
+            &Signature::from_bytes(&sig1v).unwrap(),
+            &PublicKey::from_bytes(&pk1v).unwrap(),
+            msg1
+        ));
+
+        let sk2 = SecretKey::from_seed(&[5_u8; 32]);
+        let pk2 = sk2.public_key();
+        let pk2v = pk2.to_bytes();
+        let sig2 = sign(&sk2, msg2);
+        let sig2v = sig2.to_bytes();
+
+        assert!(verify(&sig2, &pk2, msg2));
+        assert!(verify(
+            &Signature::from_bytes(&sig2v).unwrap(),
+            &PublicKey::from_bytes(&pk2v).unwrap(),
+            msg2
+        ));
+
+        // Wrong G2Element
+        assert!(!verify(&sig2, &pk1, msg1));
+        assert!(!verify(
+            &Signature::from_bytes(&sig2v).unwrap(),
+            &PublicKey::from_bytes(&pk1v).unwrap(),
+            msg1
+        ));
+        // Wrong msg
+        assert!(!verify(&sig1, &pk1, msg2));
+        assert!(!verify(
+            &Signature::from_bytes(&sig1v).unwrap(),
+            &PublicKey::from_bytes(&pk1v).unwrap(),
+            msg2
+        ));
+        // Wrong pk
+        assert!(!verify(&sig1, &pk2, msg1));
+        assert!(!verify(
+            &Signature::from_bytes(&sig1v).unwrap(),
+            &PublicKey::from_bytes(&pk2v).unwrap(),
+            msg1
+        ));
+
+        let aggsig = aggregate([sig1, sig2]);
+        let aggsigv = aggsig.to_bytes();
+        let pairs: [(&PublicKey, &[u8]); 2] = [(&pk1, &msg1), (&pk2, &msg2)];
+        assert!(aggregate_verify(&aggsig, pairs));
+        assert!(aggregate_verify(
+            &Signature::from_bytes(&aggsigv).unwrap(),
+            pairs
+        ));
+    }
+
+    #[test]
+    fn test_hash() {
+        fn hash<T: std::hash::Hash>(v: T) -> u64 {
+            use std::collections::hash_map::DefaultHasher;
+            let mut h = DefaultHasher::new();
+            v.hash(&mut h);
+            h.finish()
+        }
+
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        rng.fill(data.as_mut_slice());
+        let sk = SecretKey::from_seed(&data);
+        let sig1 = sign(&sk, &[0, 1, 2]);
+        let sig2 = sign(&sk, &[0, 1, 2, 3]);
+
+        assert!(hash(sig1) != hash(sig2));
+        assert_eq!(hash(sign(&sk, &[0, 1, 2])), hash(sign(&sk, &[0, 1, 2])));
+    }
+
+    #[test]
+    fn test_debug() {
+        let mut data = [0u8; 96];
+        data[0] = 0xc0;
+        let sig = Signature::from_bytes(&data).unwrap();
+        assert_eq!(format!("{:?}", sig), hex::encode(data));
+    }
+
+    #[test]
+    fn test_to_from_clvm() {
+        let mut a = Allocator::new();
+        let bytes = hex::decode("b45825c0ee7759945c0189b4c38b7e54231ebadc83a851bec3bb7cf954a124ae0cc8e8e5146558332ea152f63bf8846e04826185ef60e817f271f8d500126561319203f9acb95809ed20c193757233454be1562a5870570941a84605bd2c9c9a").expect("hex::decode()");
+        let ptr = a.new_atom(&bytes).expect("new_atom");
+
+        let sig = Signature::from_clvm(&a, ptr).expect("from_clvm");
+        assert_eq!(&sig.to_bytes()[..], &bytes[..]);
+
+        let sig_ptr = sig.to_clvm(&mut a).expect("to_clvm");
+        assert!(a.atom_eq(sig_ptr, ptr));
+    }
+
+    #[test]
+    fn test_from_clvm_failure() {
+        let mut a = Allocator::new();
+        let ptr = a.new_pair(a.one(), a.one()).expect("new_pair");
+        assert_eq!(
+            Signature::from_clvm(&a, ptr).unwrap_err(),
+            clvm_traits::Error::ExpectedAtom(ptr)
+        );
+    }
 }
 
 #[cfg(test)]
 #[cfg(feature = "py-bindings")]
 mod pytests {
-
     use super::*;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
     use rstest::rstest;
+
+    #[test]
+    fn test_generator() {
+        assert_eq!(
+        hex::encode(&Signature::generator().to_bytes()),
+        "93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
+    );
+    }
 
     #[test]
     fn test_json_dict_roundtrip() {

--- a/chia-bls/src/signature.rs
+++ b/chia-bls/src/signature.rs
@@ -31,7 +31,7 @@ pub const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_";
     pyclass(name = "G2Element"),
     derive(PyStreamable)
 )]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Signature(pub(crate) blst_p2);
 
 impl Signature {
@@ -92,15 +92,6 @@ impl Signature {
             ans.assume_init()
         };
         GTElement(ans)
-    }
-}
-
-impl Default for Signature {
-    fn default() -> Self {
-        unsafe {
-            let p2 = MaybeUninit::<blst_p2>::zeroed();
-            Self(p2.assume_init())
-        }
     }
 }
 

--- a/chia-bls/src/signature.rs
+++ b/chia-bls/src/signature.rs
@@ -944,13 +944,11 @@ mod pytests {
             rng.fill(msg.as_mut_slice());
             let sk = SecretKey::from_seed(&data);
             let sig = sign(&sk, msg);
-            let ret = Python::with_gil(|py| -> PyResult<()> {
-                let string = sig.to_json_dict(py)?;
+            Python::with_gil(|py| {
+                let string = sig.to_json_dict(py).expect("to_json_dict");
                 let sig2 = Signature::from_json_dict(string.as_ref(py)).unwrap();
                 assert_eq!(sig, sig2);
-                Ok(())
             });
-            assert!(ret.is_ok())
         }
     }
 
@@ -962,12 +960,10 @@ mod pytests {
     #[case("00r102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0ff000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f", "invalid hex")]
     fn test_json_dict(#[case] input: &str, #[case] msg: &str) {
         pyo3::prepare_freethreaded_python();
-        let ret = Python::with_gil(|py| -> PyResult<()> {
+        Python::with_gil(|py| {
             let err =
                 Signature::from_json_dict(input.to_string().into_py(py).as_ref(py)).unwrap_err();
             assert_eq!(err.value(py).to_string(), msg.to_string());
-            Ok(())
         });
-        assert!(ret.is_ok())
     }
 }


### PR DESCRIPTION
Simplifies a few tests and derives the `Default` trait instead of implementing it manually.

The last 3 commits move tests into their own `mod` to make them a bit less verbose. These are best reviewed ignoring white space changes, since their indentation level changed.