### PR TITLE
more BLS operations

### DIFF
--- a/chia-bls/src/lib.rs
+++ b/chia-bls/src/lib.rs
@@ -10,9 +10,12 @@ pub mod signature;
 pub use derivable_key::DerivableKey;
 pub use error::{Error, Result};
 pub use gtelement::GTElement;
-pub use public_key::PublicKey;
+pub use public_key::{hash_to_g1, hash_to_g1_with_dst, PublicKey};
 pub use secret_key::SecretKey;
-pub use signature::{aggregate, aggregate_verify, hash_to_g2, sign, sign_raw, verify, Signature};
+pub use signature::{
+    aggregate, aggregate_pairing, aggregate_verify, hash_to_g2, hash_to_g2_with_dst, sign,
+    sign_raw, verify, Signature,
+};
 
 pub type G1Element = PublicKey;
 pub type G2Element = Signature;

--- a/chia-bls/src/public_key.rs
+++ b/chia-bls/src/public_key.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::io::Cursor;
 use std::mem::MaybeUninit;
-use std::ops::{Add, AddAssign, SubAssign};
+use std::ops::{Add, AddAssign, Neg, SubAssign};
 
 #[cfg(feature = "py-bindings")]
 use crate::{GTElement, Signature};
@@ -221,6 +221,23 @@ impl Streamable for PublicKey {
 impl Hash for PublicKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         state.write(&self.to_bytes())
+    }
+}
+
+impl Neg for PublicKey {
+    type Output = PublicKey;
+    fn neg(mut self) -> Self::Output {
+        self.negate();
+        self
+    }
+}
+
+impl Neg for &PublicKey {
+    type Output = PublicKey;
+    fn neg(self) -> Self::Output {
+        let mut ret = self.clone();
+        ret.negate();
+        ret
     }
 }
 

--- a/chia-bls/src/public_key.rs
+++ b/chia-bls/src/public_key.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::io::Cursor;
 use std::mem::MaybeUninit;
-use std::ops::{Add, AddAssign};
+use std::ops::{Add, AddAssign, SubAssign};
 
 #[cfg(feature = "py-bindings")]
 use crate::{GTElement, Signature};
@@ -65,6 +65,30 @@ impl PublicKey {
         Ok(Self(p1))
     }
 
+    pub fn generator() -> Self {
+        let p1 = unsafe { *blst_p1_generator() };
+        Self(p1)
+    }
+
+    // Creates a G1 point by multiplying the generator by the specified scalar.
+    // This is the same as creating a private key from the scalar, and then get
+    // the corresponding public key
+    pub fn from_integer(int_bytes: &[u8]) -> Self {
+        let p1 = unsafe {
+            let mut scalar = MaybeUninit::<blst_scalar>::uninit();
+            blst_scalar_from_be_bytes(scalar.as_mut_ptr(), int_bytes.as_ptr(), int_bytes.len());
+            let mut p1 = MaybeUninit::<blst_p1>::uninit();
+            blst_p1_mult(
+                p1.as_mut_ptr(),
+                blst_p1_generator(),
+                scalar.as_ptr() as *const u8,
+                256,
+            );
+            p1.assume_init()
+        };
+        Self(p1)
+    }
+
     pub fn from_bytes(bytes: &[u8; 48]) -> Result<Self> {
         let ret = Self::from_bytes_unchecked(bytes)?;
         if !ret.is_valid() {
@@ -72,6 +96,20 @@ impl PublicKey {
         } else {
             Ok(ret)
         }
+    }
+
+    pub fn from_uncompressed(buf: &[u8; 96]) -> Result<Self> {
+        let p1 = unsafe {
+            let mut p1_affine = MaybeUninit::<blst_p1_affine>::uninit();
+            let ret = blst_p1_deserialize(p1_affine.as_mut_ptr(), buf as *const u8);
+            if ret != BLST_ERROR::BLST_SUCCESS {
+                return Err(Error::InvalidSignature(ret));
+            }
+            let mut p1 = MaybeUninit::<blst_p1>::uninit();
+            blst_p1_from_affine(p1.as_mut_ptr(), &p1_affine.assume_init());
+            p1.assume_init()
+        };
+        Ok(Self(p1))
     }
 
     pub fn to_bytes(&self) -> [u8; 48] {
@@ -86,6 +124,20 @@ impl PublicKey {
         // Infinity was considered a valid G1Element in older Relic versions
         // For historical compatibililty this behavior is maintained.
         unsafe { blst_p1_is_inf(&self.0) || blst_p1_in_g1(&self.0) }
+    }
+
+    pub fn negate(&mut self) {
+        unsafe {
+            blst_p1_cneg(&mut self.0, true);
+        }
+    }
+
+    pub fn scalar_multiply(&mut self, int_bytes: &[u8]) {
+        unsafe {
+            let mut scalar = MaybeUninit::<blst_scalar>::uninit();
+            blst_scalar_from_be_bytes(scalar.as_mut_ptr(), int_bytes.as_ptr(), int_bytes.len());
+            blst_p1_mult(&mut self.0, &self.0, scalar.as_ptr() as *const u8, 256);
+        }
     }
 
     pub fn get_fingerprint(&self) -> u32 {
@@ -114,8 +166,9 @@ impl PublicKey {
     }
 
     #[staticmethod]
-    pub fn generator() -> Self {
-        unsafe { Self(*blst_p1_generator()) }
+    #[pyo3(name = "generator")]
+    pub fn py_generator() -> Self {
+        Self::generator()
     }
 
     pub fn pair(&self, other: &Signature) -> GTElement {
@@ -175,6 +228,16 @@ impl AddAssign<&PublicKey> for PublicKey {
     fn add_assign(&mut self, rhs: &PublicKey) {
         unsafe {
             blst_p1_add_or_double(&mut self.0, &self.0, &rhs.0);
+        }
+    }
+}
+
+impl SubAssign<&PublicKey> for PublicKey {
+    fn sub_assign(&mut self, rhs: &PublicKey) {
+        unsafe {
+            let mut neg = rhs.clone();
+            blst_p1_cneg(&mut neg.0, true);
+            blst_p1_add_or_double(&mut self.0, &self.0, &neg.0);
         }
     }
 }
@@ -296,6 +359,29 @@ impl ToClvm for PublicKey {
     fn to_clvm(&self, a: &mut Allocator) -> clvm_traits::Result<NodePtr> {
         Ok(a.new_atom(&self.to_bytes())?)
     }
+}
+
+pub const DST: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_AUG_";
+
+pub fn hash_to_g1(msg: &[u8]) -> PublicKey {
+    hash_to_g1_with_dst(msg, DST)
+}
+
+pub fn hash_to_g1_with_dst(msg: &[u8], dst: &[u8]) -> PublicKey {
+    let p1 = unsafe {
+        let mut p1 = MaybeUninit::<blst_p1>::uninit();
+        blst_hash_to_g1(
+            p1.as_mut_ptr(),
+            msg.as_ptr(),
+            msg.len(),
+            dst.as_ptr(),
+            dst.len(),
+            std::ptr::null(),
+            0,
+        );
+        p1.assume_init()
+    };
+    PublicKey(p1)
 }
 
 #[cfg(test)]
@@ -493,6 +579,145 @@ mod tests {
             clvm_traits::Error::ExpectedAtom(ptr)
         );
     }
+
+    #[test]
+    fn test_generator() {
+        assert_eq!(
+            hex::encode(&PublicKey::generator().to_bytes()),
+            "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"
+        );
+    }
+
+    #[test]
+    fn test_from_integer() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        for _i in 0..50 {
+            // this integer may not exceed the group order, so leave the top
+            // byte as 0
+            rng.fill(&mut data[1..]);
+
+            let g1 = PublicKey::from_integer(&data);
+            let expected_g1 = SecretKey::from_bytes(&data)
+                .expect("invalid public key")
+                .public_key();
+            assert_eq!(g1, expected_g1);
+        }
+    }
+
+    // test cases from zksnark test in chia_rs
+    #[rstest]
+    #[case("06f6ba2972ab1c83718d747b2d55cca96d08729b1ea5a3ab3479b8efe2d455885abf65f58d1507d7f260cd2a4687db821171c9d8dc5c0f5c3c4fd64b26cf93ff28b2e683c409fb374c4e26cc548c6f7cef891e60b55e6115bb38bbe97822e4d4", "a6f6ba2972ab1c83718d747b2d55cca96d08729b1ea5a3ab3479b8efe2d455885abf65f58d1507d7f260cd2a4687db82")]
+    #[case("127271e81a1cb5c08a68694fcd5bd52f475d545edd4fbd49b9f6ec402ee1973f9f4102bf3bfccdcbf1b2f862af89a1340d40795c1c09d1e10b1acfa0f3a97a71bf29c11665743fa8d30e57e450b8762959571d6f6d253b236931b93cf634e7cf", "b27271e81a1cb5c08a68694fcd5bd52f475d545edd4fbd49b9f6ec402ee1973f9f4102bf3bfccdcbf1b2f862af89a134")]
+    #[case("0fe94ac2d68d39d9207ea0cae4bb2177f7352bd754173ed27bd13b4c156f77f8885458886ee9fbd212719f27a96397c110fa7b4f898b1c45c2e82c5d46b52bdad95cae8299d4fd4556ae02baf20a5ec989fc62f28c8b6b3df6dc696f2afb6e20", "afe94ac2d68d39d9207ea0cae4bb2177f7352bd754173ed27bd13b4c156f77f8885458886ee9fbd212719f27a96397c1")]
+    #[case("13aedc305adfdbc854aa105c41085618484858e6baa276b176fd89415021f7a0c75ff4f9ec39f482f142f1b54c11144815e519df6f71b1db46c83b1d2bdf381fc974059f3ccd87ed5259221dc37c50c3be407b58990d14b6d5bb79dad9ab8c42", "b3aedc305adfdbc854aa105c41085618484858e6baa276b176fd89415021f7a0c75ff4f9ec39f482f142f1b54c111448")]
+    fn test_from_uncompressed(#[case] input: &str, #[case] expect: &str) {
+        let input = hex::decode(input).unwrap();
+        let g1 = PublicKey::from_uncompressed(input.as_slice().try_into().unwrap()).unwrap();
+        let compressed = g1.to_bytes();
+        assert_eq!(hex::encode(compressed), expect);
+    }
+
+    #[test]
+    fn test_negate_roundtrip() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        for _i in 0..50 {
+            // this integer may not exceed the group order, so leave the top
+            // byte as 0
+            rng.fill(&mut data[1..]);
+
+            let g1 = PublicKey::from_integer(&data);
+            let mut g1_neg = g1.clone();
+            g1_neg.negate();
+            assert!(g1_neg != g1);
+
+            g1_neg.negate();
+            assert!(g1_neg == g1);
+        }
+    }
+
+    #[test]
+    fn test_negate_infinity() {
+        let g1 = PublicKey::default();
+        let mut g1_neg = g1.clone();
+        // negate on infinity is a no-op
+        g1_neg.negate();
+        assert!(g1_neg == g1);
+    }
+
+    #[test]
+    fn test_negate() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        for _i in 0..50 {
+            // this integer may not exceed the group order, so leave the top
+            // byte as 0
+            rng.fill(&mut data[1..]);
+
+            let g1 = PublicKey::from_integer(&data);
+            let mut g1_neg = g1.clone();
+            g1_neg.negate();
+
+            let mut g1_double = g1.clone();
+            // adding the negative undoes adding the positive
+            g1_double += &g1;
+            assert!(g1_double != g1);
+            g1_double += &g1_neg;
+            assert!(g1_double == g1);
+        }
+    }
+
+    #[test]
+    fn test_scalar_multiply() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        for _i in 0..50 {
+            // this integer may not exceed the group order, so leave the top
+            // byte as 0
+            rng.fill(&mut data[1..]);
+
+            let mut g1 = PublicKey::from_integer(&data);
+            let mut g1_double = g1.clone();
+            g1_double += &g1;
+            assert!(g1_double != g1);
+            // scalar multiply by 2 is the same as adding oneself
+            g1.scalar_multiply(&[2]);
+            assert!(g1_double == g1);
+        }
+    }
+
+    #[test]
+    fn test_hash_to_g1_different_dst() {
+        const DEFAULT_DST: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_AUG_";
+        const CUSTOM_DST: &[u8] = b"foobar";
+
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut msg = [0u8; 32];
+        for _i in 0..50 {
+            rng.fill(&mut msg);
+            let default_hash = hash_to_g1(&msg);
+            assert_eq!(default_hash, hash_to_g1_with_dst(&msg, DEFAULT_DST));
+            assert!(default_hash != hash_to_g1_with_dst(&msg, CUSTOM_DST));
+        }
+    }
+
+    // test cases from clvm_rs
+    #[rstest]
+    #[case("abcdef0123456789", "88e7302bf1fa8fcdecfb96f6b81475c3564d3bcaf552ccb338b1c48b9ba18ab7195c5067fe94fb216478188c0a3bef4a")]
+    fn test_hash_to_g1(#[case] input: &str, #[case] expect: &str) {
+        let g1 = hash_to_g1(input.as_bytes());
+        assert_eq!(hex::encode(g1.to_bytes()), expect);
+    }
+
+    // test cases from clvm_rs
+    #[rstest]
+    #[case("abcdef0123456789", "BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_", "8dd8e3a9197ddefdc25dde980d219004d6aa130d1af9b1808f8b2b004ae94484ac62a08a739ec7843388019a79c437b0")]
+    #[case("abcdef0123456789", "BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_AUG_", "88e7302bf1fa8fcdecfb96f6b81475c3564d3bcaf552ccb338b1c48b9ba18ab7195c5067fe94fb216478188c0a3bef4a")]
+    fn test_hash_to_g1_with_dst(#[case] input: &str, #[case] dst: &str, #[case] expect: &str) {
+        let g1 = hash_to_g1_with_dst(input.as_bytes(), dst.as_bytes());
+        assert_eq!(hex::encode(g1.to_bytes()), expect);
+    }
 }
 
 #[cfg(test)]
@@ -503,14 +728,6 @@ mod pytests {
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
     use rstest::rstest;
-
-    #[test]
-    fn test_generator() {
-        assert_eq!(
-            hex::encode(&PublicKey::generator().to_bytes()),
-            "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"
-        );
-    }
 
     #[test]
     fn test_json_dict_roundtrip() {

--- a/chia-bls/src/signature.rs
+++ b/chia-bls/src/signature.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::io::Cursor;
 use std::mem::MaybeUninit;
-use std::ops::{Add, AddAssign};
+use std::ops::{Add, AddAssign, SubAssign};
 
 #[cfg(feature = "py-bindings")]
 use crate::public_key::parse_hex_string;
@@ -58,12 +58,30 @@ impl Signature {
         }
     }
 
+    pub fn from_uncompressed(buf: &[u8; 192]) -> Result<Self> {
+        let p2 = unsafe {
+            let mut p2_affine = MaybeUninit::<blst_p2_affine>::uninit();
+            let ret = blst_p2_deserialize(p2_affine.as_mut_ptr(), buf as *const u8);
+            if ret != BLST_ERROR::BLST_SUCCESS {
+                return Err(Error::InvalidSignature(ret));
+            }
+            let mut p2 = MaybeUninit::<blst_p2>::uninit();
+            blst_p2_from_affine(p2.as_mut_ptr(), &p2_affine.assume_init());
+            p2.assume_init()
+        };
+        Ok(Self(p2))
+    }
+
     pub fn to_bytes(&self) -> [u8; 96] {
         unsafe {
             let mut bytes = MaybeUninit::<[u8; 96]>::uninit();
             blst_p2_compress(bytes.as_mut_ptr() as *mut u8, &self.0);
             bytes.assume_init()
         }
+    }
+
+    pub fn generator() -> Self {
+        unsafe { Self(*blst_p2_generator()) }
     }
 
     pub fn aggregate(&mut self, sig: &Signature) {
@@ -76,6 +94,20 @@ impl Signature {
         // Infinity was considered a valid G2Element in older Relic versions
         // For historical compatibililty this behavior is maintained.
         unsafe { blst_p2_is_inf(&self.0) || blst_p2_in_g2(&self.0) }
+    }
+
+    pub fn negate(&mut self) {
+        unsafe {
+            blst_p2_cneg(&mut self.0, true);
+        }
+    }
+
+    pub fn scalar_multiply(&mut self, int_bytes: &[u8]) {
+        unsafe {
+            let mut scalar = MaybeUninit::<blst_scalar>::uninit();
+            blst_scalar_from_be_bytes(scalar.as_mut_ptr(), int_bytes.as_ptr(), int_bytes.len());
+            blst_p2_mult(&mut self.0, &self.0, scalar.as_ptr() as *const u8, 256);
+        }
     }
 
     pub fn pair(&self, other: &PublicKey) -> GTElement {
@@ -135,6 +167,16 @@ impl AddAssign<&Signature> for Signature {
     fn add_assign(&mut self, rhs: &Signature) {
         unsafe {
             blst_p2_add_or_double(&mut self.0, &self.0, &rhs.0);
+        }
+    }
+}
+
+impl SubAssign<&Signature> for Signature {
+    fn sub_assign(&mut self, rhs: &Signature) {
+        unsafe {
+            let mut neg = rhs.clone();
+            blst_p2_cneg(&mut neg.0, true);
+            blst_p2_add_or_double(&mut self.0, &self.0, &neg.0);
         }
     }
 }
@@ -226,8 +268,9 @@ impl Signature {
     }
 
     #[staticmethod]
-    pub fn generator() -> Self {
-        unsafe { Self(*blst_p2_generator()) }
+    #[pyo3(name = "generator")]
+    pub fn py_generator() -> Self {
+        Self::generator()
     }
 
     pub fn __repr__(&self) -> String {
@@ -244,15 +287,71 @@ impl Signature {
     }
 }
 
+pub fn aggregate_pairing<G1: Borrow<PublicKey>, G2: Borrow<Signature>, I>(data: I) -> bool
+where
+    I: IntoIterator<Item = (G1, G2)>,
+{
+    let mut data = data.into_iter().peekable();
+    if data.peek().is_none() {
+        return true;
+    }
+
+    let mut v: Vec<u64> = vec![0; unsafe { blst_pairing_sizeof() } / 8];
+    let ctx = unsafe {
+        let ctx = v.as_mut_slice().as_mut_ptr() as *mut blst_pairing;
+        blst_pairing_init(
+            ctx,
+            true, // hash
+            DST.as_ptr(),
+            DST.len(),
+        );
+        ctx
+    };
+
+    for (g1, g2) in data {
+        if !g1.borrow().is_valid() {
+            return false;
+        }
+        if !g2.borrow().is_valid() {
+            return false;
+        }
+
+        let g1_affine = unsafe {
+            let mut g1_affine = MaybeUninit::<blst_p1_affine>::uninit();
+            blst_p1_to_affine(g1_affine.as_mut_ptr(), &g1.borrow().0);
+            g1_affine.assume_init()
+        };
+
+        let g2_affine = unsafe {
+            let mut g2_affine = MaybeUninit::<blst_p2_affine>::uninit();
+            blst_p2_to_affine(g2_affine.as_mut_ptr(), &g2.borrow().0);
+            g2_affine.assume_init()
+        };
+
+        unsafe {
+            blst_pairing_raw_aggregate(ctx, &g2_affine, &g1_affine);
+        }
+    }
+
+    unsafe {
+        blst_pairing_commit(ctx);
+        blst_pairing_finalverify(ctx, std::ptr::null())
+    }
+}
+
 pub fn hash_to_g2(msg: &[u8]) -> Signature {
+    hash_to_g2_with_dst(msg, DST)
+}
+
+pub fn hash_to_g2_with_dst(msg: &[u8], dst: &[u8]) -> Signature {
     let p2 = unsafe {
         let mut p2 = MaybeUninit::<blst_p2>::uninit();
         blst_hash_to_g2(
             p2.as_mut_ptr(),
             msg.as_ptr(),
             msg.len(),
-            DST.as_ptr(),
-            DST.len(),
+            dst.as_ptr(),
+            dst.len(),
             std::ptr::null(),
             0,
         );
@@ -408,6 +507,7 @@ mod tests {
     use hex::FromHex;
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
+    use rstest::rstest;
 
     #[test]
     fn test_from_bytes() {
@@ -907,6 +1007,128 @@ mod tests {
             clvm_traits::Error::ExpectedAtom(ptr)
         );
     }
+
+    #[test]
+    fn test_generator() {
+        assert_eq!(
+        hex::encode(&Signature::generator().to_bytes()),
+        "93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
+        );
+    }
+
+    // test cases from zksnark test in chia_rs
+    #[rstest]
+    #[case("0a7ecb9c6d6f0af8d922c9b348d686f7f827c5f5d7a53036e5dd6c4cfe088806375d730251df57c03b0eaa41ca2a9cc51817cfd6118c065e9b337e42a6b66621e2ffa79f576ae57dcb4916459b0131d42383b790a4f60c5aeb339b61a78d85a808b73e0701084dc16b5d7aa8c2f5385f83a217bc29934d0d02c51365410232e3c0288438e3110aa6e8cdef7bd32c46d60d0104952aaa0f0545cbe1548b70eed8b543ce19ede34cc51a387d092221417db0253f4651666b17303e225eac706107", "8a7ecb9c6d6f0af8d922c9b348d686f7f827c5f5d7a53036e5dd6c4cfe088806375d730251df57c03b0eaa41ca2a9cc51817cfd6118c065e9b337e42a6b66621e2ffa79f576ae57dcb4916459b0131d42383b790a4f60c5aeb339b61a78d85a8")]
+    #[case("13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb80606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801", "93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8")]
+    #[case("140acf170629d78244fb753f05fb79578add9217add53996d5de7c3005880c0dea903f851d6be749ebfb81c9721871370ef60428444d76f4ff81515628a4eb63e72c3cd7651a23c4eca109d1d88fec5a53626b36c76407926f308366b5ded1b219a481d87c6f87a4021fa8aa32851874f01b3eb011f6ed69c7884717fb0f5239bdc7310c2bc287659cd4a93976deaac20f4a21f0b004c767be4a21f36861616a5399b3e27431dc8133f325603230eaf1debdce8077105ab46baafa4836842305", "b40acf170629d78244fb753f05fb79578add9217add53996d5de7c3005880c0dea903f851d6be749ebfb81c9721871370ef60428444d76f4ff81515628a4eb63e72c3cd7651a23c4eca109d1d88fec5a53626b36c76407926f308366b5ded1b2")]
+    fn test_from_uncompressed(#[case] input: &str, #[case] expect: &str) {
+        let input = hex::decode(input).unwrap();
+        let g2 = Signature::from_uncompressed(input.as_slice().try_into().unwrap()).unwrap();
+        let compressed = g2.to_bytes();
+        assert_eq!(hex::encode(compressed), expect);
+    }
+
+    #[test]
+    fn test_negate_roundtrip() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        let mut msg = [0u8; 32];
+        rng.fill(msg.as_mut_slice());
+        for _i in 0..50 {
+            rng.fill(data.as_mut_slice());
+            let sk = SecretKey::from_seed(&data);
+            let g2 = sign(&sk, msg);
+
+            let mut g2_neg = g2.clone();
+            g2_neg.negate();
+            assert!(g2_neg != g2);
+
+            g2_neg.negate();
+            assert!(g2_neg == g2);
+        }
+    }
+
+    #[test]
+    fn test_negate_infinity() {
+        let g2 = Signature::default();
+        let mut g2_neg = g2.clone();
+        // negate on infinity is a no-op
+        g2_neg.negate();
+        assert!(g2_neg == g2);
+    }
+
+    #[test]
+    fn test_negate() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        let mut msg = [0u8; 32];
+        rng.fill(msg.as_mut_slice());
+        for _i in 0..50 {
+            rng.fill(data.as_mut_slice());
+            let sk = SecretKey::from_seed(&data);
+            let g2 = sign(&sk, msg);
+            let mut g2_neg = g2.clone();
+            g2_neg.negate();
+
+            let mut g2_double = g2.clone();
+            // adding the negative undoes adding the positive
+            g2_double += &g2;
+            assert!(g2_double != g2);
+            g2_double += &g2_neg;
+            assert!(g2_double == g2);
+        }
+    }
+
+    #[test]
+    fn test_scalar_multiply() {
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut data = [0u8; 32];
+        let mut msg = [0u8; 32];
+        rng.fill(msg.as_mut_slice());
+        for _i in 0..50 {
+            rng.fill(data.as_mut_slice());
+            let sk = SecretKey::from_seed(&data);
+            let mut g2 = sign(&sk, msg);
+            let mut g2_double = g2.clone();
+            g2_double += &g2;
+            assert!(g2_double != g2);
+            // scalar multiply by 2 is the same as adding oneself
+            g2.scalar_multiply(&[2]);
+            assert!(g2_double == g2);
+        }
+    }
+
+    #[test]
+    fn test_hash_to_g2_different_dst() {
+        const DEFAULT_DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_";
+        const CUSTOM_DST: &[u8] = b"foobar";
+
+        let mut rng = StdRng::seed_from_u64(1337);
+        let mut msg = [0u8; 32];
+        for _i in 0..50 {
+            rng.fill(&mut msg);
+            let default_hash = hash_to_g2(&msg);
+            assert_eq!(default_hash, hash_to_g2_with_dst(&msg, DEFAULT_DST));
+            assert!(default_hash != hash_to_g2_with_dst(&msg, CUSTOM_DST));
+        }
+    }
+
+    // test cases from clvm_rs
+    #[rstest]
+    #[case("abcdef0123456789", "92596412844e12c4733b5a6bfc5727cde4c20b345665d2de99de163266f3ba6a944c6c0fdd9d9fe57b9a4acb769bf3780456f8aab4cd41a70836dba57a5278a85fbd18eb96a2b56cfbda853186c9d190c43e63bc3e6a181aed692e97bbdb1944")]
+    fn test_hash_to_g2(#[case] input: &str, #[case] expect: &str) {
+        let g2 = hash_to_g2(input.as_bytes());
+        assert_eq!(hex::encode(g2.to_bytes()), expect);
+    }
+
+    // test cases from clvm_rs
+    #[rstest]
+    #[case("abcdef0123456789", "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_", "8ee1ff66094b8975401c86ad424076d97fed9c2025db5f9dfde6ed455c7bff34b55e96379c1f9ee3c173633587f425e50aed3e807c6c7cd7bed35d40542eee99891955b2ea5321ebde37172e2c01155138494c2d725b03c02765828679bf011e")]
+    #[case("abcdef0123456789", "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_", "92596412844e12c4733b5a6bfc5727cde4c20b345665d2de99de163266f3ba6a944c6c0fdd9d9fe57b9a4acb769bf3780456f8aab4cd41a70836dba57a5278a85fbd18eb96a2b56cfbda853186c9d190c43e63bc3e6a181aed692e97bbdb1944")]
+    fn test_hash_to_g2_with_dst(#[case] input: &str, #[case] dst: &str, #[case] expect: &str) {
+        let g2 = hash_to_g2_with_dst(input.as_bytes(), dst.as_bytes());
+        assert_eq!(hex::encode(g2.to_bytes()), expect);
+    }
 }
 
 #[cfg(test)]
@@ -916,14 +1138,6 @@ mod pytests {
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
     use rstest::rstest;
-
-    #[test]
-    fn test_generator() {
-        assert_eq!(
-        hex::encode(&Signature::generator().to_bytes()),
-        "93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
-    );
-    }
 
     #[test]
     fn test_json_dict_roundtrip() {


### PR DESCRIPTION
add negate, scalar_multiply, hash_to_g1, from_integer to point types as well as hash_to_g2.

These operations are sufficient to make `clvm_rs` use this crate instead of `bls12_381`