### PR TITLE
fix bug in enforcing nil-termination of new AGG_SIG_* conditions

### DIFF
--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia_rs"
-version = "0.2.10"
+version = "0.2.11"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
This fixes a bug when parsing the new `AGG_SIG_*` conditions in mempool mode.
The affected conditions are:

1. `AGG_SIG_PARENT`
2. `AGG_SIG_PUZZLE`
3. `AGG_SIG_AMOUNT`
4. `AGG_SIG_PUZZLE_AMOUNT`
5. `AGG_SIG_PARENT_PUZZLE`
6. `AGG_SIG_PARENT_AMOUNT`

In mempool mode, we require the exact correct number of arguments to be passed to conditions. Whereas in consensus mode we're more forgiving, to allow for soft-forks. The test for an NIL-terminator was incorrect and always looked at the last *cons* cell, not the last item in the list. This made this test fail unconditionally.

The bulk of this change is to extend the tests to cover this case.

The original feature landed here: https://github.com/Chia-Network/chia_rs/pull/213

This PR is targeting a new branch called `release-0.2.11` which was cut off of the most recent `0.2.10` release, to avoid pulling in any other changes for this release.