### PR TITLE
update chia-bls crate to prepare for publishing to crates.io

### DIFF
--- a/.github/workflows/build-crate-and-npm.yml
+++ b/.github/workflows/build-crate-and-npm.yml
@@ -71,6 +71,15 @@ jobs:
         cd chia_py_streamable_macro
         cargo publish
 
+    - name: publish to crates.io if tagged (chia_streamable_macro)
+      continue-on-error: true
+      if: startsWith(github.event.ref, 'refs/tags')
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.cargo_registry_token }}
+      run: |
+        cd chia_streamable_macro
+        cargo publish
+
     - name: publish to crates.io if tagged (clvm-utils)
       continue-on-error: true
       if: startsWith(github.event.ref, 'refs/tags')
@@ -78,6 +87,33 @@ jobs:
         CARGO_REGISTRY_TOKEN: ${{ secrets.cargo_registry_token }}
       run: |
         cd clvm-utils
+        cargo publish
+
+    - name: publish to crates.io if tagged (chia-traits)
+      continue-on-error: true
+      if: startsWith(github.event.ref, 'refs/tags')
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.cargo_registry_token }}
+      run: |
+        cd chia-traits
+        cargo publish
+
+    - name: publish to crates.io if tagged (clvm-traits)
+      continue-on-error: true
+      if: startsWith(github.event.ref, 'refs/tags')
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.cargo_registry_token }}
+      run: |
+        cd clvm-traits
+        cargo publish
+
+    - name: publish to crates.io if tagged (chia-bls)
+      continue-on-error: true
+      if: startsWith(github.event.ref, 'refs/tags')
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.cargo_registry_token }}
+      run: |
+        cd chia-bls
         cargo publish
 
     - name: publish to crates.io if tagged (chia-protocol)

--- a/chia-bls/Cargo.toml
+++ b/chia-bls/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/Chia-Network/chia_rs/chia-bls/"
 py-bindings = ["dep:pyo3", "chia_py_streamable_macro", "chia-traits/py-bindings"]
 
 [dependencies]
-chia-traits = { path = "../chia-traits" }
-clvm-traits = { path = "../clvm-traits" }
+chia-traits = { version = "0.1.0", path = "../chia-traits" }
+clvm-traits = { version = "0.1.0", path = "../clvm-traits", features = ["derive"] }
 tiny-bip39 = "1.0.0"
 anyhow = "1.0.71"
 # the newer sha2 crate doesn't implement the digest traits required by hkdf
@@ -23,7 +23,7 @@ blst = "0.3.10"
 clvmr = "=0.3.0"
 hex = "0.4.3"
 thiserror = "1.0.44"
-pyo3 = { version = "0.19.0", features = ["multiple-pymethods"], optional = true }
+pyo3 = { version = ">=0.19.0", features = ["multiple-pymethods"], optional = true }
 chia_py_streamable_macro = { version = "0.1.3", path = "../chia_py_streamable_macro", optional = true }
 
 [dev-dependencies]

--- a/chia-protocol/Cargo.toml
+++ b/chia-protocol/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/Chia-Network/chia_rs/chia-protocol/"
 py-bindings = ["dep:pyo3", "dep:chia_py_streamable_macro", "chia-traits/py-bindings"]
 
 [dependencies]
-pyo3 = { version = "0.19.0", features = ["multiple-pymethods"], optional = true }
+pyo3 = { version = ">=0.19.0", features = ["multiple-pymethods"], optional = true }
 sha2 = "0.9.9"
 hex = "0.4.3"
 chia_streamable_macro = { version = "0.2.4", path = "../chia_streamable_macro" }

--- a/chia-traits/Cargo.toml
+++ b/chia-traits/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 py-bindings = ["dep:pyo3", "dep:chia_py_streamable_macro"]
 
 [dependencies]
-pyo3 = { version = "0.19.0", features = ["multiple-pymethods"], optional = true }
+pyo3 = { version = ">=0.19.0", features = ["multiple-pymethods"], optional = true }
 chia_py_streamable_macro = { version = "0.1.3", path = "../chia_py_streamable_macro", optional = true }
 chia_streamable_macro = { version = "0.2.4", path = "../chia_streamable_macro" }
 clvmr = "0.3.0"


### PR DESCRIPTION
this patch updates the github workflow to publish more of our crates when we tag a release. The order matters, because some crates depend on others.

In order to be publishable, we need versions for all dependencies, including the ones we build from the local repo. That's the main fix to `chia-bls`, to enable it to be published.