### PR TITLE
include fuzzers in workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chia-bls-fuzz"
+version = "0.0.0"
+dependencies = [
+ "chia-bls",
+ "libfuzzer-sys",
+ "pyo3",
+]
+
+[[package]]
 name = "chia-client"
 version = "0.1.0"
 dependencies = [
@@ -309,6 +318,15 @@ dependencies = [
  "pyo3",
  "rstest 0.17.0",
  "sha2 0.9.9",
+]
+
+[[package]]
+name = "chia-protocol-fuzz"
+version = "0.0.0"
+dependencies = [
+ "chia-protocol",
+ "chia-traits",
+ "libfuzzer-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,10 @@
 [workspace]
 members = [
     "chia-bls",
+    "chia-bls/fuzz",
     "chia-client",
     "chia-protocol",
+    "chia-protocol/fuzz",
     "chia_py_streamable_macro",
     "chia_streamable_macro",
     "chia-tools",

--- a/chia-bls/fuzz/Cargo.toml
+++ b/chia-bls/fuzz/Cargo.toml
@@ -15,18 +15,16 @@ pyo3 = { version = ">=0.19.0", features = ["auto-initialize"]}
 [dependencies.chia-bls]
 path = ".."
 
-# Prevent this from interfering with workspaces
-[workspace]
-members = ["."]
-
 [[bin]]
 name = "derive"
 path = "fuzz_targets/derive.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "blspy-fidelity"
 path = "fuzz_targets/blspy-fidelity.rs"
 test = false
 doc = false
+bench = false

--- a/chia-bls/fuzz/fuzz_targets/derive.rs
+++ b/chia-bls/fuzz/fuzz_targets/derive.rs
@@ -1,10 +1,10 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use chia_bls::secret_key::SecretKey;
-use chia_bls::public_key::PublicKey;
-use chia_bls::signature::{sign, verify};
 use chia_bls::derivable_key::DerivableKey;
+use chia_bls::public_key::PublicKey;
+use chia_bls::secret_key::SecretKey;
+use chia_bls::signature::{sign, verify};
 
 fuzz_target!(|data: &[u8]| {
     if data.len() < 32 {
@@ -28,5 +28,4 @@ fuzz_target!(|data: &[u8]| {
 
     let sig = sign(&sk1, b"foobar");
     assert!(verify(&sig, &pk1, b"foobar"));
-
 });

--- a/chia-bls/src/public_key.rs
+++ b/chia-bls/src/public_key.rs
@@ -604,7 +604,7 @@ mod tests {
     #[test]
     fn test_generator() {
         assert_eq!(
-            hex::encode(&PublicKey::generator().to_bytes()),
+            hex::encode(PublicKey::generator().to_bytes()),
             "97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"
         );
     }

--- a/chia-bls/src/signature.rs
+++ b/chia-bls/src/signature.rs
@@ -711,7 +711,7 @@ mod tests {
         for _idx in 0..2 {
             let pk = sk.public_key();
             data.push((pk.clone(), msg));
-            agg.aggregate(&sign(&sk, msg.clone()));
+            agg.aggregate(&sign(&sk, *msg));
 
             pairs.push((pk.clone(), aug_msg_to_g2(&pk, msg)));
         }
@@ -1035,11 +1035,11 @@ mod tests {
         let mut data = [0u8; 32];
         rng.fill(data.as_mut_slice());
         let sk = SecretKey::from_seed(&data);
-        let sig1 = sign(&sk, &[0, 1, 2]);
-        let sig2 = sign(&sk, &[0, 1, 2, 3]);
+        let sig1 = sign(&sk, [0, 1, 2]);
+        let sig2 = sign(&sk, [0, 1, 2, 3]);
 
         assert!(hash(sig1) != hash(sig2));
-        assert_eq!(hash(sign(&sk, &[0, 1, 2])), hash(sign(&sk, &[0, 1, 2])));
+        assert_eq!(hash(sign(&sk, [0, 1, 2])), hash(sign(&sk, [0, 1, 2])));
     }
 
     #[test]
@@ -1076,7 +1076,7 @@ mod tests {
     #[test]
     fn test_generator() {
         assert_eq!(
-        hex::encode(&Signature::generator().to_bytes()),
+        hex::encode(Signature::generator().to_bytes()),
         "93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
         );
     }

--- a/chia-protocol/fuzz/Cargo.toml
+++ b/chia-protocol/fuzz/Cargo.toml
@@ -15,36 +15,37 @@ chia-traits = { path = "../../chia-traits" }
 [dependencies.chia-protocol]
 path = ".."
 
-# Prevent this from interfering with workspaces
-[workspace]
-members = ["."]
-
 [[bin]]
 name = "parse-full-block"
 path = "fuzz_targets/parse-full-block.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "parse-header-block"
 path = "fuzz_targets/parse-header-block.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "parse-foliage"
 path = "fuzz_targets/parse-foliage.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "parse-tx-info"
 path = "fuzz_targets/parse-tx-info.rs"
 test = false
 doc = false
+bench = false
 
 [[bin]]
 name = "parse-program"
 path = "fuzz_targets/parse-program.rs"
 test = false
 doc = false
+bench = false

--- a/chia-protocol/fuzz/fuzz_targets/parse-foliage.rs
+++ b/chia-protocol/fuzz/fuzz_targets/parse-foliage.rs
@@ -1,8 +1,8 @@
 #![no_main]
-use libfuzzer_sys::fuzz_target;
-use std::io::Cursor;
 use chia_protocol::Foliage;
 use chia_traits::Streamable;
+use libfuzzer_sys::fuzz_target;
+use std::io::Cursor;
 
 fuzz_target!(|data: &[u8]| {
     let _ret = <Foliage as Streamable>::parse(&mut Cursor::<&[u8]>::new(data));

--- a/chia-protocol/fuzz/fuzz_targets/parse-full-block.rs
+++ b/chia-protocol/fuzz/fuzz_targets/parse-full-block.rs
@@ -1,8 +1,8 @@
 #![no_main]
-use libfuzzer_sys::fuzz_target;
-use std::io::Cursor;
 use chia_protocol::FullBlock;
 use chia_traits::Streamable;
+use libfuzzer_sys::fuzz_target;
+use std::io::Cursor;
 
 fuzz_target!(|data: &[u8]| {
     let _ret = <FullBlock as Streamable>::parse(&mut Cursor::<&[u8]>::new(data));

--- a/chia-protocol/fuzz/fuzz_targets/parse-header-block.rs
+++ b/chia-protocol/fuzz/fuzz_targets/parse-header-block.rs
@@ -1,8 +1,8 @@
 #![no_main]
-use libfuzzer_sys::fuzz_target;
-use std::io::Cursor;
 use chia_protocol::HeaderBlock;
 use chia_traits::Streamable;
+use libfuzzer_sys::fuzz_target;
+use std::io::Cursor;
 
 fuzz_target!(|data: &[u8]| {
     let _ret = <HeaderBlock as Streamable>::parse(&mut Cursor::<&[u8]>::new(data));

--- a/chia-protocol/fuzz/fuzz_targets/parse-program.rs
+++ b/chia-protocol/fuzz/fuzz_targets/parse-program.rs
@@ -1,8 +1,8 @@
 #![no_main]
-use libfuzzer_sys::fuzz_target;
-use std::io::Cursor;
 use chia_protocol::Program;
 use chia_traits::Streamable;
+use libfuzzer_sys::fuzz_target;
+use std::io::Cursor;
 
 fuzz_target!(|data: &[u8]| {
     let _ret = <Program as Streamable>::parse(&mut Cursor::<&[u8]>::new(data));

--- a/chia-protocol/fuzz/fuzz_targets/parse-tx-info.rs
+++ b/chia-protocol/fuzz/fuzz_targets/parse-tx-info.rs
@@ -1,8 +1,8 @@
 #![no_main]
-use libfuzzer_sys::fuzz_target;
-use std::io::Cursor;
 use chia_protocol::TransactionsInfo;
 use chia_traits::Streamable;
+use libfuzzer_sys::fuzz_target;
+use std::io::Cursor;
 
 fuzz_target!(|data: &[u8]| {
     let _ret = <TransactionsInfo as Streamable>::parse(&mut Cursor::<&[u8]>::new(data));

--- a/clvm-traits/src/to_clvm.rs
+++ b/clvm-traits/src/to_clvm.rs
@@ -157,9 +157,9 @@ mod tests {
     #[test]
     fn test_reference() {
         let a = &mut Allocator::new();
-        assert_eq!(encode(a, &[1, 2, 3]), encode(a, [1, 2, 3]));
-        assert_eq!(encode(a, &Some(42)), encode(a, Some(42)));
-        assert_eq!(encode(a, &Some(&42)), encode(a, Some(42)));
+        assert_eq!(encode(a, [1, 2, 3]), encode(a, [1, 2, 3]));
+        assert_eq!(encode(a, Some(42)), encode(a, Some(42)));
+        assert_eq!(encode(a, Some(&42)), encode(a, Some(42)));
         assert_eq!(encode(a, Some(&42)), encode(a, Some(42)));
     }
 


### PR DESCRIPTION
this makes them covered by `cargo clippy --workspace`.

As a result, some new `clippy` issues are exposed and fixed