### PR TITLE
tool to bump crate versions

### DIFF
--- a/bump-version.py
+++ b/bump-version.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# usage:
+# bump-version <new-version-string> <previous-release-tag>
+
+import os
+import re
+import sys
+from typing import Callable, Set
+
+v = sys.argv[1]
+tag = sys.argv[2]
+
+our_crates = [
+    "chia-bls",
+    "clvm-traits",
+    "chia-traits",
+    "chia_py_streamable_macro",
+    "chia_streamable_macro",
+    "chia-protocol",
+    "chia-tools",
+    "clvm-utils",
+    "clvm-derive",
+    "chia-wallet",
+    "chia-client"
+]
+
+def crates_with_changes() -> Set[str]:
+    ret = set()
+    for c in our_crates:
+        diff = os.popen(f"git diff {tag} -- {c}").read().strip()
+        if len(diff) > 0:
+            ret.add(c)
+    return ret
+
+def update_cargo(name: str, crates: Set[str]) -> None:
+    subst = ""
+    with open(f"{name}/Cargo.toml") as f:
+        for line in f:
+            split = line.split()
+            if split == []:
+                subst += line
+                continue
+
+            if split[0] == "version" and name in crates:
+                line = f'version = "{v}"\n'
+            elif split[0] in crates:
+                line = re.sub('version = "(>?=?)\d\.\d\.\d"', f'version = "\\g<1>{v}"', line)
+            subst += line
+
+    with open(f"{name}/Cargo.toml", "w") as f:
+        f.write(subst)
+
+
+crates = crates_with_changes()
+# always update the root crate (chia)
+crates.add(".")
+crates.add("chia")
+
+print("bumping version of crates:")
+for c in crates:
+    print(f" - {c}")
+
+for c in our_crates:
+    update_cargo(c, crates)
+
+update_cargo(".", crates)
+update_cargo("wheel", crates)

--- a/chia-tools/Cargo.toml
+++ b/chia-tools/Cargo.toml
@@ -9,12 +9,12 @@ homepage = "https://github.com/Chia-Network/chia_rs/chia-tools"
 repository = "https://github.com/Chia-Network/chia_rs/chia-tools"
 
 [dependencies]
-chia-protocol = { version = "=0.2.7", path = "../chia-protocol" }
+chia-protocol = { version = "0.2.7", path = "../chia-protocol" }
 chia-traits = { path = "../chia-traits" }
 clvm-utils = { path = "../clvm-utils" }
 clvm-traits = { path = "../clvm-traits" }
 clvmr = { version = "=0.3.0", features = ["counters"] }
-chia = { version = "=0.2.9", path = ".." }
+chia = { version = "0.2.9", path = ".." }
 sqlite = "=0.31.0"
 clap = { version = "=4.3.9", features = ["derive"] }
 zstd = "=0.12.3"

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -18,9 +18,9 @@ path = "src/lib.rs"
 clvmr = "=0.3.0"
 hex = "=0.4.3"
 pyo3 = { version = "=0.19.0", features = ["extension-module", "multiple-pymethods"] }
-chia = { path = "..", features = ["py-bindings"] }
-chia-bls = { path = "../chia-bls", features = ["py-bindings"]  }
-chia-protocol = { path = "../chia-protocol", features = ["py-bindings"]  }
-chia-traits = { path = "../chia-traits", features = ["py-bindings"]  }
-chia_py_streamable_macro = { path = "../chia_py_streamable_macro" }
-chia_streamable_macro = { path = "../chia_streamable_macro" }
+chia = { version = "=0.2.9", path = "..", features = ["py-bindings"] }
+chia-bls = { version = "=0.2.7", path = "../chia-bls", features = ["py-bindings"]  }
+chia-protocol = { version = "=0.2.7", path = "../chia-protocol", features = ["py-bindings"]  }
+chia-traits = { version = "=0.1.0", path = "../chia-traits", features = ["py-bindings"]  }
+chia_py_streamable_macro = { version = "=0.1.4", path = "../chia_py_streamable_macro" }
+chia_streamable_macro = { version = "=0.2.4", path = "../chia_streamable_macro" }


### PR DESCRIPTION
This tool checks each crate for changes since the last release tag (as specified on the command line). Any crate that has had changes has its version updated to the latest version (also specified on the command line).

All internal dependencies of crates are update to match this version.

This is meant to simplify and make releases less error prone.