### PR TITLE
bump blst dependency, and build it in portable mode

### DIFF
--- a/chia-bls/Cargo.toml
+++ b/chia-bls/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0.71"
 # the newer sha2 crate doesn't implement the digest traits required by hkdf
 sha2 = "0.9.9"
 hkdf = "0.11.0"
-blst = "0.3.10"
+blst = { version = "0.3.11", features = ["portable"] }
 clvmr = "=0.3.0"
 hex = "0.4.3"
 thiserror = "1.0.44"


### PR DESCRIPTION
`blspy` builds it in portable mode, and not being portable is likely what's causing CI in chia-blockchain to fail with `SIGILL`.

https://github.com/Chia-Network/bls-signatures/blob/main/src/CMakeLists.txt#L47