### PR TITLE
make `from_bytes()` accept python's buffer API

### DIFF
--- a/tests/test_streamable.py
+++ b/tests/test_streamable.py
@@ -395,6 +395,10 @@ def test_program() -> None:
     assert str(p) == "Program(ff8080)"
     assert p.to_bytes() == bytes.fromhex("ff8080")
 
+    # make sure we can pass in a slice/memoryview
+    p = Program.from_bytes(bytes.fromhex("00ff8080")[1:])
+    assert str(p) == "Program(ff8080)"
+
     # truncated serialization
     with pytest.raises(ValueError, match="unexpected end of buffer"):
         Program.from_bytes(bytes.fromhex("ff80"))


### PR DESCRIPTION
otherwise it's not possible to directly pass in a slice of a `bytes` object. i.e. `.from_bytes(b[1:])`. It would have to be copied into a new `bytes` object first, i.e. `.from_bytes(bytes(b[1:]))`