### PR TITLE
`from_bytes()` fix

### DIFF
--- a/chia-traits/src/streamable.rs
+++ b/chia-traits/src/streamable.rs
@@ -47,7 +47,13 @@ pub trait Streamable {
     where
         Self: Sized,
     {
-        Self::parse(&mut Cursor::new(bytes))
+        let mut cursor = Cursor::new(bytes);
+        let ret = Self::parse(&mut cursor)?;
+        if cursor.position() != bytes.len() as u64 {
+            Err(Error::InputTooLarge)
+        } else {
+            Ok(ret)
+        }
     }
     fn hash(&self) -> [u8; 32] {
         let mut ctx = Sha256::new();

--- a/chia_py_streamable_macro/src/lib.rs
+++ b/chia_py_streamable_macro/src/lib.rs
@@ -150,8 +150,7 @@ pub fn py_streamable_macro(input: proc_macro::TokenStream) -> proc_macro::TokenS
                 let slice = unsafe {
                     std::slice::from_raw_parts(blob.buf_ptr() as *const u8, blob.len_bytes())
                 };
-                let mut input = std::io::Cursor::<&[u8]>::new(slice);
-                <Self as #crate_name::Streamable>::parse(&mut input).map_err(|e| <#crate_name::chia_error::Error as Into<pyo3::PyErr>>::into(e))
+                <Self as #crate_name::Streamable>::from_bytes(slice).map_err(|e| <#crate_name::chia_error::Error as Into<pyo3::PyErr>>::into(e))
             }
 
             // returns the type as well as the number of bytes read from the buffer


### PR DESCRIPTION
It requires the input be an exact match, no extra bytes at the end. This is to make it behave the same as `from_bytes()` in `chia-blockchain`