### PR TITLE
publish `chia-wallet` crate

### DIFF
--- a/.github/workflows/build-crate-and-npm.yml
+++ b/.github/workflows/build-crate-and-npm.yml
@@ -134,6 +134,15 @@ jobs:
         cd chia-protocol
         cargo publish
 
+    - name: publish to crates.io if tagged (chia-wallet)
+      continue-on-error: true
+      if: startsWith(github.event.ref, 'refs/tags')
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.cargo_registry_token }}
+      run: |
+        cd chia-wallet
+        cargo publish
+
     - name: publish to crates.io if tagged (chia_rs)
       continue-on-error: true
       if: startsWith(github.event.ref, 'refs/tags')


### PR DESCRIPTION
the root crate (chia_rs) depends on chia-wallet, so it needs to be published before we can publish chia_rs.

It's meant to address this error: https://github.com/Chia-Network/chia_rs/actions/runs/6695380930/job/18190836509#step:21:14