### PR TITLE
relax versions of dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
  "pyo3",
  "rand",
  "rstest 0.17.0",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
  "tiny-bip39",
 ]
@@ -373,7 +373,7 @@ dependencies = [
  "hex",
  "pyo3",
  "rstest 0.17.0",
- "sha2 0.9.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -385,7 +385,7 @@ dependencies = [
  "chia-traits",
  "hex",
  "libfuzzer-sys",
- "sha2 0.9.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -428,7 +428,7 @@ dependencies = [
  "chia_streamable_macro",
  "hex",
  "pyo3",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "thiserror",
 ]
 
@@ -730,16 +730,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -1113,22 +1103,11 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hkdf"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
 dependencies = [
- "digest 0.9.0",
- "hmac 0.11.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
+ "hmac",
 ]
 
 [[package]]
@@ -1243,7 +1222,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "signature",
 ]
 
@@ -1476,7 +1455,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1837,7 +1816,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
 ]
 
@@ -2121,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2360,12 +2339,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
 dependencies = [
  "anyhow",
- "hmac 0.12.1",
+ "hmac",
  "once_cell",
  "pbkdf2",
  "rand",
  "rustc-hash",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "thiserror",
  "unicode-normalization",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ py-bindings = ["dep:pyo3"]
 
 [dependencies]
 clvmr = "=0.3.0"
-hex = "=0.4.3"
+hex = "0.4.3"
 pyo3 = { version = ">=0.19.0", optional = true }
 clvm-utils = { version = "=0.2.12", path = "clvm-utils" }
 chia-traits = { version = "=0.2.13", path = "chia-traits" }
@@ -45,7 +45,7 @@ clvm-traits = { version = "=0.2.12", path = "clvm-traits" }
 clvm-derive = { version = "=0.2.12", path = "clvm-derive" }
 chia-protocol = { version = "=0.2.13", path = "chia-protocol" }
 chia-wallet = { version = "=0.2.12", path = "chia-wallet" }
-hex-literal = "=0.4.1"
+hex-literal = "0.4.1"
 thiserror = "1.0.44"
 
 [dev-dependencies]

--- a/chia-bls/Cargo.toml
+++ b/chia-bls/Cargo.toml
@@ -12,25 +12,24 @@ repository = "https://github.com/Chia-Network/chia_rs/chia-bls/"
 py-bindings = ["dep:pyo3", "chia_py_streamable_macro", "chia-traits/py-bindings"]
 
 [dependencies]
-chia-traits = { version = "0.2.13", path = "../chia-traits" }
-clvm-traits = { version = "0.2.12", path = "../clvm-traits", features = ["derive"] }
+chia-traits = { version = "=0.2.13", path = "../chia-traits" }
+clvm-traits = { version = "=0.2.12", path = "../clvm-traits", features = ["derive"] }
+chia_py_streamable_macro = { version = "=0.2.13", path = "../chia_py_streamable_macro", optional = true }
 tiny-bip39 = "1.0.0"
 anyhow = "1.0.71"
-# the newer sha2 crate doesn't implement the digest traits required by hkdf
-sha2 = "0.9.9"
-hkdf = "0.11.0"
+sha2 = "0.10.8"
+hkdf = "0.12.0"
 blst = { version = "0.3.11", features = ["portable"] }
 clvmr = "=0.3.0"
 hex = "0.4.3"
 thiserror = "1.0.44"
-pyo3 = { version = ">=0.19.0", features = ["multiple-pymethods"], optional = true }
-chia_py_streamable_macro = { version = "0.2.13", path = "../chia_py_streamable_macro", optional = true }
-arbitrary = { version = "=1.3.0" }
+pyo3 = { version = "0.19.0", features = ["multiple-pymethods"], optional = true }
+arbitrary = { version = "1.3.0" }
 
 [dev-dependencies]
 rand = "0.8.5"
 criterion = "0.5.1"
-rstest = "=0.17.0"
+rstest = "0.17.0"
 
 [lib]
 crate-type = ["rlib"]

--- a/chia-protocol/Cargo.toml
+++ b/chia-protocol/Cargo.toml
@@ -12,16 +12,16 @@ repository = "https://github.com/Chia-Network/chia_rs/chia-protocol/"
 py-bindings = ["dep:pyo3", "dep:chia_py_streamable_macro", "chia-traits/py-bindings"]
 
 [dependencies]
-pyo3 = { version = ">=0.19.0", features = ["multiple-pymethods"], optional = true }
-sha2 = "0.9.9"
+pyo3 = { version = "0.19.0", features = ["multiple-pymethods"], optional = true }
+sha2 = "0.10.8"
 hex = "0.4.3"
-chia_streamable_macro = { version = "0.2.12", path = "../chia_streamable_macro" }
-chia_py_streamable_macro = { version = "0.2.13", path = "../chia_py_streamable_macro", optional = true }
-clvmr = "0.3.0"
-chia-traits = { version = "0.2.13", path = "../chia-traits" }
-clvm-traits = { version = "0.2.12", path = "../clvm-traits", features = ["derive"] }
+chia_streamable_macro = { version = "=0.2.12", path = "../chia_streamable_macro" }
+chia_py_streamable_macro = { version = "=0.2.13", path = "../chia_py_streamable_macro", optional = true }
+clvmr = "=0.3.0"
+chia-traits = { version = "=0.2.13", path = "../chia-traits" }
+clvm-traits = { version = "=0.2.12", path = "../clvm-traits", features = ["derive"] }
 chia-bls = { version = "0.2.13", path = "../chia-bls" }
-arbitrary = { version = "=1.3.0", features = ["derive"] }
+arbitrary = { version = "1.3.0", features = ["derive"] }
 
 [dev-dependencies]
 rstest = "0.17.0"

--- a/chia-protocol/fuzz/Cargo.toml
+++ b/chia-protocol/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 chia-traits = { path = "../../chia-traits" }
 arbitrary = { version = "=1.3.0" }
-sha2 = "0.9.9"
+sha2 = "0.10.8"
 hex = "0.4.3"
 
 [dependencies.chia-protocol]

--- a/chia-traits/Cargo.toml
+++ b/chia-traits/Cargo.toml
@@ -10,9 +10,9 @@ authors = ["Arvid Norberg <arvid@chia.net>"]
 py-bindings = ["dep:pyo3", "dep:chia_py_streamable_macro"]
 
 [dependencies]
-pyo3 = { version = ">=0.19.0", features = ["multiple-pymethods"], optional = true }
-chia_py_streamable_macro = { version = "0.2.13", path = "../chia_py_streamable_macro", optional = true }
-chia_streamable_macro = { version = "0.2.12", path = "../chia_streamable_macro" }
-sha2 = "0.9.9"
-hex = "=0.4.3"
+pyo3 = { version = "0.19.0", features = ["multiple-pymethods"], optional = true }
+chia_py_streamable_macro = { version = "=0.2.13", path = "../chia_py_streamable_macro", optional = true }
+chia_streamable_macro = { version = "=0.2.12", path = "../chia_streamable_macro" }
+sha2 = "0.10.8"
+hex = "0.4.3"
 thiserror = "1.0.44"

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 clvmr = "=0.3.0"
-hex = "=0.4.3"
+hex = "0.4.3"
 pyo3 = { version = "=0.19.0", features = ["extension-module", "multiple-pymethods"] }
 chia = { version = "=0.2.13", path = "..", features = ["py-bindings"] }
 chia-bls = { version = "=0.2.13", path = "../chia-bls", features = ["py-bindings"]  }
@@ -24,4 +24,4 @@ chia-protocol = { version = "=0.2.13", path = "../chia-protocol", features = ["p
 chia-traits = { version = "=0.2.13", path = "../chia-traits", features = ["py-bindings"]  }
 chia_py_streamable_macro = { version = "=0.2.13", path = "../chia_py_streamable_macro" }
 chia_streamable_macro = { version = "=0.2.12", path = "../chia_streamable_macro" }
-sha2 = "0.9.9"
+sha2 = "0.10.8"


### PR DESCRIPTION
(except internal dependencies).
Bump `hkdf` dependency to enable bumping `sha2` version. This deduplicates the depency, to only depend on a single version of `sha2`.

The reason to keep internal dependencies exact is to let us assume all versions are incompatible (for now), until development settles down and we may actually be able to maintain stable APIs.