### PR TITLE
optimize Vec<T>::parse(), for Streamable

### DIFF
--- a/chia-bls/src/secret_key.rs
+++ b/chia-bls/src/secret_key.rs
@@ -76,13 +76,13 @@ fn to_lamport_pk(ikm: [u8; 32], idx: u32) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(lamport0);
     hasher.update(lamport1);
-    hasher.finalize().try_into().unwrap()
+    hasher.finalize().into()
 }
 
 fn sha256(bytes: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
-    hasher.finalize().try_into().unwrap()
+    hasher.finalize().into()
 }
 
 pub fn is_all_zero(buf: &[u8]) -> bool {

--- a/chia-protocol/src/bytes.rs
+++ b/chia-protocol/src/bytes.rs
@@ -366,7 +366,7 @@ impl<const N: usize> FromJsonDict for BytesImpl<N> {
                 N
             )));
         }
-        Ok((&buf).try_into()?)
+        Ok((&buf).into())
     }
 }
 

--- a/chia-tools/src/bin/fast-forward-spend.rs
+++ b/chia-tools/src/bin/fast-forward-spend.rs
@@ -36,8 +36,7 @@ fn main() {
     let new_parents_parent: Bytes32 = hex::decode(args.new_parents_parent)
         .expect("invalid hex")
         .as_slice()
-        .try_into()
-        .expect("parent_id");
+        .into();
 
     let mut a = Allocator::new_limited(500000000, 62500000, 62500000);
     let puzzle = spend.puzzle_reveal.to_clvm(&mut a).expect("to_clvm");


### PR DESCRIPTION
by pre-allocating its size