### PR TITLE
fix typo in type stubs for HeaderBlock

### DIFF
--- a/wheel/chia_rs.pyi
+++ b/wheel/chia_rs.pyi
@@ -812,7 +812,7 @@ class HeaderBlock:
     total_iters: int
     log_string: str
     is_transaction_block: bool
-    first_in_sub_slots: bool
+    first_in_sub_slot: bool
     def __init__(
         self,
         finished_sub_slots: Sequence[EndOfSubSlotBundle],

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -175,7 +175,7 @@ extra_members = {
         "total_iters: int",
         "log_string: str",
         "is_transaction_block: bool",
-        "first_in_sub_slots: bool",
+        "first_in_sub_slot: bool",
     ],
     "RewardChainBlock": [
         "def get_unfinished(self) -> RewardChainBlockUnfinished: ...",


### PR DESCRIPTION
`first_in_sub_slots` -> `first_in_sub_slot`.

The correct names are found [here](https://github.com/Chia-Network/chia_rs/blob/main/chia-protocol/src/header_block.rs#L132) and [here](https://github.com/Chia-Network/chia-blockchain/blob/main/chia/types/header_block.py#L64).