### PR TITLE
suppress RSA security alert

### DIFF
--- a/.github/workflows/audit-check.yml
+++ b/.github/workflows/audit-check.yml
@@ -1,14 +1,13 @@
 name: Security audit
 on:
-  push:
-     paths:
-       - '**/Cargo.toml'
-       - '**/Cargo.lock'
+  pull_request:
+    branches:
+      - '**'
+
 jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: cargo audit
+        run: cargo audit --ignore RUSTSEC-2023-0071

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1869,9 +1869,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ef35bf3e7fe15a53c4ab08a998e42271eab13eb0db224126bc7bc4c4bad96d"
+checksum = "af6c4b23d99685a1408194da11270ef8e9809aff951cc70ec9b17350b087e474"
 dependencies = [
  "const-oid",
  "digest 0.10.7",

--- a/chia-ssl/Cargo.toml
+++ b/chia-ssl/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/Chia-Network/chia_rs/chia-ssl/"
 lazy_static = "1.4.0"
 rand = "0.8.5"
 rcgen = { version = "0.11.1", features = ["pem", "x509-parser"] }
-rsa = "0.9.2"
+rsa = "0.9.5"
 rustls = "0.21.2"
 thiserror = "1.0.50"
 time = "0.3.22"


### PR DESCRIPTION
This addresses a `cargo audit` issue:

```
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 579 security advisories (from /Users/arvid/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (298 crate dependencies)
Crate:     rsa
Version:   0.9.3
Title:     Marvin Attack: potential key recovery through timing sidechannels
Date:      2023-11-22
ID:        RUSTSEC-2023-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0071
Solution:  No fixed upgrade is available!
Dependency tree:
rsa 0.9.3
└── chia-ssl 0.2.13
```

our current use of the `rsa` crate is to generate certificates to connect to chia nodes.