### PR TITLE
drop clvm-trait's dependency on clvmr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,8 +288,8 @@ dependencies = [
  "chia-protocol",
  "chia-traits",
  "chia-wallet",
- "clvm-derive",
- "clvm-traits",
+ "clvm-derive 0.2.14",
+ "clvm-traits 0.2.14",
  "clvm-utils",
  "clvmr",
  "hex",
@@ -310,7 +310,7 @@ dependencies = [
  "blst",
  "chia-traits",
  "chia_py_streamable_macro",
- "clvm-traits",
+ "clvm-traits 0.2.14",
  "clvmr",
  "criterion",
  "hex",
@@ -352,7 +352,7 @@ dependencies = [
  "chia",
  "chia-protocol",
  "chia-traits",
- "clvm-traits",
+ "clvm-traits 0.2.14",
  "clvm-utils",
  "clvmr",
  "hex-literal",
@@ -368,7 +368,7 @@ dependencies = [
  "chia-traits",
  "chia_py_streamable_macro",
  "chia_streamable_macro",
- "clvm-traits",
+ "clvm-traits 0.2.14",
  "clvm-utils",
  "clvmr",
  "hex",
@@ -411,7 +411,7 @@ dependencies = [
  "chia-traits",
  "chia-wallet",
  "clap",
- "clvm-traits",
+ "clvm-traits 0.2.14",
  "clvm-utils",
  "clvmr",
  "hex",
@@ -440,7 +440,7 @@ dependencies = [
  "arbitrary",
  "chia-bls",
  "chia-protocol",
- "clvm-traits",
+ "clvm-traits 0.2.14",
  "clvm-utils",
  "clvmr",
  "hex",
@@ -454,7 +454,7 @@ name = "chia-wallet-fuzz"
 version = "0.0.0"
 dependencies = [
  "chia-wallet",
- "clvm-traits",
+ "clvm-traits 0.2.14",
  "clvmr",
  "libfuzzer-sys",
  "pyo3",
@@ -569,12 +569,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "clvm-derive"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9110e638f8a4d34922e0436282c7fe1a8149020aef3aacf699377dcd3f1553da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "clvm-traits"
 version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64ffd2241dead56ca31fb0261b4d0f802ba0b98a1c1e6f4514bc06c6095a9a9"
 dependencies = [
- "clvm-derive",
+ "clvm-derive 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "clvmr",
+ "num-bigint",
+ "pyo3",
+ "thiserror",
+]
+
+[[package]]
+name = "clvm-traits"
+version = "0.2.15"
+dependencies = [
+ "clvm-derive 0.2.14",
  "hex",
+ "hex-literal",
  "num-bigint",
  "pyo3",
  "thiserror",
@@ -584,7 +608,7 @@ dependencies = [
 name = "clvm-utils"
 version = "0.2.14"
 dependencies = [
- "clvm-traits",
+ "clvm-traits 0.2.14",
  "clvmr",
  "hex",
 ]
@@ -595,7 +619,7 @@ version = "0.0.0"
 dependencies = [
  "chia",
  "chia-fuzz",
- "clvm-traits",
+ "clvm-traits 0.2.14",
  "clvm-utils",
  "clvmr",
  "libfuzzer-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ hex = "0.4.3"
 pyo3 = { version = ">=0.19.0", optional = true }
 clvm-utils = { version = "=0.2.14", path = "clvm-utils" }
 chia-traits = { version = "=0.2.14", path = "chia-traits" }
-clvm-traits = { version = "=0.2.14", path = "clvm-traits" }
+clvm-traits = { version = "=0.2.14" }
 clvm-derive = { version = "=0.2.14", path = "clvm-derive" }
 chia-protocol = { version = "=0.2.14", path = "chia-protocol" }
 chia-wallet = { version = "=0.2.14", path = "chia-wallet" }

--- a/chia-bls/Cargo.toml
+++ b/chia-bls/Cargo.toml
@@ -9,18 +9,17 @@ homepage = "https://github.com/Chia-Network/chia_rs/chia-bls/"
 repository = "https://github.com/Chia-Network/chia_rs/chia-bls/"
 
 [features]
-py-bindings = ["dep:pyo3", "chia_py_streamable_macro", "chia-traits/py-bindings"]
+py-bindings = ["dep:pyo3", "chia_py_streamable_macro", "chia-traits/py-bindings", "clvm-traits/py-bindings"]
 
 [dependencies]
 chia-traits = { version = "=0.2.14", path = "../chia-traits" }
-clvm-traits = { version = "=0.2.14", path = "../clvm-traits", features = ["derive"] }
+clvm-traits = { version = "=0.2.14", features = ["derive"] }
 chia_py_streamable_macro = { version = "=0.2.14", path = "../chia_py_streamable_macro", optional = true }
 tiny-bip39 = "1.0.0"
 anyhow = "1.0.71"
 sha2 = "0.10.8"
 hkdf = "0.12.0"
 blst = { version = "0.3.11", features = ["portable"] }
-clvmr = "=0.3.0"
 hex = "0.4.3"
 thiserror = "1.0.44"
 pyo3 = { version = "0.19.0", features = ["multiple-pymethods"], optional = true }
@@ -30,6 +29,7 @@ arbitrary = { version = "1.3.0" }
 rand = "0.8.5"
 criterion = "0.5.1"
 rstest = "0.17.0"
+clvmr = "=0.3.0"
 
 [lib]
 crate-type = ["rlib"]

--- a/chia-protocol/Cargo.toml
+++ b/chia-protocol/Cargo.toml
@@ -19,7 +19,7 @@ chia_streamable_macro = { version = "=0.2.14", path = "../chia_streamable_macro"
 chia_py_streamable_macro = { version = "=0.2.14", path = "../chia_py_streamable_macro", optional = true }
 clvmr = "=0.3.0"
 chia-traits = { version = "=0.2.14", path = "../chia-traits" }
-clvm-traits = { version = "=0.2.14", path = "../clvm-traits", features = ["derive"] }
+clvm-traits = { version = "=0.2.14", features = ["derive"] }
 clvm-utils = { version = "=0.2.14", path = "../clvm-utils" }
 chia-bls = { version = "=0.2.14", path = "../chia-bls" }
 arbitrary = { version = "1.3.0", features = ["derive"] }

--- a/chia-tools/Cargo.toml
+++ b/chia-tools/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/Chia-Network/chia_rs/chia-tools"
 chia-protocol = { version = "0.2.14", path = "../chia-protocol" }
 chia-traits = { path = "../chia-traits" }
 clvm-utils = { path = "../clvm-utils" }
-clvm-traits = { path = "../clvm-traits" }
+clvm-traits = { version = "=0.2.14" }
 chia-wallet = { version = "=0.2.14", path = "../chia-wallet" }
 clvmr = { version = "=0.3.0", features = ["counters"] }
 chia = { version = "0.2.14", path = ".." }

--- a/chia-wallet/Cargo.toml
+++ b/chia-wallet/Cargo.toml
@@ -14,7 +14,7 @@ sha2 = "0.10.8"
 num-bigint = "0.4.3"
 hex-literal = "0.4.1"
 clvm-utils = { version = "0.2.14", path = "../clvm-utils" }
-clvm-traits = { version = "0.2.14", path = "../clvm-traits" }
+clvm-traits = { version = "0.2.14" }
 chia-bls = { version = "0.2.14", path = "../chia-bls" }
 chia-protocol = { version = "0.2.14", path = "../chia-protocol" }
 arbitrary = "=1.3.0"

--- a/chia-wallet/fuzz/Cargo.toml
+++ b/chia-wallet/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ libfuzzer-sys = "0.4"
 clvmr = "0.3.0"
 pyo3 = { version = ">=0.19.0", features = ["auto-initialize"]}
 chia-wallet = { path = ".." }
-clvm-traits = { path = "../../clvm-traits" }
+clvm-traits = { version = "0.2.14" }
 
 [[bin]]
 name = "roundtrip"

--- a/clvm-traits/Cargo.toml
+++ b/clvm-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm-traits"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 license = "Apache-2.0"
 description = "Traits for encoding and decoding CLVM objects."
@@ -18,9 +18,9 @@ py-bindings = ["dep:pyo3"]
 [dependencies]
 pyo3 = { version = ">=0.19.0", optional = true }
 clvm-derive = { version = "0.2.14", path = "../clvm-derive", optional = true }
-clvmr = "0.3.0"
 num-bigint = "0.4.3"
 thiserror = "1.0.44"
 
 [dev-dependencies]
 hex = "0.4.3"
+hex-literal = "=0.4.1"

--- a/clvm-traits/docs/derive_macros.md
+++ b/clvm-traits/docs/derive_macros.md
@@ -24,7 +24,7 @@ For example:
 - `(A, B, C)` is encoded as `(A . (B . C))`, since every cons-pair must contain two values.
 - `(A, B, C, D)` is encoded as `(A . (B . (C . D)))` for the same reason as above.
 
-```rust
+```rust compile_fail
 use clvmr::Allocator;
 use clvm_traits::{ToClvm, FromClvm};
 
@@ -59,7 +59,7 @@ For example:
 Note that the following code is for example purposes only and is not indicative of how to create a secure program.
 Using a password like shown in this example is an insecure method of locking coins, but it's effective for learning.
 
-```rust
+```rust compile_fail
 use clvmr::Allocator;
 use clvm_traits::{ToClvm, FromClvm};
 
@@ -91,7 +91,7 @@ You can read more about currying on the [Chia blockchain documentation](https://
 Note that the following code is for example purposes only and is not indicative of how to create a secure program.
 Using a password like shown in this example is an insecure method of locking coins, but it's effective for learning.
 
-```rust
+```rust compile_fail
 use clvmr::Allocator;
 use clvm_traits::{ToClvm, FromClvm};
 
@@ -121,7 +121,7 @@ For convenience, this is the behavior when deriving `ToClvm` and `FromClvm` for 
 In this example, since the `tuple` representation is used and the only values are the discriminants, the variants will be encoded as an atom.
 Discriminants default to the `isize` type and the first value is `0`. Subsequent values are incremented by `1` by default.
 
-```rust
+```rust compile_fail
 use clvmr::Allocator;
 use clvm_traits::{ToClvm, FromClvm};
 
@@ -145,7 +145,7 @@ It's possible to override both the type of the discriminator, and the value.
 The `#[repr(...)]` attribute is used by the Rust compiler to allow overriding the discriminator type.
 As such, this attribute is also used to change the underlying type used to serialize and deserialize discriminator values.
 
-```rust
+```rust compile_fail
 use clvmr::Allocator;
 use clvm_traits::{ToClvm, FromClvm};
 
@@ -169,7 +169,7 @@ assert_eq!(Status::from_clvm(a, ptr).unwrap(), status);
 Of course, you can also include fields on enum variants, and they will be serialized after the discriminator accordingly.
 It's also possible to override the representation of an individual variant, as if it were a standalone struct.
 
-```rust
+```rust compile_fail
 use clvmr::Allocator;
 use clvm_traits::{ToClvm, FromClvm};
 
@@ -199,7 +199,7 @@ This is what `#[clvm(untagged)]` allows you to do. However, due to current limit
 Note that if there is any ambiguity, the first variant which matches a value will be the resulting value.
 For example, if both `A` and `B` are in that order and are the same type, if you serialize a value of `B`, it will be deserialized as `A`.
 
-```rust
+```rust compile_fail
 use clvmr::Allocator;
 use clvm_traits::{ToClvm, FromClvm};
 

--- a/clvm-traits/src/clvm_decoder.rs
+++ b/clvm-traits/src/clvm_decoder.rs
@@ -1,8 +1,3 @@
-use clvmr::{
-    allocator::{NodePtr, SExp},
-    Allocator,
-};
-
 use crate::FromClvmError;
 
 pub trait ClvmDecoder {
@@ -16,25 +11,5 @@ pub trait ClvmDecoder {
     /// since there's no `Clone` bound on the `FromClvm` trait.
     fn clone_node(&self, node: &Self::Node) -> Self::Node {
         node.clone()
-    }
-}
-
-impl ClvmDecoder for Allocator {
-    type Node = NodePtr;
-
-    fn decode_atom(&self, node: &Self::Node) -> Result<&[u8], FromClvmError> {
-        if let SExp::Atom = self.sexp(*node) {
-            Ok(self.atom(*node))
-        } else {
-            Err(FromClvmError::ExpectedAtom)
-        }
-    }
-
-    fn decode_pair(&self, node: &Self::Node) -> Result<(Self::Node, Self::Node), FromClvmError> {
-        if let SExp::Pair(first, rest) = self.sexp(*node) {
-            Ok((first, rest))
-        } else {
-            Err(FromClvmError::ExpectedPair)
-        }
     }
 }

--- a/clvm-traits/src/clvm_encoder.rs
+++ b/clvm-traits/src/clvm_encoder.rs
@@ -1,5 +1,3 @@
-use clvmr::{allocator::NodePtr, Allocator};
-
 use crate::ToClvmError;
 
 pub trait ClvmEncoder {
@@ -17,21 +15,5 @@ pub trait ClvmEncoder {
     /// since there's no `Clone` bound on the `ToClvm` trait.
     fn clone_node(&self, node: &Self::Node) -> Self::Node {
         node.clone()
-    }
-}
-
-impl ClvmEncoder for Allocator {
-    type Node = NodePtr;
-
-    fn encode_atom(&mut self, bytes: &[u8]) -> Result<Self::Node, ToClvmError> {
-        self.new_atom(bytes).or(Err(ToClvmError::OutOfMemory))
-    }
-
-    fn encode_pair(
-        &mut self,
-        first: Self::Node,
-        rest: Self::Node,
-    ) -> Result<Self::Node, ToClvmError> {
-        self.new_pair(first, rest).or(Err(ToClvmError::OutOfMemory))
     }
 }

--- a/clvm-traits/src/from_clvm.rs
+++ b/clvm-traits/src/from_clvm.rs
@@ -1,37 +1,9 @@
-use clvmr::{allocator::NodePtr, Allocator};
 use num_bigint::{BigInt, Sign};
 
 use crate::{ClvmDecoder, FromClvmError};
 
 pub trait FromClvm<N>: Sized {
     fn from_clvm(decoder: &impl ClvmDecoder<Node = N>, node: N) -> Result<Self, FromClvmError>;
-}
-
-pub trait FromNodePtr {
-    fn from_node_ptr(a: &Allocator, node: NodePtr) -> Result<Self, FromClvmError>
-    where
-        Self: Sized;
-}
-
-impl<T> FromNodePtr for T
-where
-    T: FromClvm<NodePtr>,
-{
-    fn from_node_ptr(a: &Allocator, node: NodePtr) -> Result<Self, FromClvmError>
-    where
-        Self: Sized,
-    {
-        T::from_clvm(a, node)
-    }
-}
-
-impl FromClvm<NodePtr> for NodePtr {
-    fn from_clvm(
-        _decoder: &impl ClvmDecoder<Node = NodePtr>,
-        node: NodePtr,
-    ) -> Result<Self, FromClvmError> {
-        Ok(node)
-    }
 }
 
 macro_rules! clvm_primitive {
@@ -186,85 +158,73 @@ impl<N> FromClvm<N> for String {
 
 #[cfg(test)]
 mod tests {
-    use clvmr::{allocator::NodePtr, serde::node_from_bytes, Allocator};
+    use crate::tests::{str_to_node, TestAllocator, TestNode};
 
+    use super::FromClvm;
     use super::*;
 
-    fn decode<T>(a: &mut Allocator, hex: &str) -> Result<T, FromClvmError>
+    fn decode<T>(hex: &str) -> Result<T, FromClvmError>
     where
-        T: FromClvm<NodePtr>,
+        T: FromClvm<TestNode>,
     {
-        let bytes = hex::decode(hex).unwrap();
-        let actual = node_from_bytes(a, &bytes).unwrap();
-        T::from_clvm(a, actual)
-    }
-
-    #[test]
-    fn test_nodeptr() {
-        let a = &mut Allocator::new();
-        let ptr = a.one();
-        assert_eq!(NodePtr::from_clvm(a, ptr).unwrap(), ptr);
+        let mut a = TestAllocator::new();
+        let (rest, actual) = str_to_node(&mut a, hex);
+        assert_eq!(rest, "");
+        T::from_clvm(&a, actual)
     }
 
     #[test]
     fn test_primitives() {
-        let a = &mut Allocator::new();
-        assert_eq!(decode(a, "80"), Ok(0u8));
-        assert_eq!(decode(a, "80"), Ok(0i8));
-        assert_eq!(decode(a, "05"), Ok(5u8));
-        assert_eq!(decode(a, "05"), Ok(5u32));
-        assert_eq!(decode(a, "05"), Ok(5i32));
-        assert_eq!(decode(a, "81e5"), Ok(-27i32));
-        assert_eq!(decode(a, "80"), Ok(-0));
-        assert_eq!(decode(a, "8180"), Ok(-128i8));
+        assert_eq!(decode("NIL"), Ok(0u8));
+        assert_eq!(decode("NIL"), Ok(0i8));
+        assert_eq!(decode("05"), Ok(5u8));
+        assert_eq!(decode("05"), Ok(5u32));
+        assert_eq!(decode("05"), Ok(5i32));
+        assert_eq!(decode("e5"), Ok(-27i32));
+        assert_eq!(decode("NIL"), Ok(-0));
+        assert_eq!(decode("80"), Ok(-128i8));
     }
 
     #[test]
     fn test_pair() {
-        let a = &mut Allocator::new();
-        assert_eq!(decode(a, "ff0502"), Ok((5, 2)));
-        assert_eq!(decode(a, "ff81b8ff8301600980"), Ok((-72, (90121, ()))));
+        assert_eq!(decode("( 05 02"), Ok((5, 2)));
+        assert_eq!(decode("( b8 ( 016009 NIL"), Ok((-72, (90121, ()))));
         assert_eq!(
-            decode(a, "ffff80ff80ff80ffff80ff80ff80808080"),
+            decode("( ( NIL ( NIL ( NIL ( ( NIL ( NIL ( NIL NIL NIL NIL"),
             Ok((((), ((), ((), (((), ((), ((), ()))), ())))), ()))
         );
     }
 
     #[test]
     fn test_nil() {
-        let a = &mut Allocator::new();
-        assert_eq!(decode(a, "80"), Ok(()));
+        assert_eq!(decode("NIL"), Ok(()));
     }
 
     #[test]
     fn test_array() {
-        let a = &mut Allocator::new();
-        assert_eq!(decode(a, "ff01ff02ff03ff0480"), Ok([1, 2, 3, 4]));
-        assert_eq!(decode(a, "80"), Ok([] as [i32; 0]));
+        assert_eq!(decode("( 01 ( 02 ( 03 ( 04 NIL"), Ok([1, 2, 3, 4]));
+        assert_eq!(decode("NIL"), Ok([] as [i32; 0]));
     }
 
     #[test]
     fn test_vec() {
-        let a = &mut Allocator::new();
-        assert_eq!(decode(a, "ff01ff02ff03ff0480"), Ok(vec![1, 2, 3, 4]));
-        assert_eq!(decode(a, "80"), Ok(Vec::<i32>::new()));
+        assert_eq!(decode("( 01 ( 02 ( 03 ( 04 NIL"), Ok(vec![1, 2, 3, 4]));
+        assert_eq!(decode("NIL"), Ok(Vec::<i32>::new()));
     }
 
     #[test]
     fn test_option() {
-        let a = &mut Allocator::new();
-        assert_eq!(decode(a, "8568656c6c6f"), Ok(Some("hello".to_string())));
-        assert_eq!(decode(a, "80"), Ok(None::<String>));
+        assert_eq!(decode("68656c6c6f"), Ok(Some("hello".to_string())));
+        assert_eq!(decode("NIL"), Ok(None::<String>));
 
         // Empty strings get decoded as None instead, since both values are represented by nil bytes.
         // This could be considered either intended behavior or not, depending on the way it's used.
-        assert_ne!(decode(a, "80"), Ok(Some("".to_string())));
+        assert_ne!(decode("NIL"), Ok(Some("".to_string())));
     }
 
     #[test]
     fn test_string() {
-        let a = &mut Allocator::new();
-        assert_eq!(decode(a, "8568656c6c6f"), Ok("hello".to_string()));
-        assert_eq!(decode(a, "80"), Ok("".to_string()));
+        assert_eq!(decode("68656c6c6f"), Ok("hello".to_string()));
+        assert_eq!(decode("NIL"), Ok("".to_string()));
     }
 }

--- a/clvm-utils/Cargo.toml
+++ b/clvm-utils/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/Chia-Network/chia_rs/clvm-utils"
 
 [dependencies]
 clvmr = "0.3.0"
-clvm-traits = { version = "0.2.14", path = "../clvm-traits" }
+clvm-traits = { version = "0.2.14" }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/clvm-utils/fuzz/Cargo.toml
+++ b/clvm-utils/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ libfuzzer-sys = "0.4"
 clvmr = "=0.3.0"
 chia-fuzz = { path = "../../fuzz" }
 clvm-utils = { path = ".." }
-clvm-traits = { path = "../../clvm-traits" }
+clvm-traits = { version = "=0.2.14" }
 chia = { path = "../.." }
 
 [[bin]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 clvmr = "=0.3.0"
 clvm-utils = { path = "../clvm-utils" }
-clvm-traits = { path = "../clvm-traits" }
+clvm-traits = { version = "=0.2.14" }
 chia-protocol = { path = "../chia-protocol" }
 chia-traits = { path = "../chia-traits" }
 chia = { path = ".." }

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -23,6 +23,6 @@ chia = { version = "=0.2.14", path = "..", features = ["py-bindings"] }
 chia-bls = { version = "=0.2.14", path = "../chia-bls", features = ["py-bindings"]  }
 chia-protocol = { version = "=0.2.14", path = "../chia-protocol", features = ["py-bindings"]  }
 chia-traits = { version = "=0.2.14", path = "../chia-traits", features = ["py-bindings"]  }
-clvm-traits = { version = "=0.2.14", path = "../clvm-traits", features = ["derive", "py-bindings"] }
+clvm-traits = { version = "=0.2.14", features = ["derive", "py-bindings"] }
 chia_py_streamable_macro = { version = "=0.2.14", path = "../chia_py_streamable_macro" }
 chia_streamable_macro = { version = "=0.2.14", path = "../chia_streamable_macro" }


### PR DESCRIPTION
remove the `ToNodePtr` and `FromNodePtr` traits as well as `FromClvm` and `ToClvm` for `Allocator` and `NodePtr` (those will be moved into `clvmr`).

This is one step in untangling the dependency cycle caused by making `clvmr` use `chia-bls`.

In order to keep everything building, all other crates that depend on `clvm-traits` now use the crates.io version (i.e. stay on the current version).

once this lands, `clvm_rs` can be updated to implement the `clvm-traits`. Then this repository can be restored to depend on the new `clvm_rs` and `clvm-traits`