### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chia"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "chia-protocol",
  "chia-traits",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "chia-bls"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "chia-fuzz"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "chia",
  "chia-protocol",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "chia-protocol"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "chia-bls",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "chia-tools"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "chia",
  "chia-protocol",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "chia-traits"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "chia_py_streamable_macro",
  "chia_streamable_macro",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "chia-wallet"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "chia-bls",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "chia-wallet-fuzz"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "chia-wallet",
  "clvm-traits 0.2.14",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "chia_py_streamable_macro"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "chia_streamable_macro"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -594,7 +594,7 @@ checksum = "9110e638f8a4d34922e0436282c7fe1a8149020aef3aacf699377dcd3f1553da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-traits"
-version = "0.2.15"
+version = "0.3.0"
 dependencies = [
  "clvm-derive 0.2.14",
  "hex",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-utils"
-version = "0.2.14"
+version = "0.3.0"
 dependencies = [
  "clvm-traits 0.2.14",
  "clvmr",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-utils-fuzz"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "chia",
  "chia-fuzz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = ["wheel"]
 
 [package]
 name = "chia"
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Utility functions and types used by the Chia blockchain full node"
@@ -40,12 +40,12 @@ py-bindings = ["dep:pyo3"]
 clvmr = "=0.3.0"
 hex = "0.4.3"
 pyo3 = { version = ">=0.19.0", optional = true }
-clvm-utils = { version = "=0.2.14", path = "clvm-utils" }
-chia-traits = { version = "=0.2.14", path = "chia-traits" }
+clvm-utils = { version = "=0.3.0", path = "clvm-utils" }
+chia-traits = { version = "=0.3.0", path = "chia-traits" }
 clvm-traits = { version = "=0.2.14" }
 clvm-derive = { version = "=0.2.14", path = "clvm-derive" }
-chia-protocol = { version = "=0.2.14", path = "chia-protocol" }
-chia-wallet = { version = "=0.2.14", path = "chia-wallet" }
+chia-protocol = { version = "=0.3.0", path = "chia-protocol" }
+chia-wallet = { version = "=0.3.0", path = "chia-wallet" }
 hex-literal = "0.4.1"
 thiserror = "1.0.44"
 

--- a/bump-version.py
+++ b/bump-version.py
@@ -24,6 +24,9 @@ our_crates = [
     "chia-wallet",
     "chia-client",
     "chia-ssl",
+    "fuzz",
+    "chia-wallet/fuzz",
+    "clvm-utils/fuzz",
 ]
 
 def crates_with_changes() -> Set[str]:

--- a/chia-bls/Cargo.toml
+++ b/chia-bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-bls"
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "BLS signature, verification and aggregation funcions for the Chia blockchain"
@@ -12,9 +12,9 @@ repository = "https://github.com/Chia-Network/chia_rs/chia-bls/"
 py-bindings = ["dep:pyo3", "chia_py_streamable_macro", "chia-traits/py-bindings", "clvm-traits/py-bindings"]
 
 [dependencies]
-chia-traits = { version = "=0.2.14", path = "../chia-traits" }
+chia-traits = { version = "=0.3.0", path = "../chia-traits" }
 clvm-traits = { version = "=0.2.14", features = ["derive"] }
-chia_py_streamable_macro = { version = "=0.2.14", path = "../chia_py_streamable_macro", optional = true }
+chia_py_streamable_macro = { version = "=0.3.0", path = "../chia_py_streamable_macro", optional = true }
 tiny-bip39 = "1.0.0"
 anyhow = "1.0.71"
 sha2 = "0.10.8"

--- a/chia-client/Cargo.toml
+++ b/chia-client/Cargo.toml
@@ -9,8 +9,8 @@ homepage = "https://github.com/Chia-Network/chia_rs/chia-client/"
 repository = "https://github.com/Chia-Network/chia_rs/chia-client/"
 
 [dependencies]
-chia-protocol = { version = "0.2.14", path = "../chia-protocol" }
-chia-traits = { version = "0.2.14", path = "../chia-traits" }
+chia-protocol = { version = "0.3.0", path = "../chia-protocol" }
+chia-traits = { version = "0.3.0", path = "../chia-traits" }
 tokio = { version = "1.32.0", features = ["rt", "sync"] }
 tokio-tungstenite = "0.20.0"
 futures-util = "0.3.28"

--- a/chia-protocol/Cargo.toml
+++ b/chia-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-protocol"
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Chia network protocol message types"
@@ -15,13 +15,13 @@ py-bindings = ["dep:pyo3", "dep:chia_py_streamable_macro", "chia-traits/py-bindi
 pyo3 = { version = "0.19.0", features = ["multiple-pymethods", "num-bigint"], optional = true }
 sha2 = "0.10.8"
 hex = "0.4.3"
-chia_streamable_macro = { version = "=0.2.14", path = "../chia_streamable_macro" }
-chia_py_streamable_macro = { version = "=0.2.14", path = "../chia_py_streamable_macro", optional = true }
+chia_streamable_macro = { version = "=0.3.0", path = "../chia_streamable_macro" }
+chia_py_streamable_macro = { version = "=0.3.0", path = "../chia_py_streamable_macro", optional = true }
 clvmr = "=0.3.0"
-chia-traits = { version = "=0.2.14", path = "../chia-traits" }
+chia-traits = { version = "=0.3.0", path = "../chia-traits" }
 clvm-traits = { version = "=0.2.14", features = ["derive"] }
-clvm-utils = { version = "=0.2.14", path = "../clvm-utils" }
-chia-bls = { version = "=0.2.14", path = "../chia-bls" }
+clvm-utils = { version = "=0.3.0", path = "../clvm-utils" }
+chia-bls = { version = "=0.3.0", path = "../chia-bls" }
 arbitrary = { version = "1.3.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/chia-tools/Cargo.toml
+++ b/chia-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-tools"
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Utility functions and types used by the Chia blockchain full node"
@@ -9,13 +9,13 @@ homepage = "https://github.com/Chia-Network/chia_rs/chia-tools"
 repository = "https://github.com/Chia-Network/chia_rs/chia-tools"
 
 [dependencies]
-chia-protocol = { version = "0.2.14", path = "../chia-protocol" }
+chia-protocol = { version = "0.3.0", path = "../chia-protocol" }
 chia-traits = { path = "../chia-traits" }
 clvm-utils = { path = "../clvm-utils" }
 clvm-traits = { version = "=0.2.14" }
-chia-wallet = { version = "=0.2.14", path = "../chia-wallet" }
+chia-wallet = { version = "=0.3.0", path = "../chia-wallet" }
 clvmr = { version = "=0.3.0", features = ["counters"] }
-chia = { version = "0.2.14", path = ".." }
+chia = { version = "0.3.0", path = ".." }
 rusqlite = { version = "=0.30.0", features = ["bundled"] }
 clap = { version = "=4.3.9", features = ["derive"] }
 zstd = "=0.12.3"

--- a/chia-traits/Cargo.toml
+++ b/chia-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-traits"
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Chia traits for Streamable types (chia's serialization format)"
@@ -11,8 +11,8 @@ py-bindings = ["dep:pyo3", "dep:chia_py_streamable_macro"]
 
 [dependencies]
 pyo3 = { version = "0.19.0", features = ["multiple-pymethods"], optional = true }
-chia_py_streamable_macro = { version = "=0.2.14", path = "../chia_py_streamable_macro", optional = true }
-chia_streamable_macro = { version = "=0.2.14", path = "../chia_streamable_macro" }
+chia_py_streamable_macro = { version = "=0.3.0", path = "../chia_py_streamable_macro", optional = true }
+chia_streamable_macro = { version = "=0.3.0", path = "../chia_streamable_macro" }
 sha2 = "0.10.8"
 hex = "0.4.3"
 thiserror = "1.0.44"

--- a/chia-wallet/Cargo.toml
+++ b/chia-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-wallet"
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Chia primitives needed for building wallets."
@@ -13,10 +13,10 @@ clvmr = "0.3.0"
 sha2 = "0.10.8"
 num-bigint = "0.4.3"
 hex-literal = "0.4.1"
-clvm-utils = { version = "0.2.14", path = "../clvm-utils" }
-clvm-traits = { version = "0.2.14" }
-chia-bls = { version = "0.2.14", path = "../chia-bls" }
-chia-protocol = { version = "0.2.14", path = "../chia-protocol" }
+clvm-utils = { version = "0.3.0", path = "../clvm-utils" }
+clvm-traits = { version = "=0.2.14" }
+chia-bls = { version = "0.3.0", path = "../chia-bls" }
+chia-protocol = { version = "0.3.0", path = "../chia-protocol" }
 arbitrary = "=1.3.0"
 
 [dev-dependencies]

--- a/chia-wallet/fuzz/Cargo.toml
+++ b/chia-wallet/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-wallet-fuzz"
-version = "0.0.0"
+version = "0.3.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2021"
@@ -13,7 +13,7 @@ libfuzzer-sys = "0.4"
 clvmr = "0.3.0"
 pyo3 = { version = ">=0.19.0", features = ["auto-initialize"]}
 chia-wallet = { path = ".." }
-clvm-traits = { version = "0.2.14" }
+clvm-traits = { version = "=0.2.14" }
 
 [[bin]]
 name = "roundtrip"

--- a/chia_py_streamable_macro/Cargo.toml
+++ b/chia_py_streamable_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia_py_streamable_macro"
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Derive macro to create python bindings for Chia types"

--- a/chia_streamable_macro/Cargo.toml
+++ b/chia_streamable_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia_streamable_macro"
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Streamable derive macro for serializing/deserializing types in Chia protocol format"

--- a/clvm-traits/Cargo.toml
+++ b/clvm-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm-traits"
-version = "0.2.15"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Traits for encoding and decoding CLVM objects."

--- a/clvm-utils/Cargo.toml
+++ b/clvm-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm-utils"
-version = "0.2.14"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Utility functions for processing clvm programs and structures"
@@ -10,7 +10,7 @@ repository = "https://github.com/Chia-Network/chia_rs/clvm-utils"
 
 [dependencies]
 clvmr = "0.3.0"
-clvm-traits = { version = "0.2.14" }
+clvm-traits = { version = "=0.2.14" }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/clvm-utils/fuzz/Cargo.toml
+++ b/clvm-utils/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm-utils-fuzz"
-version = "0.0.0"
+version = "0.3.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2021"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-fuzz"
-version = "0.0.0"
+version = "0.3.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2021"

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia_rs"
-version = "0.2.14"
+version = "0.3.0"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -19,10 +19,10 @@ clvmr = "=0.3.0"
 hex = "0.4.3"
 sha2 = "0.10.8"
 pyo3 = { version = "=0.19.0", features = ["extension-module", "multiple-pymethods"] }
-chia = { version = "=0.2.14", path = "..", features = ["py-bindings"] }
-chia-bls = { version = "=0.2.14", path = "../chia-bls", features = ["py-bindings"]  }
-chia-protocol = { version = "=0.2.14", path = "../chia-protocol", features = ["py-bindings"]  }
-chia-traits = { version = "=0.2.14", path = "../chia-traits", features = ["py-bindings"]  }
+chia = { version = "=0.3.0", path = "..", features = ["py-bindings"] }
+chia-bls = { version = "=0.3.0", path = "../chia-bls", features = ["py-bindings"]  }
+chia-protocol = { version = "=0.3.0", path = "../chia-protocol", features = ["py-bindings"]  }
+chia-traits = { version = "=0.3.0", path = "../chia-traits", features = ["py-bindings"]  }
 clvm-traits = { version = "=0.2.14", features = ["derive", "py-bindings"] }
-chia_py_streamable_macro = { version = "=0.2.14", path = "../chia_py_streamable_macro" }
-chia_streamable_macro = { version = "=0.2.14", path = "../chia_streamable_macro" }
+chia_py_streamable_macro = { version = "=0.3.0", path = "../chia_py_streamable_macro" }
+chia_streamable_macro = { version = "=0.3.0", path = "../chia_streamable_macro" }


### PR DESCRIPTION
This prepares for publishing the new `clvm-traits` that does not include `ToNodePtr`, `FromNodePtr` traits, as well as implementations for `Allocator` and `NodePtr`.

Note that since `clvmr` isn't updated yet, all other crates still depend on the 0.2.14 version of `clvm-traits`. Once this is published, we can update `clvmr` and restore the crates to depend on the local version in this repo.