### PR TITLE
Add unregister messages

### DIFF
--- a/chia-protocol/src/chia_protocol.rs
+++ b/chia-protocol/src/chia_protocol.rs
@@ -123,8 +123,8 @@ pub enum ProtocolMessageTypes {
     RespondFeeEstimates = 90,
 
     // Extended wallet protocol
-    UnregisterForPhUpdates = 92,
-    UnregisterForCoinUpdates = 93,
+    UnregisterPhUpdates = 92,
+    UnregisterCoinUpdates = 93,
 }
 
 pub trait ChiaProtocolMessage {

--- a/chia-protocol/src/chia_protocol.rs
+++ b/chia-protocol/src/chia_protocol.rs
@@ -121,6 +121,10 @@ pub enum ProtocolMessageTypes {
     RespondBlockHeaders = 88,
     RequestFeeEstimates = 89,
     RespondFeeEstimates = 90,
+
+    // Extended wallet protocol
+    UnregisterForPhUpdates = 92,
+    UnregisterForCoinUpdates = 93,
 }
 
 pub trait ChiaProtocolMessage {

--- a/chia-protocol/src/wallet_protocol.rs
+++ b/chia-protocol/src/wallet_protocol.rs
@@ -148,11 +148,11 @@ message_struct! (RespondToCoinUpdates {
     coin_states: Vec<CoinState>,
 });
 
-message_struct! (UnregisterForPhUpdates {
+message_struct! (UnregisterPhUpdates {
     puzzle_hashes: Vec<Bytes32>,
 });
 
-message_struct! (UnregisterForCoinUpdates {
+message_struct! (UnregisterCoinUpdates {
     coin_ids: Vec<Bytes32>,
 });
 

--- a/chia-protocol/src/wallet_protocol.rs
+++ b/chia-protocol/src/wallet_protocol.rs
@@ -148,6 +148,14 @@ message_struct! (RespondToCoinUpdates {
     coin_states: Vec<CoinState>,
 });
 
+message_struct! (UnregisterForPhUpdates {
+    puzzle_hashes: Vec<Bytes32>,
+});
+
+message_struct! (UnregisterForCoinUpdates {
+    coin_ids: Vec<Bytes32>,
+});
+
 message_struct! (CoinStateUpdate {
     height: u32,
     fork_height: u32,


### PR DESCRIPTION
As part of https://github.com/Chia-Network/chia-blockchain/pull/17012 

Adds support for the following new wallet protocol types:

- `UnregisterPhUpdates`
- `UnregisterCoinUpdates`