### PR TITLE
Pin versions

### DIFF
--- a/chia-wallet/Cargo.toml
+++ b/chia-wallet/Cargo.toml
@@ -13,10 +13,10 @@ clvmr = "0.3.0"
 sha2 = "0.10.8"
 num-bigint = "0.4.3"
 hex-literal = "0.4.1"
-clvm-utils = { version = "0.3.0" }
+clvm-utils = { version = "=0.3.0" }
 clvm-traits = { version = "=0.2.14" }
-chia-bls = { version = "0.3.0" }
-chia-protocol = { version = "0.3.0" }
+chia-bls = { version = "=0.3.0" }
+chia-protocol = { version = "=0.3.0" }
 arbitrary = "=1.3.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes an error in the release because of the version of one crate bumping before publishing another.