### PR TITLE
Unpin dependencies for library crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,22 +37,22 @@ repository = "https://github.com/Chia-Network/chia_rs/"
 py-bindings = ["dep:pyo3"]
 
 [dependencies]
-clvmr = "=0.3.2"
+clvmr = "0.3.2"
 hex = "0.4.3"
 pyo3 = { version = ">=0.19.0", optional = true }
-clvm-utils = { version = "=0.3.0", path = "clvm-utils" }
-chia-traits = { version = "=0.3.0", path = "chia-traits" }
-clvm-traits = { version = "=0.3.2", path = "clvm-traits" }
-clvm-derive = { version = "=0.2.14", path = "clvm-derive" }
-chia-protocol = { version = "=0.3.1", path = "chia-protocol" }
-chia-wallet = { version = "=0.3.2", path = "chia-wallet" }
+clvm-utils = { version = "0.3.0", path = "clvm-utils" }
+chia-traits = { version = "0.3.0", path = "chia-traits" }
+clvm-traits = { version = "0.3.2", path = "clvm-traits" }
+clvm-derive = { version = "0.2.14", path = "clvm-derive" }
+chia-protocol = { version = "0.3.1", path = "chia-protocol" }
+chia-wallet = { version = "0.3.2", path = "chia-wallet" }
 hex-literal = "0.4.1"
 thiserror = "1.0.44"
 
 [dev-dependencies]
-num-traits = "=0.2.15"
-rstest = "=0.16.0"
-text-diff = "=0.4.0"
+num-traits = "0.2.15"
+rstest = "0.16.0"
+text-diff = "0.4.0"
 
 [lib]
 name = "chia"

--- a/chia-bls/Cargo.toml
+++ b/chia-bls/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/Chia-Network/chia_rs/chia-bls/"
 py-bindings = ["dep:pyo3", "chia_py_streamable_macro", "chia-traits/py-bindings"]
 
 [dependencies]
-chia-traits = { version = "=0.3.0", path = "../chia-traits" }
-chia_py_streamable_macro = { version = "=0.3.0", path = "../chia_py_streamable_macro", optional = true }
+chia-traits = { version = "0.3.0", path = "../chia-traits" }
+chia_py_streamable_macro = { version = "0.3.0", path = "../chia_py_streamable_macro", optional = true }
 tiny-bip39 = "1.0.0"
 anyhow = "1.0.71"
 sha2 = "0.10.8"

--- a/chia-protocol/Cargo.toml
+++ b/chia-protocol/Cargo.toml
@@ -15,13 +15,13 @@ py-bindings = ["dep:pyo3", "dep:chia_py_streamable_macro", "chia-traits/py-bindi
 pyo3 = { version = "0.19.0", features = ["multiple-pymethods", "num-bigint"], optional = true }
 sha2 = "0.10.8"
 hex = "0.4.3"
-chia_streamable_macro = { version = "=0.3.0", path = "../chia_streamable_macro" }
-chia_py_streamable_macro = { version = "=0.3.0", path = "../chia_py_streamable_macro", optional = true }
-clvmr = "=0.3.2"
-chia-traits = { version = "=0.3.0", path = "../chia-traits" }
-clvm-traits = { version = "=0.3.2", path = "../clvm-traits", features = ["derive"] }
-clvm-utils = { version = "=0.3.0", path = "../clvm-utils" }
-chia-bls = { version = "=0.3.1", path = "../chia-bls" }
+chia_streamable_macro = { version = "0.3.0", path = "../chia_streamable_macro" }
+chia_py_streamable_macro = { version = "0.3.0", path = "../chia_py_streamable_macro", optional = true }
+clvmr = "0.3.2"
+chia-traits = { version = "0.3.0", path = "../chia-traits" }
+clvm-traits = { version = "0.3.2", path = "../clvm-traits", features = ["derive"] }
+clvm-utils = { version = "0.3.0", path = "../clvm-utils" }
+chia-bls = { version = "0.3.1", path = "../chia-bls" }
 arbitrary = { version = "1.3.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/chia-traits/Cargo.toml
+++ b/chia-traits/Cargo.toml
@@ -11,8 +11,8 @@ py-bindings = ["dep:pyo3", "dep:chia_py_streamable_macro"]
 
 [dependencies]
 pyo3 = { version = "0.19.0", features = ["multiple-pymethods"], optional = true }
-chia_py_streamable_macro = { version = "=0.3.0", path = "../chia_py_streamable_macro", optional = true }
-chia_streamable_macro = { version = "=0.3.0", path = "../chia_streamable_macro" }
+chia_py_streamable_macro = { version = "0.3.0", path = "../chia_py_streamable_macro", optional = true }
+chia_streamable_macro = { version = "0.3.0", path = "../chia_streamable_macro" }
 sha2 = "0.10.8"
 hex = "0.4.3"
 thiserror = "1.0.44"

--- a/chia-wallet/Cargo.toml
+++ b/chia-wallet/Cargo.toml
@@ -9,15 +9,15 @@ homepage = "https://github.com/Chia-Network/chia_rs/chia-wallet/"
 repository = "https://github.com/Chia-Network/chia_rs/chia-wallet/"
 
 [dependencies]
-clvmr = "=0.3.2"
+clvmr = "0.3.2"
 sha2 = "0.10.8"
 num-bigint = "0.4.3"
 hex-literal = "0.4.1"
-clvm-utils = { version = "=0.3.0", path = "../clvm-utils" }
-clvm-traits = { version = "=0.3.2", path = "../clvm-traits", features = ["chia-bls"] }
-chia-bls = { version = "=0.3.1", path = "../chia-bls" }
-chia-protocol = { version = "=0.3.1", path = "../chia-protocol" }
-arbitrary = "=1.3.0"
+clvm-utils = { version = "0.3.0", path = "../clvm-utils" }
+clvm-traits = { version = "0.3.2", path = "../clvm-traits", features = ["chia-bls"] }
+chia-bls = { version = "0.3.1", path = "../chia-bls" }
+chia-protocol = { version = "0.3.1", path = "../chia-protocol" }
+arbitrary = "1.3.0"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/clvm-traits/Cargo.toml
+++ b/clvm-traits/Cargo.toml
@@ -25,4 +25,4 @@ thiserror = "1.0.44"
 
 [dev-dependencies]
 hex = "0.4.3"
-hex-literal = "=0.4.1"
+hex-literal = "0.4.1"

--- a/clvm-utils/Cargo.toml
+++ b/clvm-utils/Cargo.toml
@@ -9,8 +9,8 @@ homepage = "https://github.com/Chia-Network/chia_rs/"
 repository = "https://github.com/Chia-Network/chia_rs/clvm-utils"
 
 [dependencies]
-clvmr = "=0.3.2"
-clvm-traits = { version = "=0.3.2", path = "../clvm-traits" }
+clvmr = "0.3.2"
+clvm-traits = { version = "0.3.2", path = "../clvm-traits" }
 
 [dev-dependencies]
 hex = "0.4.3"


### PR DESCRIPTION
As long as we follow semver compatibility, this should help prevent version conflicts when installing our library crates.