### PR TITLE
Program as a bytes buffer

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Build
       run: |
-        python -m pip install clvm_tools colorama blspy chia-blockchain==2.1.0
+        python -m pip install clvm_tools colorama blspy chia-blockchain==2.1.2 clvm==0.9.8
         maturin develop --release -m wheel/Cargo.toml
 
     - name: python mypy

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -389,7 +389,7 @@ jobs:
           source venv/bin/activate
           git clone https://github.com/Chia-Network/clvm_tools.git --branch=main --single-branch
           pip install ./clvm_tools
-          pip install colorama maturin pytest chia-blockchain==2.1.0
+          pip install colorama maturin pytest chia-blockchain==2.1.2 clvm==0.9.8
           maturin develop --release -m wheel/Cargo.toml
           pytest tests
           grcov . --binary-path target -s . --branch --ignore-not-existing --ignore='*/.cargo/*' --ignore='tests/*' --ignore='venv/*' -o rust_cov.info

--- a/chia-protocol/src/program.rs
+++ b/chia-protocol/src/program.rs
@@ -90,9 +90,6 @@ fn clvm_convert(a: &mut Allocator, o: &PyAny) -> PyResult<NodePtr> {
     // None
     if o.is_none() {
         Ok(a.null())
-    // Program itself
-    } else if let Ok(prg) = o.extract::<Program>() {
-        Ok(node_from_bytes_backrefs(a, prg.0.as_slice())?)
     // bytes
     } else if let Ok(buffer) = o.extract::<&[u8]>() {
         a.new_atom(buffer)
@@ -148,6 +145,12 @@ fn clvm_convert(a: &mut Allocator, o: &PyAny) -> PyResult<NodePtr> {
             a.new_atom(atom.extract::<&[u8]>()?)
                 .map_err(|e| PyMemoryError::new_err(e.to_string()))
         }
+    // Program itself. This is interpreted as a program in serialized form, and
+    // just a buffer of that serialization. This is an optimization to finding
+    // __bytes__() and calling it
+    } else if let Ok(prg) = o.extract::<Program>() {
+        a.new_atom(prg.0.as_slice())
+            .map_err(|e| PyMemoryError::new_err(e.to_string()))
     // anything convertible to bytes
     } else if let Ok(fun) = o.getattr("__bytes__") {
         let bytes = fun.call0()?;

--- a/tests/test_program_fidelity.py
+++ b/tests/test_program_fidelity.py
@@ -29,13 +29,16 @@ def rand_list(rnd: Random) -> List:
 def rand_program(rnd: Random) -> ChiaProgram:
     return ChiaProgram.from_bytes(b"\xff\x01\xff\x04\x01")
 
+def rand_rust_program(rnd: Random) -> chia_rs.Program:
+    return chia_rs.Program.from_bytes(b"\xff\x01\xff\x04\x01")
+
 def rand_optional(rnd: Random) -> Optional[object]:
     if rnd.randint(0, 1) == 0:
         return None
     return rand_object(rnd)
 
 def rand_object(rnd: Random) -> object:
-    types = [rand_optional, rand_int, rand_string, rand_bytes, rand_program, rand_list]
+    types = [rand_optional, rand_int, rand_string, rand_bytes, rand_program, rand_list, rand_rust_program]
     return rnd.sample(types, 1)[0](rnd)
 
 def test_run_program() -> None:


### PR DESCRIPTION
for purposes of converting it from python structures.

This patch updates the behavior of converting a python structure into a `Program`. This fixes fidelity with the python implementation for how `SerializedProgram` is treated. In python it hits [this](https://github.com/Chia-Network/clvm/blob/main/clvm/SExp.py#L52-L53) case, and converts to `bytes`.

This is now correctly reflected in the `clvm_convert()` function. The test was expanded to cover this case.

This requires a recent version of the `clvm` wheel, (0.9.8).