### PR TITLE
Switch to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,9 +36,7 @@ jobs:
           python -m pip install --upgrade pip
 
     - name: Set up rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+      uses: dtolnay/rust-toolchain@stable
 
     - name: setup venv
       run: |
@@ -85,9 +83,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Set up rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+      uses: dtolnay/rust-toolchain@stable
 
     - name: setup venv
       run: |
@@ -128,9 +124,7 @@ jobs:
         fetch-depth: 1
 
     - name: Set up rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+      uses: dtolnay/rust-toolchain@stable
 
     - name: cargo bench
       run: |

--- a/.github/workflows/build-crate-and-npm.yml
+++ b/.github/workflows/build-crate-and-npm.yml
@@ -23,15 +23,13 @@ jobs:
         fetch-depth: 0
 
     - name: Set up rusts
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
         components: rustfmt, clippy
 
     - name: Set up rust (nightly)
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly
         components: rustfmt, clippy
 
     - name: fmt (nightly)

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -140,9 +140,7 @@ jobs:
           python -m pip install --upgrade pip
 
     - name: Set up rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Install dependencies
       run: |
@@ -282,12 +280,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
+
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-            toolchain: nightly
             components: rustfmt, clippy
-            override: true
+        run: rustup override set nightly
+
       - name: fmt
         run: |
             cargo fmt --all -- --files-with-diff --check
@@ -298,11 +297,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
           components: clippy
-          override: true
+        run: rustup override set nightly
+
       - name: workspace
         run: |
             cargo clippy --workspace --all-features -- -Dwarnings
@@ -317,9 +316,7 @@ jobs:
         CARGO_PROFILE_RELEASE_LTO: false
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: nightly
+      - uses: dtolnay/rust-toolchain@nightly
       - name: cargo-fuzz
         run: cargo +nightly install cargo-fuzz
       - name: cargo fuzz (chia_rs)
@@ -365,9 +362,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - name: Prepare for coverage
         if: matrix.os == 'ubuntu-latest'
         run: |


### PR DESCRIPTION
[https://github.com/actions-rs/toolchain](actions-rs/toolchain) is archived and unmaintained, so we should use [https://github.com/dtolnay/rust-toolchain](dtolnay/rust-toolchain) instead.