### PR TITLE
add missing type annotation of HeaderBlock

### DIFF
--- a/wheel/chia_rs.pyi
+++ b/wheel/chia_rs.pyi
@@ -1654,6 +1654,7 @@ class HeaderBlock:
     transactions_filter: bytes
     transactions_info: Optional[TransactionsInfo]
     prev_header_hash: bytes32
+    prev_hash: bytes32
     header_hash: bytes32
     height: int
     weight: int

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -179,6 +179,7 @@ extra_members = {
     ],
     "HeaderBlock": [
         "prev_header_hash: bytes32",
+        "prev_hash: bytes32",
         "header_hash: bytes32",
         "height: int",
         "weight: int",


### PR DESCRIPTION
`HeaderBlock` is missing type annotation for `prev_hash`.

It's defined here: https://github.com/Chia-Network/chia_rs/blob/main/chia-protocol/src/header_block.rs#L90
and here in the python counterpart: https://github.com/Chia-Network/chia-blockchain/blob/main/chia/types/header_block.py#L36