### PR TITLE
add BlockRecord

### DIFF
--- a/chia-protocol/fuzz/fuzz_targets/streamable.rs
+++ b/chia-protocol/fuzz/fuzz_targets/streamable.rs
@@ -67,6 +67,7 @@ fuzz_target!(|data: &[u8]| {
     test::<FoliageBlockData>(data);
     test::<Foliage>(data);
     test::<FullBlock>(data);
+    test::<BlockRecord>(data);
     test::<UnfinishedBlock>(data);
     test::<HeaderBlock>(data);
     test::<PoolTarget>(data);

--- a/chia-protocol/src/block_record.rs
+++ b/chia-protocol/src/block_record.rs
@@ -1,0 +1,157 @@
+use chia_streamable_macro::Streamable;
+
+use crate::streamable_struct;
+use crate::{Bytes32, ClassgroupElement, Coin, SubEpochSummary};
+
+#[cfg(feature = "py-bindings")]
+use pyo3::prelude::*;
+
+// This class is not included or hashed into the blockchain, but it is kept in memory as a more
+// efficient way to maintain data about the blockchain. This allows us to validate future blocks,
+// difficulty adjustments, etc, without saving the whole header block in memory.
+streamable_struct! (BlockRecord {
+    header_hash: Bytes32,
+    // Header hash of the previous block
+    prev_hash: Bytes32,
+    height: u32,
+    // Total cumulative difficulty of all ancestor blocks since genesis
+    weight: u128,
+    // Total number of VDF iterations since genesis, including this block
+    total_iters: u128,
+    signage_point_index: u8,
+    // This is the intermediary VDF output at ip_iters in challenge chain
+    challenge_vdf_output: ClassgroupElement,
+    // This is the intermediary VDF output at ip_iters in infused cc, iff deficit <= 3
+    infused_challenge_vdf_output: Option<ClassgroupElement>,
+    // The reward chain infusion output, input to next VDF
+    reward_infusion_new_challenge: Bytes32,
+    // Hash of challenge chain data, used to validate end of slots in the future
+    challenge_block_info_hash: Bytes32,
+    // Current network sub_slot_iters parameter
+    sub_slot_iters: u64,
+    // Need to keep track of these because Coins are created in a future block
+    pool_puzzle_hash: Bytes32,
+    farmer_puzzle_hash: Bytes32,
+    // The number of iters required for this proof of space
+    required_iters: u64,
+    // A deficit of 16 is an overflow block after an infusion. Deficit of 15 is a challenge block
+    deficit: u8,
+    overflow: bool,
+    prev_transaction_block_height: u32,
+
+    // Transaction block (present iff is_transaction_block)
+    timestamp: Option<u64>,
+    // Header hash of the previous transaction block
+    prev_transaction_block_hash: Option<Bytes32>,
+    fees: Option<u64>,
+    reward_claims_incorporated: Option<Vec<Coin>>,
+
+    // Slot (present iff this is the first SB in sub slot)
+    finished_challenge_slot_hashes: Option<Vec<Bytes32>>,
+    finished_infused_challenge_slot_hashes: Option<Vec<Bytes32>>,
+    finished_reward_slot_hashes: Option<Vec<Bytes32>>,
+
+    // Sub-epoch (present iff this is the first SB after sub-epoch)
+    sub_epoch_summary_included: Option<SubEpochSummary>,
+});
+
+impl BlockRecord {
+    pub fn is_transaction_block(&self) -> bool {
+        self.timestamp.is_some()
+    }
+
+    pub fn first_in_sub_slot(&self) -> bool {
+        self.finished_challenge_slot_hashes.is_some()
+    }
+
+    pub fn is_challenge_block(&self, min_blocks_per_challenge_block: u8) -> bool {
+        self.deficit == min_blocks_per_challenge_block - 1
+    }
+}
+
+#[cfg(feature = "py-bindings")]
+use pyo3::types::PyDict;
+
+#[cfg(feature = "py-bindings")]
+use pyo3::exceptions::PyValueError;
+
+#[cfg(feature = "py-bindings")]
+#[pymethods]
+impl BlockRecord {
+    #[getter]
+    #[pyo3(name = "is_transaction_block")]
+    fn py_is_transaction_block(&self) -> bool {
+        self.is_transaction_block()
+    }
+
+    #[getter]
+    #[pyo3(name = "first_in_sub_slot")]
+    fn py_first_in_sub_slot(&self) -> bool {
+        self.first_in_sub_slot()
+    }
+
+    #[pyo3(name = "is_challenge_block")]
+    fn py_is_challenge_block(&self, constants: &PyAny) -> PyResult<bool> {
+        Ok(self.is_challenge_block(
+            constants
+                .getattr("MIN_BLOCKS_PER_CHALLENGE_BLOCK")?
+                .extract::<u8>()?,
+        ))
+    }
+
+    // TODO: at some point it would be nice to port
+    // chia.consensus.pot_iterations to rust, and make this less hacky
+    fn sp_sub_slot_total_iters(&self, py: Python, constants: &PyAny) -> PyResult<u128> {
+        let ret = self
+            .total_iters
+            .checked_sub(self.ip_iters(py, constants)? as u128)
+            .ok_or(PyValueError::new_err("uint128 overflow"))?;
+        if self.overflow {
+            ret.checked_sub(self.sub_slot_iters as u128)
+                .ok_or(PyValueError::new_err("uint128 overflow"))
+        } else {
+            Ok(ret)
+        }
+    }
+
+    fn ip_sub_slot_total_iters(&self, py: Python, constants: &PyAny) -> PyResult<u128> {
+        self.total_iters
+            .checked_sub(self.ip_iters(py, constants)? as u128)
+            .ok_or(PyValueError::new_err("uint128 overflow"))
+    }
+
+    fn sp_iters(&self, py: Python, constants: &PyAny) -> PyResult<u64> {
+        let ctx: &PyDict = PyDict::new(py);
+        ctx.set_item("sub_slot_iters", self.sub_slot_iters)?;
+        ctx.set_item("signage_point_index", self.signage_point_index)?;
+        ctx.set_item("constants", constants)?;
+        py.run(
+            "from chia.consensus.pot_iterations import calculate_ip_iters, calculate_sp_iters\n\
+            ret = calculate_sp_iters(constants, sub_slot_iters, signage_point_index)\n",
+            None,
+            Some(ctx),
+        )?;
+        ctx.get_item("ret").unwrap().extract::<u64>()
+    }
+
+    fn ip_iters(&self, py: Python, constants: &PyAny) -> PyResult<u64> {
+        let ctx: &PyDict = PyDict::new(py);
+        ctx.set_item("sub_slot_iters", self.sub_slot_iters)?;
+        ctx.set_item("signage_point_index", self.signage_point_index)?;
+        ctx.set_item("required_iters", self.required_iters)?;
+        ctx.set_item("constants", constants)?;
+        py.run(
+            "from chia.consensus.pot_iterations import calculate_ip_iters, calculate_sp_iters\n\
+            ret = calculate_ip_iters(constants, sub_slot_iters, signage_point_index, required_iters)\n",
+            None,
+            Some(ctx),
+            )?;
+        ctx.get_item("ret").unwrap().extract::<u64>()
+    }
+
+    fn sp_total_iters(&self, py: Python, constants: &PyAny) -> PyResult<u128> {
+        self.sp_sub_slot_total_iters(py, constants)?
+            .checked_add(self.sp_iters(py, constants)? as u128)
+            .ok_or(PyValueError::new_err("uint128 overflow"))
+    }
+}

--- a/chia-protocol/src/lib.rs
+++ b/chia-protocol/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod block_record;
 pub mod bytes;
 pub mod chia_protocol;
 pub mod classgroup;
@@ -28,6 +29,7 @@ pub mod weight_proof;
 pub mod lazy_node;
 
 // export shorter names
+pub use crate::block_record::*;
 pub use crate::bytes::*;
 pub use crate::chia_protocol::*;
 pub use crate::classgroup::*;

--- a/tests/test_block_record_fidelity.py
+++ b/tests/test_block_record_fidelity.py
@@ -1,0 +1,148 @@
+from typing import List, Tuple, Optional, Any, Callable
+
+import string
+import sys
+import time
+from chia_rs import BlockRecord, ClassgroupElement
+from chia.consensus.block_record import BlockRecord as PyBlockRecord
+from chia.types.blockchain_format.sized_bytes import bytes32, bytes100
+from random import Random
+from chia.consensus.default_constants import DEFAULT_CONSTANTS
+from chia.util.ints import uint32, uint64, uint8, uint128
+
+
+def get_classgroup_element(rng: Random) -> ClassgroupElement:
+    return ClassgroupElement(bytes100.random(rng))
+
+
+def get_u4(rng: Random) -> uint8:
+    return uint8(rng.randint(0, 0xF))
+
+
+def get_u8(rng: Random) -> uint8:
+    return uint8(rng.randint(0, 0xFF))
+
+
+def get_u32(rng: Random) -> uint32:
+    return uint32(rng.randint(0, 0xFFFFFFFF))
+
+
+def get_ssi(rng: Random) -> uint64:
+    return uint64(DEFAULT_CONSTANTS.NUM_SPS_SUB_SLOT * rng.randint(0, 0xFFFF) + rng.randint(
+        0, 1
+    ))
+
+
+def get_u64(rng: Random) -> uint64:
+    return uint64(rng.randint(0, 0xFFFFFFFFFFFFFFFF))
+
+
+def get_u128(rng: Random) -> uint128:
+    return uint128(rng.randint(0, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
+
+
+def get_optional(rng: Random, gen: Callable[[Random], Any]) -> Optional[Any]:
+    if rng.randint(0, 1) == 0:
+        return None
+    else:
+        return gen(rng)
+
+
+def get_list(rng: Random, gen: Callable[[Random], Any]) -> List[Any]:
+    length = rng.sample([0, 1, 5, 32, 500], 1)[0]
+    ret: List[Any] = []
+    for i in range(length):
+        ret.append(gen(rng))
+    return ret
+
+
+def get_bool(rng: Random) -> bool:
+    return rng.randint(0, 1) == 1
+
+
+def get_hash(rng: Random) -> bytes32:
+    return bytes32.random(rng)
+
+
+def get_block_record(rng: Random) -> BlockRecord:
+    height = get_u32(rng)
+    weight = get_u128(rng)
+    iters = get_u128(rng)
+    sp_index = get_u4(rng)
+    vdf_out = get_classgroup_element(rng)
+    infused_challenge = get_optional(rng, get_classgroup_element)
+    sub_slot_iters = get_ssi(rng)
+    required_iters = get_u64(rng)
+    deficit = get_u8(rng)
+    overflow = get_bool(rng)
+    prev_tx_height = get_u32(rng)
+    timestamp = 123456789
+    prev_tx_hash = get_optional(rng, get_hash)
+    fees = get_optional(rng, get_u64)
+
+    return BlockRecord(
+        bytes32.random(rng),
+        bytes32.random(rng),
+        height,
+        weight,
+        iters,
+        sp_index,
+        vdf_out,
+        infused_challenge,
+        bytes32.random(rng),
+        bytes32.random(rng),
+        sub_slot_iters,
+        bytes32.random(rng),
+        bytes32.random(rng),
+        required_iters,
+        deficit,
+        overflow,
+        prev_tx_height,
+        timestamp,
+        prev_tx_hash,
+        fees,
+        [],
+        None,
+        None,
+        None,
+        None,
+    )
+
+
+def wrap_call(expr: str, br: Any) -> str:
+    try:
+        ret = eval(expr, None, {"br": br})
+        return f"V:{ret}"
+    except Exception as e:
+        return f"E:{e}"
+
+
+def test_block_record() -> None:
+    rng = Random()
+    seed = int(time.time())
+    print(f"seed: {seed}")
+    rng.seed(seed)
+
+    for i in range(500000):
+        br = get_block_record(rng)
+        serialized = bytes(br)
+        py_identity = PyBlockRecord.from_bytes(serialized)
+
+        assert bytes(py_identity) == serialized
+        assert f"{type(br)}" != f"{type(py_identity)}"
+
+        for test_call in [
+            "ip_iters",
+            "sp_total_iters",
+            "sp_iters",
+            "ip_sub_slot_total_iters",
+            "sp_sub_slot_total_iters",
+        ]:
+            rust_ret = wrap_call(f"br.{test_call}(DEFAULT_CONSTANTS)", br)
+            py_ret = wrap_call(f"br.{test_call}(DEFAULT_CONSTANTS)", py_identity)
+
+            assert rust_ret == py_ret
+
+        if (i & 0x3FF) == 0:
+            sys.stdout.write(f" {i}     \r")
+            sys.stdout.flush()

--- a/wheel/chia_rs.pyi
+++ b/wheel/chia_rs.pyi
@@ -6,6 +6,7 @@
 from typing import List, Optional, Sequence, Tuple
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.program import Program as ChiaProgram
+from chia.consensus.constants import ConsensusConstants
 
 ReadableBuffer = Union[bytes, bytearray, memoryview]
 
@@ -342,6 +343,112 @@ class SpendBundleConditions:
         cost: Union[ int, _Unspec] = _Unspec(),
         removal_amount: Union[ int, _Unspec] = _Unspec(),
         addition_amount: Union[ int, _Unspec] = _Unspec()) -> SpendBundleConditions: ...
+
+class BlockRecord:
+    header_hash: bytes32
+    prev_hash: bytes32
+    height: int
+    weight: int
+    total_iters: int
+    signage_point_index: int
+    challenge_vdf_output: ClassgroupElement
+    infused_challenge_vdf_output: Optional[ClassgroupElement]
+    reward_infusion_new_challenge: bytes32
+    challenge_block_info_hash: bytes32
+    sub_slot_iters: int
+    pool_puzzle_hash: bytes32
+    farmer_puzzle_hash: bytes32
+    required_iters: int
+    deficit: int
+    overflow: bool
+    prev_transaction_block_height: int
+    timestamp: Optional[int]
+    prev_transaction_block_hash: Optional[bytes32]
+    fees: Optional[int]
+    reward_claims_incorporated: Optional[List[Coin]]
+    finished_challenge_slot_hashes: Optional[List[bytes32]]
+    finished_infused_challenge_slot_hashes: Optional[List[bytes32]]
+    finished_reward_slot_hashes: Optional[List[bytes32]]
+    sub_epoch_summary_included: Optional[SubEpochSummary]
+    is_transaction_block: bool
+    first_in_sub_slot: bool
+    def is_challenge_block(self, constants: ConsensusConstants) -> bool: ...
+    def sp_sub_slot_total_iters(self, constants: ConsensusConstants) -> int: ...
+    def ip_sub_slot_total_iters(self, constants: ConsensusConstants) -> int: ...
+    def sp_iters(self, constants: ConsensusConstants) -> int: ...
+    def ip_iters(self, constants: ConsensusConstants) -> int: ...
+    def sp_total_iters(self, constants: ConsensusConstants) -> int: ...
+    def __init__(
+        self,
+        header_hash: bytes,
+        prev_hash: bytes,
+        height: int,
+        weight: int,
+        total_iters: int,
+        signage_point_index: int,
+        challenge_vdf_output: ClassgroupElement,
+        infused_challenge_vdf_output: Optional[ClassgroupElement],
+        reward_infusion_new_challenge: bytes,
+        challenge_block_info_hash: bytes,
+        sub_slot_iters: int,
+        pool_puzzle_hash: bytes,
+        farmer_puzzle_hash: bytes,
+        required_iters: int,
+        deficit: int,
+        overflow: bool,
+        prev_transaction_block_height: int,
+        timestamp: Optional[int],
+        prev_transaction_block_hash: Optional[bytes32],
+        fees: Optional[int],
+        reward_claims_incorporated: Optional[Sequence[Coin]],
+        finished_challenge_slot_hashes: Optional[Sequence[bytes32]],
+        finished_infused_challenge_slot_hashes: Optional[Sequence[bytes32]],
+        finished_reward_slot_hashes: Optional[Sequence[bytes32]],
+        sub_epoch_summary_included: Optional[SubEpochSummary]
+    ) -> None: ...
+    def __hash__(self) -> int: ...
+    def __repr__(self) -> str: ...
+    def __richcmp__(self) -> Any: ...
+    def __deepcopy__(self) -> BlockRecord: ...
+    def __copy__(self) -> BlockRecord: ...
+    @staticmethod
+    def from_bytes(bytes) -> BlockRecord: ...
+    @staticmethod
+    def from_bytes_unchecked(bytes) -> BlockRecord: ...
+    @staticmethod
+    def parse_rust(ReadableBuffer, bool = False) -> Tuple[BlockRecord, int]: ...
+    def to_bytes(self) -> bytes: ...
+    def __bytes__(self) -> bytes: ...
+    def stream_to_bytes(self) -> bytes: ...
+    def get_hash(self) -> bytes32: ...
+    def to_json_dict(self) -> Dict[str, Any]: ...
+    @staticmethod
+    def from_json_dict(json_dict: Dict[str, Any]) -> BlockRecord: ...
+    def replace(self, *, header_hash: Union[ bytes32, _Unspec] = _Unspec(),
+        prev_hash: Union[ bytes32, _Unspec] = _Unspec(),
+        height: Union[ int, _Unspec] = _Unspec(),
+        weight: Union[ int, _Unspec] = _Unspec(),
+        total_iters: Union[ int, _Unspec] = _Unspec(),
+        signage_point_index: Union[ int, _Unspec] = _Unspec(),
+        challenge_vdf_output: Union[ ClassgroupElement, _Unspec] = _Unspec(),
+        infused_challenge_vdf_output: Union[ Optional[ClassgroupElement], _Unspec] = _Unspec(),
+        reward_infusion_new_challenge: Union[ bytes32, _Unspec] = _Unspec(),
+        challenge_block_info_hash: Union[ bytes32, _Unspec] = _Unspec(),
+        sub_slot_iters: Union[ int, _Unspec] = _Unspec(),
+        pool_puzzle_hash: Union[ bytes32, _Unspec] = _Unspec(),
+        farmer_puzzle_hash: Union[ bytes32, _Unspec] = _Unspec(),
+        required_iters: Union[ int, _Unspec] = _Unspec(),
+        deficit: Union[ int, _Unspec] = _Unspec(),
+        overflow: Union[ bool, _Unspec] = _Unspec(),
+        prev_transaction_block_height: Union[ int, _Unspec] = _Unspec(),
+        timestamp: Union[ Optional[int], _Unspec] = _Unspec(),
+        prev_transaction_block_hash: Union[ Optional[bytes32], _Unspec] = _Unspec(),
+        fees: Union[ Optional[int], _Unspec] = _Unspec(),
+        reward_claims_incorporated: Union[ Optional[List[Coin]], _Unspec] = _Unspec(),
+        finished_challenge_slot_hashes: Union[ Optional[List[bytes32]], _Unspec] = _Unspec(),
+        finished_infused_challenge_slot_hashes: Union[ Optional[List[bytes32]], _Unspec] = _Unspec(),
+        finished_reward_slot_hashes: Union[ Optional[List[bytes32]], _Unspec] = _Unspec(),
+        sub_epoch_summary_included: Union[ Optional[SubEpochSummary], _Unspec] = _Unspec()) -> BlockRecord: ...
 
 class Message:
     msg_type: int

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -215,6 +215,16 @@ extra_members = {
         "def additions(self) -> List[Coin]: ...",
         "def debug(self) -> None: ...",
     ],
+    "BlockRecord": [
+        "is_transaction_block: bool",
+        "first_in_sub_slot: bool",
+        "def is_challenge_block(self, constants: ConsensusConstants) -> bool: ...",
+        "def sp_sub_slot_total_iters(self, constants: ConsensusConstants) -> int: ...",
+        "def ip_sub_slot_total_iters(self, constants: ConsensusConstants) -> int: ...",
+        "def sp_iters(self, constants: ConsensusConstants) -> int: ...",
+        "def ip_iters(self, constants: ConsensusConstants) -> int: ...",
+        "def sp_total_iters(self, constants: ConsensusConstants) -> int: ...",
+    ],
 }
 
 classes = []
@@ -233,6 +243,7 @@ with open(output_file, "w") as f:
 from typing import List, Optional, Sequence, Tuple
 from chia.types.blockchain_format.sized_bytes import bytes32
 from chia.types.blockchain_format.program import Program as ChiaProgram
+from chia.consensus.constants import ConsensusConstants
 
 ReadableBuffer = Union[bytes, bytearray, memoryview]
 

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -14,8 +14,8 @@ use chia::gen::solution_generator::solution_generator as native_solution_generat
 use chia::gen::solution_generator::solution_generator_backrefs as native_solution_generator_backrefs;
 use chia::merkle_set::compute_merkle_set_root as compute_merkle_root_impl;
 use chia_protocol::{
-    Bytes32, ChallengeBlockInfo, ChallengeChainSubSlot, ClassgroupElement, Coin, CoinSpend,
-    CoinState, CoinStateUpdate, EndOfSubSlotBundle, Foliage, FoliageBlockData,
+    BlockRecord, Bytes32, ChallengeBlockInfo, ChallengeChainSubSlot, ClassgroupElement, Coin,
+    CoinSpend, CoinState, CoinStateUpdate, EndOfSubSlotBundle, Foliage, FoliageBlockData,
     FoliageTransactionBlock, FullBlock, HeaderBlock, InfusedChallengeChainSubSlot, NewCompactVDF,
     NewPeak, NewPeakWallet, NewSignagePointOrEndOfSubSlot, NewTransaction, NewUnfinishedBlock,
     PoolTarget, Program, ProofBlockHeader, ProofOfSpace, PuzzleSolutionResponse, RecentChainData,
@@ -392,6 +392,7 @@ pub fn chia_rs(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<SubEpochSummary>()?;
     m.add_class::<UnfinishedBlock>()?;
     m.add_class::<FullBlock>()?;
+    m.add_class::<BlockRecord>()?;
     m.add_class::<WeightProof>()?;
     m.add_class::<RecentChainData>()?;
     m.add_class::<ProofBlockHeader>()?;


### PR DESCRIPTION
This PR is best reviewed one commit at a time.

This adds the `BlockRecord` type, defined in python [here](https://github.com/Chia-Network/chia-blockchain/blob/main/chia/consensus/block_record.py#L46).

The main challenge in this type is implementing `sp_sub_slot_total_iters()`, `ip_sub_slot_total_iters()`, `sp_iters()`, `ip_iters()`, `sp_total_iters()`. The underlying functions used by these are implemented in python.

This patch calls back into python to run these functions. It's not elegant or efficient, but it's a stop-gap until we have ported these functions to rust.

In order to ensure this works, a fuzzer constructs an arbitrary `BlockRecord` object and calls all these functions on both the rust and python version, ensuring the results are identical, including failures.