### PR TITLE
Address issues with windows AMD K10 architecture - Build with clang for portable SHA256

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -176,6 +176,9 @@ jobs:
 
     - name: Build Windows with maturin on Python ${{ matrix.python }}
       if: matrix.os.matrix == 'windows'
+      env:
+        CC: 'clang'
+        CFLAGS: "-D__BLST_PORTABLE__"
       run: |
         py -${{ matrix.python.major-dot-minor }} -m venv venv
         . .\venv\Scripts\Activate.ps1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,8 +233,7 @@ dependencies = [
 [[package]]
 name = "blst"
 version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
+source = "git+https://github.com/supranational/blst.git?rev=0d46eefa45fc1e57aceb42bba0e84eab3a7a9725#0d46eefa45fc1e57aceb42bba0e84eab3a7a9725"
 dependencies = [
  "cc",
  "glob",
@@ -283,7 +282,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chia"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "chia-protocol",
  "chia-traits",
@@ -303,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "chia-bls"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -334,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "chia-client"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "chia-protocol",
  "chia-traits",
@@ -361,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "chia-protocol"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "arbitrary",
  "chia-bls",
@@ -390,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "chia-ssl"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "lazy_static",
  "rand",
@@ -422,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "chia-traits"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "chia_py_streamable_macro",
  "chia_streamable_macro",
@@ -444,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "chia_py_streamable_macro"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,6 @@ crate-type = ["rlib"]
 
 [profile.release]
 lto = "thin"
+
+[patch.crates-io]
+blst = { git = "https://github.com/supranational/blst.git", rev = "0d46eefa45fc1e57aceb42bba0e84eab3a7a9725" }

--- a/chia-bls/Cargo.toml
+++ b/chia-bls/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0.71"
 # the newer sha2 crate doesn't implement the digest traits required by hkdf
 sha2 = "0.9.9"
 hkdf = "0.11.0"
-blst = { version = "0.3.11", features = ["portable"] }
+blst = { version = "0.3.11", git = "https://github.com/supranational/blst.git", rev = "0d46eefa45fc1e57aceb42bba0e84eab3a7a9725", features = ["portable"] }
 clvmr = "=0.3.0"
 hex = "0.4.3"
 thiserror = "1.0.44"

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -24,3 +24,6 @@ chia-protocol = { version = "=0.2.13", path = "../chia-protocol", features = ["p
 chia-traits = { version = "=0.2.13", path = "../chia-traits", features = ["py-bindings"]  }
 chia_py_streamable_macro = { version = "=0.2.13", path = "../chia_py_streamable_macro" }
 chia_streamable_macro = { version = "=0.2.12", path = "../chia_streamable_macro" }
+
+[patch.crates-io]
+blst = { git = "https://github.com/supranational/blst.git", rev = "0d46eefa45fc1e57aceb42bba0e84eab3a7a9725" }


### PR DESCRIPTION
Use clang on windows and a target git reference for BLST to force BLST to compile SHA256 into portable mode.
This addresses the problem with AMD K10 architecture on Windows.