### PR TITLE
bump version to 0.2.15 using bump-version.py

### DIFF
--- a/.github/workflows/audit-check.yml
+++ b/.github/workflows/audit-check.yml
@@ -1,14 +1,13 @@
 name: Security audit
 on:
-  push:
-     paths:
-       - '**/Cargo.toml'
-       - '**/Cargo.lock'
+  pull_request:
+    branches:
+      - '**'
+
 jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: cargo audit
+        run: cargo audit --ignore RUSTSEC-2023-0071

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ exclude = ["wheel"]
 
 [package]
 name = "chia"
-version = "0.2.13"
+version = "0.2.15"
 edition = "2021"
 license = "Apache-2.0"
 description = "Utility functions and types used by the Chia blockchain full node"

--- a/chia-bls/src/secret_key.rs
+++ b/chia-bls/src/secret_key.rs
@@ -75,13 +75,13 @@ fn to_lamport_pk(ikm: [u8; 32], idx: u32) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(lamport0);
     hasher.update(lamport1);
-    hasher.finalize().try_into().unwrap()
+    hasher.finalize().into()
 }
 
 fn sha256(bytes: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
-    hasher.finalize().try_into().unwrap()
+    hasher.finalize().into()
 }
 
 pub fn is_all_zero(buf: &[u8]) -> bool {

--- a/chia-protocol/src/bytes.rs
+++ b/chia-protocol/src/bytes.rs
@@ -366,7 +366,7 @@ impl<const N: usize> FromJsonDict for BytesImpl<N> {
                 N
             )));
         }
-        Ok((&buf).try_into()?)
+        Ok((&buf).into())
     }
 }
 

--- a/chia-tools/Cargo.toml
+++ b/chia-tools/Cargo.toml
@@ -15,7 +15,7 @@ clvm-utils = { path = "../clvm-utils" }
 clvm-traits = { path = "../clvm-traits" }
 chia-wallet = { version = "=0.2.12", path = "../chia-wallet" }
 clvmr = { version = "=0.3.0", features = ["counters"] }
-chia = { version = "0.2.13", path = ".." }
+chia = { version = "0.2.15", path = ".." }
 sqlite = "=0.31.0"
 clap = { version = "=4.3.9", features = ["derive"] }
 zstd = "=0.12.3"

--- a/chia-tools/src/bin/fast-forward-spend.rs
+++ b/chia-tools/src/bin/fast-forward-spend.rs
@@ -36,8 +36,7 @@ fn main() {
     let new_parents_parent: Bytes32 = hex::decode(args.new_parents_parent)
         .expect("invalid hex")
         .as_slice()
-        .try_into()
-        .expect("parent_id");
+        .into();
 
     let mut a = Allocator::new_limited(500000000, 62500000, 62500000);
     let puzzle = spend.puzzle_reveal.to_clvm(&mut a).expect("to_clvm");

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia_rs"
-version = "0.2.13"
+version = "0.2.15"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 clvmr = "=0.3.0"
 hex = "=0.4.3"
 pyo3 = { version = "=0.19.0", features = ["extension-module", "multiple-pymethods"] }
-chia = { version = "=0.2.13", path = "..", features = ["py-bindings"] }
+chia = { version = "=0.2.15", path = "..", features = ["py-bindings"] }
 chia-bls = { version = "=0.2.13", path = "../chia-bls", features = ["py-bindings"]  }
 chia-protocol = { version = "=0.2.13", path = "../chia-protocol", features = ["py-bindings"]  }
 chia-traits = { version = "=0.2.13", path = "../chia-traits", features = ["py-bindings"]  }


### PR DESCRIPTION
this was automated by running:

```
python bump-version.py 0.2.15 0.2.13
```

Also
- remove python 3.7 from the benchmark test matrix
- update the cargo audit check workflow to match main
- minor fixes needed for clippy due to changes in rust 1.75 (current stable) that were not in the version of rust used at the time of `0.2.13`