### PR TITLE
Update trait impls and conversions for byte types

### DIFF
--- a/chia-protocol/src/bytes.rs
+++ b/chia-protocol/src/bytes.rs
@@ -163,7 +163,7 @@ impl<const N: usize> BytesImpl<N> {
         &self.0
     }
 
-    pub fn into_inner(self) -> [u8; N] {
+    pub fn to_bytes(self) -> [u8; N] {
         self.0
     }
 

--- a/chia-protocol/src/bytes.rs
+++ b/chia-protocol/src/bytes.rs
@@ -1,12 +1,9 @@
-use chia_traits::chia_error;
-use chia_traits::{read_bytes, Streamable};
+use chia_traits::{chia_error, read_bytes, Streamable};
 use clvm_traits::{ClvmDecoder, ClvmEncoder, FromClvm, FromClvmError, ToClvm, ToClvmError};
-use core::fmt::Formatter;
 use sha2::{Digest, Sha256};
-use std::convert::AsRef;
-use std::convert::TryInto;
+use std::array::TryFromSliceError;
+use std::convert::{AsRef, TryInto};
 use std::fmt;
-use std::fmt::Debug;
 use std::io::Cursor;
 use std::ops::Deref;
 
@@ -21,11 +18,15 @@ use pyo3::prelude::*;
 #[cfg(feature = "py-bindings")]
 use pyo3::types::PyBytes;
 
-#[derive(Hash, Clone, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Default, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
 pub struct Bytes(Vec<u8>);
 
 impl Bytes {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -37,6 +38,22 @@ impl Bytes {
     pub fn as_slice(&self) -> &[u8] {
         self.0.as_slice()
     }
+
+    pub fn into_inner(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl fmt::Debug for Bytes {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&hex::encode(self))
+    }
+}
+
+impl fmt::Display for Bytes {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(&hex::encode(self))
+    }
 }
 
 impl Streamable for Bytes {
@@ -44,6 +61,7 @@ impl Streamable for Bytes {
         (self.0.len() as u32).update_digest(digest);
         digest.update(&self.0);
     }
+
     fn stream(&self, out: &mut Vec<u8>) -> chia_error::Result<()> {
         if self.0.len() > u32::MAX as usize {
             Err(chia_error::Error::SequenceTooLarge)
@@ -57,12 +75,6 @@ impl Streamable for Bytes {
     fn parse<const TRUSTED: bool>(input: &mut Cursor<&[u8]>) -> chia_error::Result<Self> {
         let len = u32::parse::<TRUSTED>(input)?;
         Ok(Bytes(read_bytes(input, len as usize)?.to_vec()))
-    }
-}
-
-impl Debug for Bytes {
-    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        formatter.write_str(&hex::encode(&self.0))
     }
 }
 
@@ -106,63 +118,21 @@ impl<N> FromClvm<N> for Bytes {
     }
 }
 
-impl PartialEq<Bytes> for Vec<u8> {
-    fn eq(&self, lhs: &Bytes) -> bool {
-        *self == lhs.0
-    }
-}
-
-impl PartialEq<Vec<u8>> for Bytes {
-    fn eq(&self, lhs: &Vec<u8>) -> bool {
-        self.0 == *lhs
-    }
-}
-
-impl PartialEq<&[u8]> for Bytes {
-    fn eq(&self, lhs: &&[u8]) -> bool {
-        &self.0 == lhs
-    }
-}
-
-impl PartialEq<Bytes> for &[u8] {
-    fn eq(&self, lhs: &Bytes) -> bool {
-        self == &lhs.0
-    }
-}
-
-impl<const N: usize> PartialEq<[u8; N]> for Bytes {
-    fn eq(&self, lhs: &[u8; N]) -> bool {
-        self.0 == lhs
-    }
-}
-
-impl<const N: usize> PartialEq<&[u8; N]> for Bytes {
-    fn eq(&self, lhs: &&[u8; N]) -> bool {
-        self.0 == *lhs
-    }
-}
-
-impl<const N: usize> PartialEq<Bytes> for &[u8; N] {
-    fn eq(&self, lhs: &Bytes) -> bool {
-        lhs.0 == *self
-    }
-}
-
-impl<const N: usize> PartialEq<Bytes> for [u8; N] {
-    fn eq(&self, lhs: &Bytes) -> bool {
-        lhs.0 == self
-    }
-}
-
 impl From<&[u8]> for Bytes {
-    fn from(v: &[u8]) -> Bytes {
-        Bytes(v.to_vec())
+    fn from(value: &[u8]) -> Self {
+        Self(value.to_vec())
     }
 }
 
 impl From<Vec<u8>> for Bytes {
-    fn from(v: Vec<u8>) -> Bytes {
-        Bytes(v)
+    fn from(value: Vec<u8>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Bytes> for Vec<u8> {
+    fn from(value: Bytes) -> Self {
+        value.0
     }
 }
 
@@ -172,15 +142,53 @@ impl AsRef<[u8]> for Bytes {
     }
 }
 
-impl fmt::Display for Bytes {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str(&hex::encode(&self.0))
+impl Deref for Bytes {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.0
     }
 }
 
-#[derive(Hash, PartialEq, Eq, Copy, Clone, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
 pub struct BytesImpl<const N: usize>([u8; N]);
+
+impl<const N: usize> BytesImpl<N> {
+    pub fn new(bytes: [u8; N]) -> Self {
+        Self(bytes)
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> [u8; N] {
+        self.0
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+}
+
+impl<const N: usize> Default for BytesImpl<N> {
+    fn default() -> Self {
+        Self([0; N])
+    }
+}
+
+impl<const N: usize> fmt::Debug for BytesImpl<N> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        formatter.write_str(&hex::encode(self))
+    }
+}
+
+impl<const N: usize> fmt::Display for BytesImpl<N> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(&hex::encode(self))
+    }
+}
 
 impl<const N: usize> Streamable for BytesImpl<N> {
     fn update_digest(&self, digest: &mut Sha256) {
@@ -193,137 +201,6 @@ impl<const N: usize> Streamable for BytesImpl<N> {
 
     fn parse<const TRUSTED: bool>(input: &mut Cursor<&[u8]>) -> chia_error::Result<Self> {
         Ok(BytesImpl(read_bytes(input, N)?.try_into().unwrap()))
-    }
-}
-
-impl<N, const LEN: usize> ToClvm<N> for BytesImpl<LEN> {
-    fn to_clvm(&self, encoder: &mut impl ClvmEncoder<Node = N>) -> Result<N, ToClvmError> {
-        encoder.encode_atom(self.0.as_slice())
-    }
-}
-
-impl<N, const LEN: usize> FromClvm<N> for BytesImpl<LEN> {
-    fn from_clvm(decoder: &impl ClvmDecoder<Node = N>, node: N) -> Result<Self, FromClvmError> {
-        let bytes = decoder.decode_atom(&node)?;
-        if bytes.len() != LEN {
-            return Err(FromClvmError::WrongAtomLength {
-                expected: LEN,
-                found: bytes.len(),
-            });
-        }
-        Ok(Self::from(bytes))
-    }
-}
-
-impl<const N: usize> From<[u8; N]> for BytesImpl<N> {
-    fn from(v: [u8; N]) -> BytesImpl<N> {
-        BytesImpl::<N>(v)
-    }
-}
-impl<const N: usize> From<&[u8; N]> for BytesImpl<N> {
-    fn from(v: &[u8; N]) -> BytesImpl<N> {
-        BytesImpl::<N>(*v)
-    }
-}
-impl<const N: usize> From<&[u8]> for BytesImpl<N> {
-    fn from(v: &[u8]) -> BytesImpl<N> {
-        if v.len() != N {
-            panic!("invalid atom, expected {} bytes (got {})", N, v.len());
-        }
-        let mut ret = BytesImpl::<N>([0; N]);
-        ret.0.copy_from_slice(v);
-        ret
-    }
-}
-impl<const N: usize> From<&Vec<u8>> for BytesImpl<N> {
-    fn from(v: &Vec<u8>) -> BytesImpl<N> {
-        if v.len() != N {
-            panic!("invalid atom, expected {} bytes (got {})", N, v.len());
-        }
-        let mut ret = BytesImpl::<N>([0; N]);
-        ret.0.copy_from_slice(v);
-        ret
-    }
-}
-impl<'a, const N: usize> From<&'a BytesImpl<N>> for &'a [u8; N] {
-    fn from(v: &'a BytesImpl<N>) -> &'a [u8; N] {
-        &v.0
-    }
-}
-
-impl<const N: usize> From<&BytesImpl<N>> for [u8; N] {
-    fn from(v: &BytesImpl<N>) -> [u8; N] {
-        v.0
-    }
-}
-
-impl<'a, const N: usize> From<&'a BytesImpl<N>> for &'a [u8] {
-    fn from(v: &'a BytesImpl<N>) -> &'a [u8] {
-        &v.0
-    }
-}
-
-impl<const N: usize> BytesImpl<N> {
-    pub fn to_vec(&self) -> Vec<u8> {
-        self.0.to_vec()
-    }
-}
-
-impl<const N: usize> AsRef<[u8]> for BytesImpl<N> {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-impl<const N: usize> Deref for BytesImpl<N> {
-    type Target = [u8];
-    fn deref(&self) -> &[u8] {
-        &self.0
-    }
-}
-impl<const N: usize> Debug for BytesImpl<N> {
-    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        formatter.write_str(&hex::encode(self.0))
-    }
-}
-impl<const N: usize> fmt::Display for BytesImpl<N> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str(&hex::encode(self.0))
-    }
-}
-
-impl<const N: usize> PartialEq<&[u8]> for BytesImpl<N> {
-    fn eq(&self, lhs: &&[u8]) -> bool {
-        self.0 == *lhs
-    }
-}
-
-impl<const N: usize> PartialEq<BytesImpl<N>> for &[u8] {
-    fn eq(&self, lhs: &BytesImpl<N>) -> bool {
-        self == &lhs.0
-    }
-}
-
-impl<const N: usize> PartialEq<&[u8; N]> for BytesImpl<N> {
-    fn eq(&self, lhs: &&[u8; N]) -> bool {
-        &self.0 == *lhs
-    }
-}
-
-impl<const N: usize> PartialEq<BytesImpl<N>> for &[u8; N] {
-    fn eq(&self, lhs: &BytesImpl<N>) -> bool {
-        *self == &lhs.0
-    }
-}
-
-impl<const N: usize> PartialEq<[u8; N]> for BytesImpl<N> {
-    fn eq(&self, lhs: &[u8; N]) -> bool {
-        &self.0 == lhs
-    }
-}
-
-impl<const N: usize> PartialEq<BytesImpl<N>> for [u8; N] {
-    fn eq(&self, lhs: &BytesImpl<N>) -> bool {
-        self == &lhs.0
     }
 }
 
@@ -357,7 +234,106 @@ impl<const N: usize> FromJsonDict for BytesImpl<N> {
                 N
             )));
         }
-        Ok((&buf).into())
+        Ok(buf.try_into().unwrap())
+    }
+}
+
+impl<N, const LEN: usize> ToClvm<N> for BytesImpl<LEN> {
+    fn to_clvm(&self, encoder: &mut impl ClvmEncoder<Node = N>) -> Result<N, ToClvmError> {
+        encoder.encode_atom(self.0.as_slice())
+    }
+}
+
+impl<N, const LEN: usize> FromClvm<N> for BytesImpl<LEN> {
+    fn from_clvm(decoder: &impl ClvmDecoder<Node = N>, node: N) -> Result<Self, FromClvmError> {
+        let bytes = decoder.decode_atom(&node)?;
+        if bytes.len() != LEN {
+            return Err(FromClvmError::WrongAtomLength {
+                expected: LEN,
+                found: bytes.len(),
+            });
+        }
+        Ok(Self::try_from(bytes).unwrap())
+    }
+}
+
+impl<const N: usize> TryFrom<&[u8]> for BytesImpl<N> {
+    type Error = TryFromSliceError;
+
+    fn try_from(value: &[u8]) -> Result<Self, TryFromSliceError> {
+        Ok(Self(value.try_into()?))
+    }
+}
+
+impl<const N: usize> TryFrom<Vec<u8>> for BytesImpl<N> {
+    type Error = TryFromSliceError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, TryFromSliceError> {
+        value.as_slice().try_into()
+    }
+}
+
+impl<const N: usize> TryFrom<&Vec<u8>> for BytesImpl<N> {
+    type Error = TryFromSliceError;
+
+    fn try_from(value: &Vec<u8>) -> Result<Self, TryFromSliceError> {
+        value.as_slice().try_into()
+    }
+}
+
+impl<const N: usize> From<BytesImpl<N>> for Vec<u8> {
+    fn from(value: BytesImpl<N>) -> Self {
+        value.to_vec()
+    }
+}
+
+impl<const N: usize> From<[u8; N]> for BytesImpl<N> {
+    fn from(value: [u8; N]) -> Self {
+        Self(value)
+    }
+}
+
+impl<const N: usize> From<&[u8; N]> for BytesImpl<N> {
+    fn from(value: &[u8; N]) -> Self {
+        Self(*value)
+    }
+}
+
+impl<const N: usize> From<BytesImpl<N>> for [u8; N] {
+    fn from(value: BytesImpl<N>) -> Self {
+        value.0
+    }
+}
+
+impl<'a, const N: usize> From<&'a BytesImpl<N>> for &'a [u8; N] {
+    fn from(value: &'a BytesImpl<N>) -> &'a [u8; N] {
+        &value.0
+    }
+}
+
+impl<const N: usize> From<&BytesImpl<N>> for [u8; N] {
+    fn from(value: &BytesImpl<N>) -> [u8; N] {
+        value.0
+    }
+}
+
+impl<'a, const N: usize> From<&'a BytesImpl<N>> for &'a [u8] {
+    fn from(value: &'a BytesImpl<N>) -> &'a [u8] {
+        &value.0
+    }
+}
+
+impl<const N: usize> AsRef<[u8]> for BytesImpl<N> {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<const N: usize> Deref for BytesImpl<N> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.0
     }
 }
 
@@ -449,11 +425,10 @@ mod tests {
     fn test_bytes_comparisons(#[case] lhs: &str, #[case] rhs: &str, #[case] expect_equal: bool) {
         let lhs_vec: Vec<u8> = hex::decode(lhs).expect("hex::decode");
         let rhs_vec: Vec<u8> = hex::decode(rhs).expect("hex::decode");
-        let lhs_slice = &lhs_vec[..];
-        let rhs_slice = &rhs_vec[..];
+
         if lhs_vec.len() == 32 && rhs_vec.len() == 32 {
-            let lhs = Bytes32::from(&lhs_vec);
-            let rhs = Bytes32::from(&rhs_vec);
+            let lhs = Bytes32::try_from(&lhs_vec).unwrap();
+            let rhs = Bytes32::try_from(&rhs_vec).unwrap();
 
             assert_eq!(lhs.len(), 32);
             assert_eq!(rhs.len(), 32);
@@ -461,49 +436,12 @@ mod tests {
             assert_eq!(lhs.is_empty(), lhs_vec.is_empty());
             assert_eq!(rhs.is_empty(), rhs_vec.is_empty());
 
-            // Bytes32 compare against arrays of the same size, not slices
-            let lhs_array: &[u8; 32] = lhs_slice.try_into().unwrap();
-            let rhs_array: &[u8; 32] = rhs_slice.try_into().unwrap();
             if expect_equal {
                 assert_eq!(lhs, rhs);
                 assert_eq!(rhs, lhs);
-
-                // array comparisons
-                assert_eq!(lhs, rhs_array);
-                assert_eq!(rhs, lhs_array);
-                assert_eq!(lhs_array, rhs);
-                assert_eq!(rhs_array, lhs);
-
-                assert_eq!(lhs, *rhs_array);
-                assert_eq!(rhs, *lhs_array);
-                assert_eq!(*lhs_array, rhs);
-                assert_eq!(*rhs_array, lhs);
-
-                // slice comparisona
-                assert_eq!(lhs, rhs_slice);
-                assert_eq!(rhs, lhs_slice);
-                assert_eq!(lhs_slice, rhs);
-                assert_eq!(rhs_slice, lhs);
             } else {
                 assert!(lhs != rhs);
                 assert!(rhs != lhs);
-
-                // array comparisons
-                assert!(lhs != rhs_array);
-                assert!(rhs != lhs_array);
-                assert!(lhs_array != rhs);
-                assert!(rhs_array != lhs);
-
-                assert!(lhs != *rhs_array);
-                assert!(rhs != *lhs_array);
-                assert!(*lhs_array != rhs);
-                assert!(*rhs_array != lhs);
-
-                // slice comparisons
-                assert!(lhs != rhs_slice);
-                assert!(rhs != lhs_slice);
-                assert!(lhs_slice != rhs);
-                assert!(rhs_slice != lhs);
             }
         } else {
             let lhs = Bytes::from(lhs_vec.clone());
@@ -515,47 +453,12 @@ mod tests {
             assert_eq!(lhs.is_empty(), lhs_vec.is_empty());
             assert_eq!(rhs.is_empty(), rhs_vec.is_empty());
 
-            // array comparisons
-            let array: &[u8; 3] = &[1, 2, 3];
-            assert!(lhs != array);
-            assert!(rhs != array);
-            assert!(array != lhs);
-            assert!(array != rhs);
-            assert!(lhs != *array);
-            assert!(rhs != *array);
-            assert!(*array != lhs);
-            assert!(*array != rhs);
-
             if expect_equal {
                 assert_eq!(lhs, rhs);
                 assert_eq!(rhs, lhs);
-
-                // slice comparisons
-                assert_eq!(lhs, rhs_slice);
-                assert_eq!(rhs, lhs_slice);
-                assert_eq!(lhs_slice, rhs);
-                assert_eq!(rhs_slice, lhs);
-
-                // vec comparisons
-                assert_eq!(lhs, rhs_vec);
-                assert_eq!(rhs, lhs_vec);
-                assert_eq!(lhs_vec, rhs);
-                assert_eq!(rhs_vec, lhs);
             } else {
                 assert!(lhs != rhs);
                 assert!(rhs != lhs);
-
-                // slice comparisons
-                assert!(lhs != rhs_slice);
-                assert!(rhs != lhs_slice);
-                assert!(lhs_slice != rhs);
-                assert!(rhs_slice != lhs);
-
-                // vec comparisons
-                assert!(lhs != rhs_vec);
-                assert!(rhs != lhs_vec);
-                assert!(lhs_vec != rhs);
-                assert!(rhs_vec != lhs);
             }
         }
     }
@@ -586,12 +489,12 @@ mod tests {
 
     #[test]
     fn test_stream_bytes32() {
-        let buf: &[u8] = &[
+        let buf = [
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
         ];
         let out = stream(&Bytes32::from(buf));
-        assert_eq!(&buf, &out);
+        assert_eq!(buf.as_slice(), &out);
     }
 
     #[test]
@@ -633,22 +536,22 @@ mod tests {
 
     #[test]
     fn test_parse_bytes32() {
-        let buf: &[u8] = &[
+        let buf = [
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32,
         ];
-        from_bytes::<Bytes32>(buf, Bytes32::from(buf));
+        from_bytes::<Bytes32>(&buf, Bytes32::from(buf));
         from_bytes_fail::<Bytes32>(&buf[0..30], chia_error::Error::EndOfBuffer);
     }
 
     #[test]
     fn test_parse_bytes48() {
-        let buf: &[u8] = &[
+        let buf = [
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
             25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
             47, 48,
         ];
-        from_bytes::<Bytes48>(buf, Bytes48::from(buf));
+        from_bytes::<Bytes48>(&buf, Bytes48::from(buf));
         from_bytes_fail::<Bytes48>(&buf[0..47], chia_error::Error::EndOfBuffer);
     }
 

--- a/chia-protocol/src/bytes.rs
+++ b/chia-protocol/src/bytes.rs
@@ -18,7 +18,7 @@ use pyo3::prelude::*;
 #[cfg(feature = "py-bindings")]
 use pyo3::types::PyBytes;
 
-#[derive(Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
 pub struct Bytes(Vec<u8>);
 
@@ -150,7 +150,7 @@ impl Deref for Bytes {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
 pub struct BytesImpl<const N: usize>([u8; N]);
 

--- a/chia-protocol/src/classgroup.rs
+++ b/chia-protocol/src/classgroup.rs
@@ -25,7 +25,9 @@ impl ClassgroupElement {
     #[staticmethod]
     pub fn create(bytes: &[u8]) -> ClassgroupElement {
         if bytes.len() == 100 {
-            ClassgroupElement { data: bytes.into() }
+            ClassgroupElement {
+                data: bytes.try_into().unwrap(),
+            }
         } else {
             assert!(bytes.len() < 100);
             let mut data = [0_u8; 100];

--- a/chia-protocol/src/spend_bundle.rs
+++ b/chia-protocol/src/spend_bundle.rs
@@ -177,12 +177,14 @@ mod tests {
     fn test_impl<F: Fn(Coin, SpendBundle)>(solution: &str, body: F) {
         let solution = hex::decode(solution).expect("hex::decode");
         let test_coin = Coin::new(
-            (&hex::decode("4444444444444444444444444444444444444444444444444444444444444444")
-                .unwrap())
-                .into(),
-            (&hex::decode("3333333333333333333333333333333333333333333333333333333333333333")
-                .unwrap())
-                .into(),
+            hex::decode("4444444444444444444444444444444444444444444444444444444444444444")
+                .unwrap()
+                .try_into()
+                .unwrap(),
+            hex::decode("3333333333333333333333333333333333333333333333333333333333333333")
+                .unwrap()
+                .try_into()
+                .unwrap(),
             1,
         );
         let spend = CoinSpend::new(
@@ -213,9 +215,10 @@ ff01\
 
             let new_coin = Coin::new(
                 test_coin.coin_id().into(),
-                (&hex::decode("2222222222222222222222222222222222222222222222222222222222222222")
-                    .unwrap())
-                    .into(),
+                hex::decode("2222222222222222222222222222222222222222222222222222222222222222")
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
                 1,
             );
             assert_eq!(additions, [new_coin]);

--- a/chia-tools/src/bin/fast-forward-spend.rs
+++ b/chia-tools/src/bin/fast-forward-spend.rs
@@ -34,8 +34,8 @@ fn main() {
 
     let new_parents_parent: Bytes32 = hex::decode(args.new_parents_parent)
         .expect("invalid hex")
-        .as_slice()
-        .into();
+        .try_into()
+        .unwrap();
 
     let mut a = Allocator::new_limited(500000000);
     let puzzle = spend.puzzle_reveal.to_node_ptr(&mut a).expect("to_clvm");

--- a/chia-tools/src/bin/gen-corpus.rs
+++ b/chia-tools/src/bin/gen-corpus.rs
@@ -89,7 +89,7 @@ fn main() {
                             };
 
                         let run_puzzle = seen_puzzles.lock().unwrap().insert(mod_hash);
-                        let fast_forward = (mod_hash == SINGLETON_TOP_LAYER_PUZZLE_HASH)
+                        let fast_forward = (*mod_hash == SINGLETON_TOP_LAYER_PUZZLE_HASH)
                             && seen_singletons.lock().unwrap().insert(puzzle_hash);
 
                         if !run_puzzle && !fast_forward && !args.spend_bundles {

--- a/chia-tools/src/visit_spends.rs
+++ b/chia-tools/src/visit_spends.rs
@@ -131,7 +131,7 @@ pub fn visit_spends<
         let [parent_id, puzzle, amount, solution, _spend_level_extra] =
             extract_n::<5>(a, spend, ErrorCode::InvalidCondition)?;
         let amount: u64 = a.number(amount).try_into().expect("invalid amount");
-        let parent_id = Bytes32::from(a.atom(parent_id));
+        let parent_id = Bytes32::try_from(a.atom(parent_id)).unwrap();
         callback(a, parent_id, amount, puzzle, solution);
     }
     Ok(())

--- a/fuzz/fuzz_targets/fast-forward.rs
+++ b/fuzz/fuzz_targets/fast-forward.rs
@@ -34,7 +34,7 @@ fuzz_target!(|data: &[u8]| {
     for new_amount in [0, 2, 3] {
         for new_parent_amount in [0, 2, 3] {
             let new_parent_coin = Coin {
-                parent_coin_info: new_parents_parent.as_slice().into(),
+                parent_coin_info: new_parents_parent.into(),
                 puzzle_hash,
                 amount: if new_parent_amount == 0 {
                     spend.coin.amount

--- a/src/fast_forward.rs
+++ b/src/fast_forward.rs
@@ -109,7 +109,7 @@ pub fn fast_forward_singleton(
 
     // this is the tree hash of the singleton top layer puzzle
     // the tree hash of singleton_top_layer_v1_1.clsp
-    if singleton.args.singleton_struct.mod_hash.into_inner() != SINGLETON_TOP_LAYER_PUZZLE_HASH {
+    if singleton.args.singleton_struct.mod_hash.as_ref() != SINGLETON_TOP_LAYER_PUZZLE_HASH {
         return Err(Error::NotSingletonModHash);
     }
 

--- a/src/fast_forward.rs
+++ b/src/fast_forward.rs
@@ -109,7 +109,7 @@ pub fn fast_forward_singleton(
 
     // this is the tree hash of the singleton top layer puzzle
     // the tree hash of singleton_top_layer_v1_1.clsp
-    if singleton.args.singleton_struct.mod_hash != SINGLETON_TOP_LAYER_PUZZLE_HASH {
+    if singleton.args.singleton_struct.mod_hash.into_inner() != SINGLETON_TOP_LAYER_PUZZLE_HASH {
         return Err(Error::NotSingletonModHash);
     }
 
@@ -141,18 +141,18 @@ pub fn fast_forward_singleton(
         amount: new_solution.lineage_proof.parent_amount,
     };
 
-    if parent_coin.coin_id() != coin.parent_coin_info {
+    if parent_coin.coin_id() != *coin.parent_coin_info {
         return Err(Error::ParentCoinMismatch);
     }
 
     let inner_puzzle_hash = tree_hash(a, singleton.args.inner_puzzle);
-    if inner_puzzle_hash != new_solution.lineage_proof.parent_inner_puzzle_hash {
+    if inner_puzzle_hash != *new_solution.lineage_proof.parent_inner_puzzle_hash {
         return Err(Error::InnerPuzzleHashMismatch);
     }
 
     let puzzle_hash = tree_hash(a, puzzle);
 
-    if puzzle_hash != new_parent.puzzle_hash || puzzle_hash != coin.puzzle_hash {
+    if puzzle_hash != *new_parent.puzzle_hash || puzzle_hash != *coin.puzzle_hash {
         // we can only fast-forward if the puzzle hash match the new coin
         // the spend is assumed to be valied already, so we don't check it
         // against the original coin being spent
@@ -166,7 +166,7 @@ pub fn fast_forward_singleton(
 
     let expected_new_parent = new_parent.coin_id();
 
-    if new_coin.parent_coin_info != expected_new_parent {
+    if *new_coin.parent_coin_info != expected_new_parent {
         return Err(Error::CoinMismatch);
     }
 
@@ -213,7 +213,7 @@ mod tests {
         let puzzle_hash = Bytes32::from(tree_hash(&a, puzzle));
 
         let new_parent_coin = Coin {
-            parent_coin_info: new_parents_parent.as_slice().into(),
+            parent_coin_info: new_parents_parent.try_into().unwrap(),
             puzzle_hash,
             amount: if prev_amount == 0 {
                 spend.coin.amount
@@ -285,7 +285,7 @@ mod tests {
         let puzzle_hash = Bytes32::from(tree_hash(&a, puzzle));
 
         let mut new_parent_coin = Coin {
-            parent_coin_info: new_parents_parent.into(),
+            parent_coin_info: new_parents_parent.try_into().unwrap(),
             puzzle_hash,
             amount: spend.coin.amount,
         };

--- a/src/gen/coin_id.rs
+++ b/src/gen/coin_id.rs
@@ -12,7 +12,8 @@ pub fn compute_coin_id(
     hasher.update(a.atom(parent_id));
     hasher.update(a.atom(puzzle_hash));
     hasher.update(amount);
-    hasher.finalize().as_slice().into()
+    let coin_id: [u8; 32] = hasher.finalize().into();
+    coin_id.into()
 }
 
 // from chia.types.blockchain_format.coin import Coin

--- a/src/gen/conditions.rs
+++ b/src/gen/conditions.rs
@@ -2447,7 +2447,7 @@ fn test_single_create_coin() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(&c.puzzle_hash.into_inner(), H2);
+        assert_eq!(c.puzzle_hash.as_ref(), H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.nil());
     }
@@ -2470,7 +2470,7 @@ fn test_create_coin_max_amount() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(&c.puzzle_hash.into_inner(), H2);
+        assert_eq!(c.puzzle_hash.as_ref(), H2);
         assert_eq!(c.amount, 0xffffffffffffffff_u64);
         assert_eq!(c.hint, a.nil());
     }
@@ -2536,7 +2536,7 @@ fn test_create_coin_with_hint() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert!(&c.puzzle_hash.into_inner() == H2);
+        assert!(c.puzzle_hash.as_ref() == H2);
         assert!(c.amount == 42_u64);
         assert!(a.atom(c.hint) == H1.to_vec());
     }
@@ -2559,7 +2559,7 @@ fn test_create_coin_extra_arg() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert!(&c.puzzle_hash.into_inner() == H2);
+        assert!(c.puzzle_hash.as_ref() == H2);
         assert!(c.amount == 42_u64);
         assert!(a.atom(c.hint) == H1.to_vec());
     }
@@ -2580,7 +2580,7 @@ fn test_create_coin_with_multiple_hints() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert!(&c.puzzle_hash.into_inner() == H2);
+        assert!(c.puzzle_hash.as_ref() == H2);
         assert!(c.amount == 42_u64);
         assert!(a.atom(c.hint) == H1.to_vec());
     }
@@ -2602,7 +2602,7 @@ fn test_create_coin_with_hint_as_atom() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(&c.puzzle_hash.into_inner(), H2);
+        assert_eq!(c.puzzle_hash.as_ref(), H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.nil());
     }
@@ -2623,7 +2623,7 @@ fn test_create_coin_with_invalid_hint_as_terminator() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(&c.puzzle_hash.into_inner(), H2);
+        assert_eq!(c.puzzle_hash.as_ref(), H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.nil());
     }
@@ -2657,7 +2657,7 @@ fn test_create_coin_with_short_hint() {
     assert_eq!(spend.create_coin.len(), 1);
 
     for c in &spend.create_coin {
-        assert!(&c.puzzle_hash.into_inner() == H2);
+        assert!(c.puzzle_hash.as_ref() == H2);
         assert!(c.amount == 42_u64);
         assert!(a.atom(c.hint) == MSG1.to_vec());
     }
@@ -2679,7 +2679,7 @@ fn test_create_coin_with_long_hint() {
     assert_eq!(spend.create_coin.len(), 1);
 
     for c in &spend.create_coin {
-        assert_eq!(&c.puzzle_hash.into_inner(), H2);
+        assert_eq!(c.puzzle_hash.as_ref(), H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.nil());
     }
@@ -2702,7 +2702,7 @@ fn test_create_coin_with_pair_hint() {
     assert_eq!(spend.create_coin.len(), 1);
 
     for c in &spend.create_coin {
-        assert_eq!(&c.puzzle_hash.into_inner(), H2);
+        assert_eq!(c.puzzle_hash.as_ref(), H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(a.atom(c.hint), H1.to_vec());
     }
@@ -2724,7 +2724,7 @@ fn test_create_coin_with_cons_hint() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(&c.puzzle_hash.into_inner(), H2);
+        assert_eq!(c.puzzle_hash.as_ref(), H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.nil());
     }

--- a/src/gen/conditions.rs
+++ b/src/gen/conditions.rs
@@ -131,10 +131,9 @@ impl SpendVisitor for MempoolVisitor {
         // to look for something that looks like a singleton output, with the same
         // puzzle hash as our input coin
         if (spend.flags & ELIGIBLE_FOR_FF) != 0
-            && !spend
-                .create_coin
-                .iter()
-                .any(|c| (c.amount & 1) == 1 && a.atom(spend.puzzle_hash) == c.puzzle_hash)
+            && !spend.create_coin.iter().any(|c| {
+                (c.amount & 1) == 1 && a.atom(spend.puzzle_hash) == c.puzzle_hash.as_slice()
+            })
         {
             spend.flags &= !ELIGIBLE_FOR_FF;
         }
@@ -888,7 +887,7 @@ pub fn parse_conditions<V: SpendVisitor>(
             }
             Condition::CreateCoin(ph, amount, hint) => {
                 let new_coin = NewCoin {
-                    puzzle_hash: a.atom(ph).into(),
+                    puzzle_hash: a.atom(ph).try_into().unwrap(),
                     amount,
                     hint,
                 };
@@ -1118,7 +1117,7 @@ fn is_ephemeral(
     spends: &[Spend],
 ) -> bool {
     let spend = &spends[spend_idx];
-    let idx = match spent_ids.get(&Bytes32::from(a.atom(spend.parent_id))) {
+    let idx = match spent_ids.get(&Bytes32::try_from(a.atom(spend.parent_id)).unwrap()) {
         None => {
             return false;
         }
@@ -1129,7 +1128,7 @@ fn is_ephemeral(
     // coins. Note that hint is not relevant for this lookup
     let parent_spend = &spends[idx];
     parent_spend.create_coin.contains(&NewCoin {
-        puzzle_hash: Bytes32::from(a.atom(spend.puzzle_hash)),
+        puzzle_hash: Bytes32::try_from(a.atom(spend.puzzle_hash)).unwrap(),
         amount: spend.coin_amount,
         hint: a.nil(),
     })
@@ -1224,7 +1223,7 @@ pub fn validate_conditions(
     for coin_id in state.assert_concurrent_spend {
         if !state
             .spent_coins
-            .contains_key(&Bytes32::from(a.atom(coin_id)))
+            .contains_key(&Bytes32::try_from(a.atom(coin_id)).unwrap())
         {
             return Err(ValidationErr(
                 coin_id,
@@ -1239,11 +1238,11 @@ pub fn validate_conditions(
         // expand all the spent puzzle hashes into a set, to allow
         // fast lookups of all assertions
         for ph in state.spent_puzzles {
-            spent_phs.insert(a.atom(ph).into());
+            spent_phs.insert(a.atom(ph).try_into().unwrap());
         }
 
         for puzzle_assert in state.assert_concurrent_puzzle {
-            if !spent_phs.contains(&a.atom(puzzle_assert).into()) {
+            if !spent_phs.contains(&a.atom(puzzle_assert).try_into().unwrap()) {
                 return Err(ValidationErr(
                     puzzle_assert,
                     ErrorCode::AssertConcurrentPuzzleFailed,
@@ -1261,11 +1260,12 @@ pub fn validate_conditions(
             let mut hasher = Sha256::new();
             hasher.update(*coin_id);
             hasher.update(a.atom(announce));
-            announcements.insert(hasher.finalize().as_slice().into());
+            let announcement_id: [u8; 32] = hasher.finalize().into();
+            announcements.insert(announcement_id.into());
         }
 
         for coin_assert in state.assert_coin {
-            if !announcements.contains(&a.atom(coin_assert).into()) {
+            if !announcements.contains(&a.atom(coin_assert).try_into().unwrap()) {
                 return Err(ValidationErr(
                     coin_assert,
                     ErrorCode::AssertCoinAnnouncementFailed,
@@ -1303,11 +1303,12 @@ pub fn validate_conditions(
             let mut hasher = Sha256::new();
             hasher.update(a.atom(puzzle_hash));
             hasher.update(a.atom(announce));
-            announcements.insert(hasher.finalize().as_slice().into());
+            let announcement_id: [u8; 32] = hasher.finalize().into();
+            announcements.insert(announcement_id.into());
         }
 
         for puzzle_assert in state.assert_puzzle {
-            if !announcements.contains(&a.atom(puzzle_assert).into()) {
+            if !announcements.contains(&a.atom(puzzle_assert).try_into().unwrap()) {
                 return Err(ValidationErr(
                     puzzle_assert,
                     ErrorCode::AssertPuzzleAnnouncementFailed,
@@ -1426,7 +1427,8 @@ fn test_coin_id(parent_id: &[u8; 32], puzzle_hash: &[u8; 32], amount: u64) -> By
     hasher.update(puzzle_hash);
     let buf = u64_to_bytes(amount);
     hasher.update(&buf);
-    hasher.finalize().as_slice().into()
+    let coin_id: [u8; 32] = hasher.finalize().into();
+    coin_id.into()
 }
 
 // this is a very simple parser. It does not handle errors, because it's only
@@ -2445,7 +2447,7 @@ fn test_single_create_coin() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(c.puzzle_hash, H2);
+        assert_eq!(&c.puzzle_hash.into_inner(), H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.nil());
     }
@@ -2468,7 +2470,7 @@ fn test_create_coin_max_amount() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(c.puzzle_hash, H2);
+        assert_eq!(&c.puzzle_hash.into_inner(), H2);
         assert_eq!(c.amount, 0xffffffffffffffff_u64);
         assert_eq!(c.hint, a.nil());
     }
@@ -2534,7 +2536,7 @@ fn test_create_coin_with_hint() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert!(c.puzzle_hash == H2);
+        assert!(&c.puzzle_hash.into_inner() == H2);
         assert!(c.amount == 42_u64);
         assert!(a.atom(c.hint) == H1.to_vec());
     }
@@ -2557,7 +2559,7 @@ fn test_create_coin_extra_arg() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert!(c.puzzle_hash == H2);
+        assert!(&c.puzzle_hash.into_inner() == H2);
         assert!(c.amount == 42_u64);
         assert!(a.atom(c.hint) == H1.to_vec());
     }
@@ -2578,7 +2580,7 @@ fn test_create_coin_with_multiple_hints() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert!(c.puzzle_hash == H2);
+        assert!(&c.puzzle_hash.into_inner() == H2);
         assert!(c.amount == 42_u64);
         assert!(a.atom(c.hint) == H1.to_vec());
     }
@@ -2600,7 +2602,7 @@ fn test_create_coin_with_hint_as_atom() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(c.puzzle_hash, H2);
+        assert_eq!(&c.puzzle_hash.into_inner(), H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.nil());
     }
@@ -2621,7 +2623,7 @@ fn test_create_coin_with_invalid_hint_as_terminator() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(c.puzzle_hash, H2);
+        assert_eq!(&c.puzzle_hash.into_inner(), H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.nil());
     }
@@ -2655,7 +2657,7 @@ fn test_create_coin_with_short_hint() {
     assert_eq!(spend.create_coin.len(), 1);
 
     for c in &spend.create_coin {
-        assert!(c.puzzle_hash == H2);
+        assert!(&c.puzzle_hash.into_inner() == H2);
         assert!(c.amount == 42_u64);
         assert!(a.atom(c.hint) == MSG1.to_vec());
     }
@@ -2677,7 +2679,7 @@ fn test_create_coin_with_long_hint() {
     assert_eq!(spend.create_coin.len(), 1);
 
     for c in &spend.create_coin {
-        assert_eq!(c.puzzle_hash, H2);
+        assert_eq!(&c.puzzle_hash.into_inner(), H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.nil());
     }
@@ -2700,7 +2702,7 @@ fn test_create_coin_with_pair_hint() {
     assert_eq!(spend.create_coin.len(), 1);
 
     for c in &spend.create_coin {
-        assert_eq!(c.puzzle_hash, H2);
+        assert_eq!(&c.puzzle_hash.into_inner(), H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(a.atom(c.hint), H1.to_vec());
     }
@@ -2722,7 +2724,7 @@ fn test_create_coin_with_cons_hint() {
     assert_eq!(a.atom(spend.puzzle_hash), H2);
     assert_eq!(spend.create_coin.len(), 1);
     for c in &spend.create_coin {
-        assert_eq!(c.puzzle_hash, H2);
+        assert_eq!(&c.puzzle_hash.into_inner(), H2);
         assert_eq!(c.amount, 42_u64);
         assert_eq!(c.hint, a.nil());
     }

--- a/src/gen/get_puzzle_and_solution.rs
+++ b/src/gen/get_puzzle_and_solution.rs
@@ -81,7 +81,8 @@ use clvmr::sha2::{Digest, Sha256};
 fn make_dummy_id(seed: u64) -> Bytes32 {
     let mut sha256 = Sha256::new();
     sha256.update(seed.to_be_bytes());
-    sha256.finalize().as_slice().into()
+    let id: [u8; 32] = sha256.finalize().into();
+    id.into()
 }
 
 #[cfg(test)]

--- a/src/gen/run_puzzle.rs
+++ b/src/gen/run_puzzle.rs
@@ -41,7 +41,7 @@ pub fn run_puzzle<V: SpendVisitor>(
     let puzzle_hash = tree_hash(a, puzzle);
     let coin_id = Arc::<Bytes32>::new(
         Coin {
-            parent_coin_info: parent_id.into(),
+            parent_coin_info: parent_id.try_into().unwrap(),
             puzzle_hash: puzzle_hash.into(),
             amount,
         }

--- a/src/gen/test_generators.rs
+++ b/src/gen/test_generators.rs
@@ -32,7 +32,7 @@ fn print_conditions(a: &Allocator, c: &SpendBundleConditions) -> String {
     }
     let mut agg_sigs = Vec::<(Bytes48, Bytes)>::new();
     for (pk, msg) in &c.agg_sig_unsafe {
-        agg_sigs.push((a.atom(*pk).into(), a.atom(*msg).into()));
+        agg_sigs.push((a.atom(*pk).try_into().unwrap(), a.atom(*msg).into()));
     }
     agg_sigs.sort();
     for (pk, msg) in agg_sigs {
@@ -86,7 +86,7 @@ fn print_conditions(a: &Allocator, c: &SpendBundleConditions) -> String {
 
         let mut agg_sigs = Vec::<(Bytes48, Bytes)>::new();
         for (pk, msg) in s.agg_sig_me {
-            agg_sigs.push((a.atom(pk).into(), a.atom(msg).into()));
+            agg_sigs.push((a.atom(pk).try_into().unwrap(), a.atom(msg).into()));
         }
         agg_sigs.sort();
         for (pk, msg) in agg_sigs {

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -68,7 +68,7 @@ pub struct PySpendBundleConditions {
 fn convert_agg_sigs(a: &Allocator, agg_sigs: &[(NodePtr, NodePtr)]) -> Vec<(Bytes48, Bytes)> {
     let mut ret = Vec::<(Bytes48, Bytes)>::new();
     for (pk, msg) in agg_sigs {
-        ret.push((a.atom(*pk).into(), a.atom(*msg).into()));
+        ret.push((a.atom(*pk).try_into().unwrap(), a.atom(*msg).into()));
     }
     ret
 }
@@ -90,8 +90,8 @@ fn convert_spend(a: &Allocator, spend: Spend) -> PySpend {
 
     PySpend {
         coin_id: *spend.coin_id,
-        parent_id: a.atom(spend.parent_id).into(),
-        puzzle_hash: a.atom(spend.puzzle_hash).into(),
+        parent_id: a.atom(spend.parent_id).try_into().unwrap(),
+        puzzle_hash: a.atom(spend.puzzle_hash).try_into().unwrap(),
         coin_amount: spend.coin_amount,
         height_relative: spend.height_relative,
         seconds_relative: spend.seconds_relative,
@@ -122,7 +122,7 @@ pub fn convert_spend_bundle_conds(
 
     let mut agg_sigs = Vec::<(Bytes48, Bytes)>::with_capacity(sb.agg_sig_unsafe.len());
     for (pk, msg) in sb.agg_sig_unsafe {
-        agg_sigs.push((a.atom(pk).into(), a.atom(msg).into()));
+        agg_sigs.push((a.atom(pk).try_into().unwrap(), a.atom(msg).into()));
     }
 
     PySpendBundleConditions {


### PR DESCRIPTION
This PR adds missing conversions for `Bytes`, `BytesImpl`, and `Program`, and removes `PartialEq` implementations for other types to reduce complexity.

It also changes `From` to `TryFrom` in some cases where the conversion is fallible:
> **Note: This trait must not fail.** The `From` trait is intended for perfect conversions. If the conversion can fail or is not perfect, use `TryFrom`.

https://doc.rust-lang.org/std/convert/trait.From.html