### PR TITLE
Add python 3.12

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -358,7 +358,9 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        exclude:
+          - python:
+            matrix: '3.12'
     name: Unit tests
     steps:
       # the test files are read verbatim, making it problematic if git is

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -359,8 +359,9 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         exclude:
-          - python:
-            matrix: '3.12'
+          - os: macos-latest
+            python:
+              matrix: '3.12'
     name: Unit tests
     steps:
       # the test files are read verbatim, making it problematic if git is

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -358,6 +358,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+        python: ['3.8', '3.9', '3.10', '3.11']
     name: Unit tests
     steps:
       # the test files are read verbatim, making it problematic if git is

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -358,7 +358,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     name: Unit tests
     steps:
       # the test files are read verbatim, making it problematic if git is

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -358,9 +358,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        exclude:
-          - os: macos-latest
-    name: Fred
+    name: Unit tests
     steps:
       # the test files are read verbatim, making it problematic if git is
       # allowed to insert \r when checking out files

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -360,9 +360,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
         exclude:
           - os: macos-latest
-            python:
-              matrix: 3.12
-    name: Unit tests
+    name: Fred
     steps:
       # the test files are read verbatim, making it problematic if git is
       # allowed to insert \r when checking out files

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -361,7 +361,7 @@ jobs:
         exclude:
           - os: macos-latest
             python:
-              matrix: '3.12'
+              matrix: 3.12
     name: Unit tests
     steps:
       # the test files are read verbatim, making it problematic if git is

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -90,6 +90,19 @@ jobs:
                 docker-url: ghcr.io/chia-network/build-images/centos-pypa-rust-x86_64
                 rustup-target: x86_64-unknown-linux-musl
             matrix: '3.11'
+          - major-dot-minor: '3.12'
+            cibw-build: 'cp312-*'
+            by-arch:
+              arm:
+                manylinux-version: 2014
+                docker-url: ghcr.io/chia-network/build-images/centos-pypa-rust-aarch64
+                rustup-target: aarch64-unknown-linux-musl
+              intel:
+                manylinux-version: 2014
+                docker-url: ghcr.io/chia-network/build-images/centos-pypa-rust-x86_64
+                rustup-target: x86_64-unknown-linux-musl
+            matrix: '3.12'
+
         arch:
           - name: ARM
             matrix: arm
@@ -105,19 +118,6 @@ jobs:
               matrix: windows
               runs-on:
                 intel: [windows-latest]
-            arch:
-              name: ARM
-              matrix: arm
-          - os:
-              name: macOS
-              matrix: macos
-              runs-on:
-                arm: [macOS, ARM64]
-                intel: [macos-latest]
-            python:
-              major-dot-minor: '3.7'
-              cibw-build: 'cp37-*'
-              matrix: '3.7'
             arch:
               name: ARM
               matrix: arm


### PR DESCRIPTION
Add python 3.12 to matrix
Remove old exclusion of python 3.7 since it's not used anymore

Note, test matrix does not specify 3.12 since it requires the wheel to get all published first