### PR TITLE
Tree hash benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,10 @@ lto = "thin"
 name = "run-generator"
 harness = false
 
+[[bench]]
+name = "tree-hash"
+harness = false
+
 # This is also necessary in `wheel/Cargo.toml` to make sure the `wheel` crate builds as well.
 # This overrides the crates.io version of `clvm-traits` with the local version.
 # This is because `clvmr` currently uses the latest published version of `clvm-traits`.

--- a/benches/tree-hash.rs
+++ b/benches/tree-hash.rs
@@ -1,0 +1,41 @@
+use clvmr::serde::{node_from_bytes, node_from_bytes_backrefs, node_to_bytes_backrefs};
+use clvmr::Allocator;
+use criterion::{criterion_group, criterion_main, Criterion, SamplingMode};
+use std::fs::read_to_string;
+use std::time::Instant;
+
+fn run(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tree-hash");
+    group.sample_size(20);
+    group.sampling_mode(SamplingMode::Flat);
+
+    for name in &["block-4671894", "block-834752", "block-225758"] {
+        let filename = format!("generator-tests/{name}.txt");
+        println!("file: {filename}");
+        let test_file = read_to_string(filename).expect("test file not found");
+        let generator = test_file.split_once('\n').expect("invalid test file").0;
+        let generator = hex::decode(generator).expect("invalid hex encoded generator");
+
+        let compressed_generator = {
+            let mut a = Allocator::new();
+            let input = node_from_bytes(&mut a, &generator).expect("failed to parse input file");
+            node_to_bytes_backrefs(&a, input).expect("failed to compress generator")
+        };
+
+        for (gen, name_suffix) in &[(generator, ""), (compressed_generator, "-compressed")] {
+            let mut a = Allocator::new();
+            let gen = node_from_bytes_backrefs(&mut a, &gen).expect("parse generator");
+
+            group.bench_function(format!("tree-hash {name}{name_suffix}"), |b| {
+                b.iter(|| {
+                    let start = Instant::now();
+                    clvm_utils::tree_hash(&a, gen);
+                    start.elapsed()
+                })
+            });
+        }
+    }
+}
+
+criterion_group!(tree_hash, run);
+criterion_main!(tree_hash);


### PR DESCRIPTION
This PR is best reviewed one commit at a time. The second commit introduces a change in indentation, so ignoring whitespace will make it easier to see what's happening.

There are to changes:

* a new `tree-hash` benchmarks is added
* the existing `run-generator` benchmark is amended to run all blocks as both uncompressed and compressed (i.e. clvm backrefs)