### PR TITLE
Remove clvm-traits patch.crates-io entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,12 +71,6 @@ name = "tree-hash"
 harness = false
 
 # This is also necessary in `wheel/Cargo.toml` to make sure the `wheel` crate builds as well.
-# This overrides the crates.io version of `clvm-traits` with the local version.
-# This is because `clvmr` currently uses the latest published version of `clvm-traits`.
-# Because path dependencies are considered different from crates.io dependencies, they conflict.
-# All of the types are considered different by Cargo, and the below snippet is necessary to fix this.
-# When making breaking changes, this may be a complication.
-# Ideally this should be removed once a long term fix is found.
+# Pin the `blst` dependency to the correct revision, since the fix has not been properly released yet.
 [patch.crates-io]
-clvm-traits = { path = "clvm-traits" }
 blst = { git = "https://github.com/supranational/blst.git", rev = "0d46eefa45fc1e57aceb42bba0e84eab3a7a9725" }

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -29,5 +29,4 @@ chia_streamable_macro = { version = "=0.3.0", path = "../chia_streamable_macro" 
 
 # See `../Cargo.toml` for more information on why this is necessary.
 [patch.crates-io]
-clvm-traits = { path = "../clvm-traits" }
 blst = { git = "https://github.com/supranational/blst.git", rev = "0d46eefa45fc1e57aceb42bba0e84eab3a7a9725" }


### PR DESCRIPTION
This is no longer necessary since we removed the dependency from `clvmr`.