### PR TITLE
make tree_hash() support CLVM with backrefs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,7 @@ dependencies = [
  "chia_py_streamable_macro",
  "chia_streamable_macro 0.3.0",
  "clvm-traits",
+ "clvm-utils",
  "clvmr",
  "hex",
  "pyo3",

--- a/benches/tree-hash.rs
+++ b/benches/tree-hash.rs
@@ -1,15 +1,21 @@
 use clvmr::serde::{node_from_bytes, node_from_bytes_backrefs, node_to_bytes_backrefs};
 use clvmr::Allocator;
-use criterion::{criterion_group, criterion_main, Criterion, SamplingMode};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::fs::read_to_string;
 use std::time::Instant;
 
 fn run(c: &mut Criterion) {
     let mut group = c.benchmark_group("tree-hash");
-    group.sample_size(20);
-    group.sampling_mode(SamplingMode::Flat);
 
-    for name in &["block-4671894", "block-834752", "block-225758"] {
+    for name in &[
+        "block-4671894",
+        "block-834752",
+        "block-225758",
+        "block-c2a8df0d",
+        "block-1ee588dc",
+        "block-6fe59b24",
+        "block-b45268ac",
+    ] {
         let filename = format!("generator-tests/{name}.txt");
         println!("file: {filename}");
         let test_file = read_to_string(filename).expect("test file not found");
@@ -22,14 +28,24 @@ fn run(c: &mut Criterion) {
             node_to_bytes_backrefs(&a, input).expect("failed to compress generator")
         };
 
-        for (gen, name_suffix) in &[(generator, ""), (compressed_generator, "-compressed")] {
+        for (gen, name_suffix) in &[(&generator, ""), (&compressed_generator, "-compressed")] {
             let mut a = Allocator::new();
             let gen = node_from_bytes_backrefs(&mut a, &gen).expect("parse generator");
 
             group.bench_function(format!("tree-hash {name}{name_suffix}"), |b| {
                 b.iter(|| {
                     let start = Instant::now();
-                    clvm_utils::tree_hash(&a, gen);
+                    let _ = black_box(clvm_utils::tree_hash(&a, gen));
+                    start.elapsed()
+                })
+            });
+        }
+
+        for (gen, name_suffix) in &[(&generator, ""), (&compressed_generator, "-compressed")] {
+            group.bench_function(format!("tree-hash-from-stream {name}{name_suffix}"), |b| {
+                b.iter(|| {
+                    let start = Instant::now();
+                    let _ = black_box(clvm_utils::tree_hash_from_bytes(gen));
                     start.elapsed()
                 })
             });

--- a/chia-protocol/src/program.rs
+++ b/chia-protocol/src/program.rs
@@ -320,8 +320,7 @@ impl Program {
     }
 
     fn get_tree_hash(&self) -> crate::Bytes32 {
-        let mut cursor = Cursor::new(self.0.as_ref());
-        clvmr::serde::tree_hash_from_stream(&mut cursor)
+        clvm_utils::tree_hash_from_bytes(self.0.as_ref())
             .unwrap()
             .into()
     }

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -24,5 +24,6 @@ chia-bls = { version = "=0.5.1", path = "../chia-bls", features = ["py-bindings"
 chia-protocol = { version = "=0.5.1", path = "../chia-protocol", features = ["py-bindings"]  }
 chia-traits = { version = "=0.5.2", path = "../chia-traits", features = ["py-bindings"]  }
 clvm-traits = { version = "=0.5.2", path = "../clvm-traits", features = ["derive", "py-bindings"] }
+clvm-utils = { version = "=0.5.1", path = "../clvm-utils" }
 chia_py_streamable_macro = { version = "=0.5.1", path = "../chia_py_streamable_macro" }
 chia_streamable_macro = { version = "=0.3.0", path = "../chia_streamable_macro" }

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -35,7 +35,7 @@ use chia_protocol::{
     SubEpochSegments, SubEpochSummary, SubSlotData, SubSlotProofs, TimestampedPeerInfo,
     TransactionAck, TransactionsInfo, UnfinishedBlock, VDFInfo, VDFProof, WeightProof,
 };
-use clvmr::serde::tree_hash_from_stream;
+use clvm_utils::tree_hash_from_bytes;
 use clvmr::{ENABLE_BLS_OPS_OUTSIDE_GUARD, ENABLE_FIXED_DIV, LIMIT_HEAP, NO_UNKNOWN_OPS};
 use pyo3::buffer::PyBuffer;
 use pyo3::exceptions::PyRuntimeError;
@@ -87,8 +87,7 @@ pub fn tree_hash(py: Python, blob: PyBuffer<u8>) -> PyResult<&PyBytes> {
     }
     let slice =
         unsafe { std::slice::from_raw_parts(blob.buf_ptr() as *const u8, blob.len_bytes()) };
-    let mut input = std::io::Cursor::<&[u8]>::new(slice);
-    Ok(PyBytes::new(py, &tree_hash_from_stream(&mut input)?))
+    Ok(PyBytes::new(py, &tree_hash_from_bytes(slice)?))
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
I don't think anything depends on this (yet), but not supporting it is inconsistent between `SerializedProgram` and `Program` (in `chia-blockchain`) and a risk.

There are optimizations to improve performance of computing the tree hash for clvm structures with backrefs that I intend to explore. But the first step is to support it in the first place.