### PR TITLE
expose bytes32 as the right type, from chia-blockchain

### DIFF
--- a/chia-protocol/src/bytes.rs
+++ b/chia-protocol/src/bytes.rs
@@ -359,7 +359,13 @@ impl<const N: usize> IntoPy<PyObject> for BytesImpl<N> {
 #[cfg(feature = "py-bindings")]
 impl<const N: usize> ChiaToPython for BytesImpl<N> {
     fn to_python<'a>(&self, py: Python<'a>) -> PyResult<&'a PyAny> {
-        Ok(PyBytes::new(py, &self.0).into())
+        if N == 32 {
+            let bytes_module = PyModule::import(py, "chia.types.blockchain_format.sized_bytes")?;
+            let ty = bytes_module.getattr("bytes32")?;
+            ty.call1((self.0.into_py(py),))
+        } else {
+            Ok(PyBytes::new(py, &self.0).into())
+        }
     }
 }
 

--- a/tests/test_block_record_fidelity.py
+++ b/tests/test_block_record_fidelity.py
@@ -109,6 +109,14 @@ def get_block_record(rng: Random) -> BlockRecord:
     )
 
 
+def test_bytes32():
+    rng = Random()
+    rng.seed(1337)
+    br = get_block_record(rng)
+    assert isinstance(br.header_hash, bytes32)
+    assert f"{br.header_hash}" == "e433713dd932b2314eab219aa5504f71b9fe9f2d8e2f5cadfa892d8dc6a7ba53"
+    assert br.header_hash.__str__() == "e433713dd932b2314eab219aa5504f71b9fe9f2d8e2f5cadfa892d8dc6a7ba53"
+
 def wrap_call(expr: str, br: Any) -> str:
     try:
         ret = eval(expr, None, {"br": br})


### PR DESCRIPTION
Now that we have the infrastructure to have these custom conversions, we might as well do it for `bytes32` as well.
This addresses a lot of risks when using these types in chia-blockchain, as we don't have test coverage for all places we print `bytes32` objects for instance.