### PR TITLE
add test for (x) error message

### DIFF
--- a/chia-protocol/src/program.rs
+++ b/chia-protocol/src/program.rs
@@ -394,7 +394,10 @@ impl Program {
                 let val = LazyNode::new(Rc::new(a), reduction.1);
                 Ok((reduction.0, to_program(py, val)?))
             }
-            Err(eval_err) => Err(PyValueError::new_err(eval_err.to_string())),
+            Err(eval_err) => {
+                let blob = node_to_bytes(&a, eval_err.0).ok().map(hex::encode);
+                Err(PyValueError::new_err((eval_err.1, blob)))
+            }
         }
     }
 

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -1,0 +1,10 @@
+from chia_rs import run_chia_program
+
+def test_raise() -> None:
+    try:
+        # (x (q . "foobar"))
+        run_chia_program(bytes.fromhex("ff08ffff0186666f6f62617280"), bytes.fromhex("80"), 100000, 0)
+        # We expect this to throw
+        assert False
+    except ValueError as e:
+        assert f"{e}" == "('clvm raise', '86666f6f626172')"

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -1,9 +1,20 @@
-from chia_rs import run_chia_program
+from chia_rs import run_chia_program, Program
 
 def test_raise() -> None:
     try:
         # (x (q . "foobar"))
         run_chia_program(bytes.fromhex("ff08ffff0186666f6f62617280"), bytes.fromhex("80"), 100000, 0)
+        # We expect this to throw
+        assert False
+    except ValueError as e:
+        assert f"{e}" == "('clvm raise', '86666f6f626172')"
+
+def test_raise_program() -> None:
+    try:
+        # (x (q . "foobar"))
+        prg = Program.fromhex("ff08ffff0186666f6f62617280")
+
+        prg.run_with_cost(100000, [])
         # We expect this to throw
         assert False
     except ValueError as e:

--- a/wheel/src/adapt_response.rs
+++ b/wheel/src/adapt_response.rs
@@ -2,17 +2,10 @@ use clvmr::allocator::Allocator;
 use clvmr::reduction::EvalErr;
 use clvmr::serde::node_to_bytes;
 
+use pyo3::exceptions::*;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
 
-pub fn eval_err_to_pyresult<T>(py: Python, eval_err: EvalErr, allocator: Allocator) -> PyResult<T> {
-    let ctx: &PyDict = PyDict::new(py);
-    let msg = eval_err.1;
-    ctx.set_item("msg", msg)?;
-    if let Ok(blob) = node_to_bytes(&allocator, eval_err.0) {
-        ctx.set_item("blob", blob)?;
-    }
-    Err(py
-        .run("raise ValueError(msg, bytes(blob).hex())", None, Some(ctx))
-        .unwrap_err())
+pub fn eval_err_to_pyresult<T>(eval_err: EvalErr, allocator: Allocator) -> PyResult<T> {
+    let blob = node_to_bytes(&allocator, eval_err.0).ok().map(hex::encode);
+    Err(PyValueError::new_err((eval_err.1, blob)))
 }

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -143,7 +143,7 @@ pub fn get_puzzle_and_solution_for_coin(
         };
     */
     match r {
-        Err(eval_err) => eval_err_to_pyresult(py, eval_err, allocator),
+        Err(eval_err) => eval_err_to_pyresult(eval_err, allocator),
         Ok((puzzle, solution)) => Ok((
             PyBytes::new(py, &serialize(&allocator, puzzle)?),
             PyBytes::new(py, &serialize(&allocator, solution)?),

--- a/wheel/src/run_program.rs
+++ b/wheel/src/run_program.rs
@@ -50,6 +50,6 @@ pub fn run_chia_program(
             let val = LazyNode::new(Rc::new(allocator), reduction.1);
             Ok((reduction.0, val))
         }
-        Err(eval_err) => eval_err_to_pyresult(py, eval_err, allocator),
+        Err(eval_err) => eval_err_to_pyresult(eval_err, allocator),
     }
 }


### PR DESCRIPTION
improve conversion from `EvalErr` to `ValueError` in python. in `Program._run()`, we did not convert the error consistently with other places (and lost information). This fixes that and adds a test.

Thanks for the report, @trepca