### PR TITLE
Bump clvm 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9703ae71967bce4aa064bcdcb4103b065b2e40ae710729f42697e94bff43553f"
+checksum = "f2a325317df74c08409b8080cbea9c8c8a9d46184d5b2d89e941c5a958fe87eb"
 dependencies = [
  "chia-bls 0.4.0",
  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ repository = "https://github.com/Chia-Network/chia_rs/"
 py-bindings = ["dep:pyo3"]
 
 [dependencies]
-clvmr = "0.5.0"
+clvmr = "0.6.0"
 hex = "0.4.3"
 pyo3 = { version = ">=0.19.0", optional = true }
 clvm-utils = { version = "0.5.1", path = "clvm-utils" }

--- a/chia-protocol/Cargo.toml
+++ b/chia-protocol/Cargo.toml
@@ -17,7 +17,7 @@ sha2 = "0.10.8"
 hex = "0.4.3"
 chia_streamable_macro = { version = "0.3.0", path = "../chia_streamable_macro" }
 chia_py_streamable_macro = { version = "0.5.1", path = "../chia_py_streamable_macro", optional = true }
-clvmr = "0.5.0"
+clvmr = "0.6.0"
 chia-traits = { version = "0.5.1", path = "../chia-traits" }
 clvm-traits = { version = "0.5.1", path = "../clvm-traits", features = ["derive"] }
 clvm-utils = { version = "0.5.1", path = "../clvm-utils" }

--- a/chia-protocol/fuzz/Cargo.toml
+++ b/chia-protocol/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-clvmr = "0.5.0"
+clvmr = "0.6.0"
 chia-traits = { path = "../../chia-traits" }
 clvm-traits = { path = "../../clvm-traits" }
 arbitrary = { version = "=1.3.0" }

--- a/chia-protocol/fuzz/fuzz_targets/spend-bundle.rs
+++ b/chia-protocol/fuzz/fuzz_targets/spend-bundle.rs
@@ -39,10 +39,10 @@ fuzz_target!(|data: &[u8]| {
             let op = first(&a, c).expect("first");
             let c = rest(&a, c).expect("rest");
             let buf = a.atom(op);
-            if buf.len() != 1 {
+            if buf.as_ref().len() != 1 {
                 continue;
             }
-            if buf[0] == 51 {
+            if buf.as_ref()[0] == 51 {
                 let (puzzle_hash, (amount, _)) =
                     <(Bytes32, (u64, NodePtr))>::from_clvm(&a, c).expect("parse spend");
                 expected.insert(Coin {

--- a/chia-protocol/src/bytes.rs
+++ b/chia-protocol/src/bytes.rs
@@ -114,7 +114,7 @@ impl<N> ToClvm<N> for Bytes {
 impl<N> FromClvm<N> for Bytes {
     fn from_clvm(decoder: &impl ClvmDecoder<Node = N>, node: N) -> Result<Self, FromClvmError> {
         let bytes = decoder.decode_atom(&node)?;
-        Ok(Self(bytes.to_vec()))
+        Ok(Self(bytes.as_ref().to_vec()))
     }
 }
 
@@ -247,13 +247,13 @@ impl<N, const LEN: usize> ToClvm<N> for BytesImpl<LEN> {
 impl<N, const LEN: usize> FromClvm<N> for BytesImpl<LEN> {
     fn from_clvm(decoder: &impl ClvmDecoder<Node = N>, node: N) -> Result<Self, FromClvmError> {
         let bytes = decoder.decode_atom(&node)?;
-        if bytes.len() != LEN {
+        if bytes.as_ref().len() != LEN {
             return Err(FromClvmError::WrongAtomLength {
                 expected: LEN,
-                found: bytes.len(),
+                found: bytes.as_ref().len(),
             });
         }
-        Ok(Self::try_from(bytes).unwrap())
+        Ok(Self::try_from(bytes.as_ref()).unwrap())
     }
 }
 

--- a/chia-protocol/src/lazy_node.rs
+++ b/chia-protocol/src/lazy_node.rs
@@ -36,7 +36,7 @@ impl LazyNode {
     #[getter(atom)]
     pub fn atom(&self, py: Python) -> Option<PyObject> {
         match &self.allocator.sexp(self.node) {
-            SExp::Atom => Some(PyBytes::new(py, self.allocator.atom(self.node)).into()),
+            SExp::Atom => Some(PyBytes::new(py, self.allocator.atom(self.node).as_ref()).into()),
             _ => None,
         }
     }

--- a/chia-protocol/src/spend_bundle.rs
+++ b/chia-protocol/src/spend_bundle.rs
@@ -70,6 +70,7 @@ impl SpendBundle {
                         return Err(EvalErr(op, "invalid condition".to_string()));
                     }
                 };
+                let buf = buf.as_ref();
                 if buf.len() != 1 {
                     continue;
                 }

--- a/chia-tools/Cargo.toml
+++ b/chia-tools/Cargo.toml
@@ -15,7 +15,7 @@ clvm-utils = { version = "0.5.1", path = "../clvm-utils" }
 clvm-traits = { version = "0.5.2", path = "../clvm-traits" }
 chia-wallet = { version = "0.5.1", path = "../chia-wallet" }
 chia-bls = { version = "0.5.1", path = "../chia-bls" }
-clvmr = { version = "0.5.0", features = ["counters"] }
+clvmr = { version = "0.6.0", features = ["counters"] }
 chia = { version = "0.5.2", path = ".." }
 rusqlite = { version = "0.30.0", features = ["bundled"] }
 clap = { version = "4.3.9", features = ["derive"] }

--- a/chia-tools/src/visit_spends.rs
+++ b/chia-tools/src/visit_spends.rs
@@ -131,7 +131,7 @@ pub fn visit_spends<
         let [parent_id, puzzle, amount, solution, _spend_level_extra] =
             extract_n::<5>(a, spend, ErrorCode::InvalidCondition)?;
         let amount: u64 = a.number(amount).try_into().expect("invalid amount");
-        let parent_id = Bytes32::try_from(a.atom(parent_id)).unwrap();
+        let parent_id = Bytes32::try_from(a.atom(parent_id).as_ref()).unwrap();
         callback(a, parent_id, amount, puzzle, solution);
     }
     Ok(())

--- a/chia-wallet/Cargo.toml
+++ b/chia-wallet/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/Chia-Network/chia_rs/chia-wallet/"
 repository = "https://github.com/Chia-Network/chia_rs/chia-wallet/"
 
 [dependencies]
-clvmr = "0.5.0"
+clvmr = "0.6.0"
 sha2 = "0.10.8"
 num-bigint = "0.4.3"
 hex-literal = "0.4.1"

--- a/chia-wallet/fuzz/Cargo.toml
+++ b/chia-wallet/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-clvmr = "0.5.0"
+clvmr = "0.6.0"
 pyo3 = { version = ">=0.19.0", features = ["auto-initialize"]}
 chia-wallet = { path = ".." }
 clvm-traits = { version = "0.5.2", path = "../../clvm-traits" }

--- a/clvm-traits/Cargo.toml
+++ b/clvm-traits/Cargo.toml
@@ -18,7 +18,7 @@ py-bindings = ["dep:pyo3"]
 
 [dependencies]
 pyo3 = { version = ">=0.19.0", optional = true }
-clvmr = "0.5.0"
+clvmr = "0.6.0"
 clvm-derive = { version = "0.5.2", path = "../clvm-derive", optional = true }
 chia-bls = { version = "0.5.1", path = "../chia-bls", optional = true }
 num-bigint = "0.4.3"

--- a/clvm-traits/src/clvm_decoder.rs
+++ b/clvm-traits/src/clvm_decoder.rs
@@ -1,11 +1,11 @@
-use clvmr::{allocator::SExp, Allocator, NodePtr};
+use clvmr::{allocator::SExp, Allocator, Atom, NodePtr};
 
 use crate::{FromClvm, FromClvmError};
 
 pub trait ClvmDecoder {
     type Node: Clone;
 
-    fn decode_atom(&self, node: &Self::Node) -> Result<&[u8], FromClvmError>;
+    fn decode_atom(&self, node: &Self::Node) -> Result<Atom, FromClvmError>;
     fn decode_pair(&self, node: &Self::Node) -> Result<(Self::Node, Self::Node), FromClvmError>;
 
     /// This is a helper function that just calls `clone` on the node.
@@ -19,7 +19,7 @@ pub trait ClvmDecoder {
 impl ClvmDecoder for Allocator {
     type Node = NodePtr;
 
-    fn decode_atom(&self, node: &Self::Node) -> Result<&[u8], FromClvmError> {
+    fn decode_atom(&self, node: &Self::Node) -> Result<Atom, FromClvmError> {
         if let SExp::Atom = self.sexp(*node) {
             Ok(self.atom(*node))
         } else {

--- a/clvm-traits/src/match_byte.rs
+++ b/clvm-traits/src/match_byte.rs
@@ -18,7 +18,7 @@ impl<N, const BYTE: u8> ToClvm<N> for MatchByte<BYTE> {
 
 impl<N, const BYTE: u8> FromClvm<N> for MatchByte<BYTE> {
     fn from_clvm(decoder: &impl ClvmDecoder<Node = N>, node: N) -> Result<Self, FromClvmError> {
-        match decoder.decode_atom(&node)? {
+        match decoder.decode_atom(&node)?.as_ref() {
             [] if BYTE == 0 => Ok(Self),
             [byte] if *byte == BYTE && BYTE > 0 => Ok(Self),
             _ => Err(FromClvmError::Custom(format!(

--- a/clvm-utils/Cargo.toml
+++ b/clvm-utils/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/Chia-Network/chia_rs/"
 repository = "https://github.com/Chia-Network/chia_rs/clvm-utils"
 
 [dependencies]
-clvmr = "0.5.0"
+clvmr = "0.6.0"
 clvm-traits = { version = "0.5.1", path = "../clvm-traits" }
 
 [dev-dependencies]

--- a/clvm-utils/fuzz/Cargo.toml
+++ b/clvm-utils/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-clvmr = "=0.5.0"
+clvmr = "=0.6.0"
 chia-fuzz = { path = "../../fuzz" }
 clvm-utils = { path = ".." }
 clvm-traits = { path = "../../clvm-traits" }

--- a/clvm-utils/src/tree_hash.rs
+++ b/clvm-utils/src/tree_hash.rs
@@ -31,7 +31,7 @@ pub fn tree_hash(a: &Allocator, node: NodePtr) -> [u8; 32] {
         match op {
             TreeOp::SExp(node) => match a.sexp(node) {
                 SExp::Atom => {
-                    hashes.push(tree_hash_atom(a.atom(node)));
+                    hashes.push(tree_hash_atom(a.atom(node).as_ref()));
                 }
                 SExp::Pair(left, right) => {
                     ops.push(TreeOp::Cons);

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-clvmr = "0.5.0"
+clvmr = "0.6.0"
 clvm-utils = { path = "../clvm-utils" }
 clvm-traits = { path = "../clvm-traits" }
 chia-protocol = { path = "../chia-protocol" }

--- a/src/gen/condition_sanitizers.rs
+++ b/src/gen/condition_sanitizers.rs
@@ -10,7 +10,7 @@ pub fn sanitize_hash(
 ) -> Result<NodePtr, ValidationErr> {
     let buf = atom(a, n, code)?;
 
-    if buf.len() != size {
+    if buf.as_ref().len() != size {
         Err(ValidationErr(n, code))
     } else {
         Ok(n)
@@ -33,7 +33,7 @@ pub fn sanitize_announce_msg(
 ) -> Result<NodePtr, ValidationErr> {
     let buf = atom(a, n, code)?;
 
-    if buf.len() > 1024 {
+    if buf.as_ref().len() > 1024 {
         Err(ValidationErr(n, code))
     } else {
         Ok(n)

--- a/src/gen/opcodes.rs
+++ b/src/gen/opcodes.rs
@@ -110,6 +110,7 @@ pub fn parse_opcode(a: &Allocator, op: NodePtr, flags: u32) -> Option<ConditionO
         SExp::Atom => a.atom(op),
         _ => return None,
     };
+    let buf = buf.as_ref();
     if buf.len() == 2 && (flags & ENABLE_SOFTFORK_CONDITION) != 0 {
         if buf[0] == 0 {
             // no redundant leading zeroes

--- a/src/gen/sanitize_int.rs
+++ b/src/gen/sanitize_int.rs
@@ -19,6 +19,7 @@ pub fn sanitize_uint(
     assert!(max_size <= 8);
 
     let buf = atom(a, n, code)?;
+    let buf = buf.as_ref();
 
     if buf.is_empty() {
         return Ok(SanitizedUint::Ok(0));

--- a/src/gen/test_generators.rs
+++ b/src/gen/test_generators.rs
@@ -32,7 +32,10 @@ fn print_conditions(a: &Allocator, c: &SpendBundleConditions) -> String {
     }
     let mut agg_sigs = Vec::<(Bytes48, Bytes)>::new();
     for (pk, msg) in &c.agg_sig_unsafe {
-        agg_sigs.push((a.atom(*pk).try_into().unwrap(), a.atom(*msg).into()));
+        agg_sigs.push((
+            a.atom(*pk).as_ref().try_into().unwrap(),
+            a.atom(*msg).as_ref().into(),
+        ));
     }
     agg_sigs.sort();
     for (pk, msg) in agg_sigs {
@@ -86,7 +89,10 @@ fn print_conditions(a: &Allocator, c: &SpendBundleConditions) -> String {
 
         let mut agg_sigs = Vec::<(Bytes48, Bytes)>::new();
         for (pk, msg) in s.agg_sig_me {
-            agg_sigs.push((a.atom(pk).try_into().unwrap(), a.atom(msg).into()));
+            agg_sigs.push((
+                a.atom(pk).as_ref().try_into().unwrap(),
+                a.atom(msg).as_ref().into(),
+            ));
         }
         agg_sigs.sort();
         for (pk, msg) in agg_sigs {

--- a/src/gen/validation_error.rs
+++ b/src/gen/validation_error.rs
@@ -1,4 +1,4 @@
-use clvmr::allocator::{Allocator, NodePtr, SExp};
+use clvmr::allocator::{Allocator, Atom, NodePtr, SExp};
 use clvmr::reduction::EvalErr;
 use thiserror::Error;
 
@@ -161,7 +161,7 @@ pub fn next(a: &Allocator, n: NodePtr) -> Result<Option<(NodePtr, NodePtr)>, Val
     }
 }
 
-pub fn atom(a: &Allocator, n: NodePtr, code: ErrorCode) -> Result<&[u8], ValidationErr> {
+pub fn atom(a: &Allocator, n: NodePtr, code: ErrorCode) -> Result<Atom, ValidationErr> {
     match a.sexp(n) {
         SExp::Atom => Ok(a.atom(n)),
         _ => Err(ValidationErr(n, code)),
@@ -169,7 +169,7 @@ pub fn atom(a: &Allocator, n: NodePtr, code: ErrorCode) -> Result<&[u8], Validat
 }
 
 pub fn check_nil(a: &Allocator, n: NodePtr) -> Result<(), ValidationErr> {
-    if atom(a, n, ErrorCode::InvalidCondition)?.is_empty() {
+    if atom(a, n, ErrorCode::InvalidCondition)?.as_ref().is_empty() {
         Ok(())
     } else {
         Err(ValidationErr(n, ErrorCode::InvalidCondition))

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-clvmr = "0.5.0"
+clvmr = "0.6.0"
 hex = "0.4.3"
 sha2 = "0.10.8"
 pyo3 = { version = "=0.19.0", features = ["multiple-pymethods"] }

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -68,7 +68,10 @@ pub struct PySpendBundleConditions {
 fn convert_agg_sigs(a: &Allocator, agg_sigs: &[(NodePtr, NodePtr)]) -> Vec<(Bytes48, Bytes)> {
     let mut ret = Vec::<(Bytes48, Bytes)>::new();
     for (pk, msg) in agg_sigs {
-        ret.push((a.atom(*pk).try_into().unwrap(), a.atom(*msg).into()));
+        ret.push((
+            a.atom(*pk).as_ref().try_into().unwrap(),
+            a.atom(*msg).as_ref().into(),
+        ));
     }
     ret
 }
@@ -81,7 +84,7 @@ fn convert_spend(a: &Allocator, spend: Spend) -> PySpend {
             c.puzzle_hash,
             c.amount,
             if c.hint != a.nil() {
-                Some(a.atom(c.hint).into())
+                Some(a.atom(c.hint).as_ref().into())
             } else {
                 None
             },
@@ -90,8 +93,8 @@ fn convert_spend(a: &Allocator, spend: Spend) -> PySpend {
 
     PySpend {
         coin_id: *spend.coin_id,
-        parent_id: a.atom(spend.parent_id).try_into().unwrap(),
-        puzzle_hash: a.atom(spend.puzzle_hash).try_into().unwrap(),
+        parent_id: a.atom(spend.parent_id).as_ref().try_into().unwrap(),
+        puzzle_hash: a.atom(spend.puzzle_hash).as_ref().try_into().unwrap(),
         coin_amount: spend.coin_amount,
         height_relative: spend.height_relative,
         seconds_relative: spend.seconds_relative,
@@ -122,7 +125,10 @@ pub fn convert_spend_bundle_conds(
 
     let mut agg_sigs = Vec::<(Bytes48, Bytes)>::with_capacity(sb.agg_sig_unsafe.len());
     for (pk, msg) in sb.agg_sig_unsafe {
-        agg_sigs.push((a.atom(pk).try_into().unwrap(), a.atom(msg).into()));
+        agg_sigs.push((
+            a.atom(pk).as_ref().try_into().unwrap(),
+            a.atom(msg).as_ref().into(),
+        ));
     }
 
     PySpendBundleConditions {


### PR DESCRIPTION
the new `clvmr` crate has a slightly new API for `Allocator::atom()`. The second commit in this PR adapts `chia_rs` to this API.