### PR TITLE
`tree_hash_cached()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,6 +634,7 @@ dependencies = [
  "clvm-traits",
  "clvmr",
  "hex",
+ "rstest 0.16.0",
 ]
 
 [[package]]

--- a/clvm-utils/Cargo.toml
+++ b/clvm-utils/Cargo.toml
@@ -14,3 +14,4 @@ clvm-traits = { version = "0.5.1", path = "../clvm-traits" }
 
 [dev-dependencies]
 hex = "0.4.3"
+rstest = "0.16.0"

--- a/clvm-utils/fuzz/fuzz_targets/tree-hash.rs
+++ b/clvm-utils/fuzz/fuzz_targets/tree-hash.rs
@@ -1,12 +1,28 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use clvm_utils::tree_hash;
-use clvmr::allocator::Allocator;
+use clvm_utils::{tree_hash, tree_hash_cached};
+use clvmr::{Allocator, NodePtr};
 use fuzzing_utils::{make_tree, BitCursor};
+use std::collections::{HashMap, HashSet};
+
+use clvmr::serde::{node_from_bytes_backrefs_record, node_to_bytes_backrefs};
+
+fn test_hash(a: &Allocator, node: NodePtr, backrefs: &HashSet<NodePtr>) {
+    let hash1 = tree_hash(a, node);
+
+    let mut cache = HashMap::<NodePtr, [u8; 32]>::new();
+    let hash2 = tree_hash_cached(a, node, backrefs, &mut cache);
+    assert_eq!(hash1, hash2);
+}
 
 fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();
     let input = make_tree(&mut a, &mut BitCursor::new(data), false);
-    let _ret = tree_hash(&a, input);
+    test_hash(&a, input, &HashSet::new());
+
+    let bytes = node_to_bytes_backrefs(&a, input).expect("node_to_bytes_backrefs");
+    let (input, backrefs) =
+        node_from_bytes_backrefs_record(&mut a, &bytes).expect("node_from_bytes_backrefs_record");
+    test_hash(&a, input, &backrefs);
 });

--- a/clvm-utils/src/tree_hash.rs
+++ b/clvm-utils/src/tree_hash.rs
@@ -1,5 +1,5 @@
 use clvmr::allocator::{Allocator, NodePtr, SExp};
-use clvmr::serde::node_from_bytes_backrefs;
+use clvmr::serde::node_from_bytes_backrefs_record;
 use clvmr::sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::io;
@@ -108,8 +108,9 @@ pub fn tree_hash_cached(
 
 pub fn tree_hash_from_bytes(buf: &[u8]) -> io::Result<[u8; 32]> {
     let mut a = Allocator::new();
-    let node = node_from_bytes_backrefs(&mut a, buf)?;
-    Ok(tree_hash(&a, node))
+    let (node, backrefs) = node_from_bytes_backrefs_record(&mut a, buf)?;
+    let mut cache = HashMap::<NodePtr, [u8; 32]>::new();
+    Ok(tree_hash_cached(&a, node, &backrefs, &mut cache))
 }
 
 #[test]


### PR DESCRIPTION
This PR introduces an optimization of puzzle hash computations. It will take effect after the hard fork, when blocks are generated in compressed CLVM form (i.e. with back-references).

# summary

## tree hash

speed-up of tree hashing a block generators. These are blocks from mainnet, but re-serialized in compressed form.

| block | speed-up (AMD)| speed-up (RPi5) | speed-up (M1) |
| --- | --- | --- | --- |
| 1ee588dc  |   5.08  | 5.95 | 6.19 |
| 225758  |   1.00   | 1.1 | 1.15 |
| 4671894 |   1.13  | 1.29 | 1.35 |
| 6fe59b24 | 4.15 |  5.09 | 4.98 |
| 834752 |  3.64 | 4.27 | 4.45 |
| b45268ac  | 5.00  | 6.02 |6.23 |
| c2a8df0d  | 5.85 | 6.99 | 7.52 |

## run_generator2

speed-up of running block generators (with the rust implementation of the generator ROM, i.e. post hard-fork). Since this also runs CLVM and partially validates conditions, the hashing of puzzles does not dominate the total cost.

| block | speed-up (AMD) | speed-up (RPi5) | speed-up (M1) |
| --- | --- | --- | --- |
| 1ee588dc  | 1.75 | 3.08 | 3.69 |
| 225758  |  0.97   | 0.98 | 1.03 |
| 4671894 |   0.95  | 0.99 | 1.01 |
| 6fe59b24 | 1.68 | 2.73 | 3.14 |
| 834752 | 1.26 | 1.78 | 1.92 |
| b45268ac  |  1.75 | 3.0 | 3.62 |
| c2a8df0d  |  1.88| 3.52 | 4.29 |
| e5002df2| 1.68 | 2.8 | 3.26 |

plain CLVM may see a small slow-down, since the cache logic is not free, and will have a 0% cache hit-rate. However, `run_block_generator2()` won't be used until after the hard fork anyway, so it will only see compressed plots.

| block | speed-up (AMD) | speed-up (RPi5) | speed-up (M1) |
| --- | --- | --- | --- |
|1ee588dc | 1.03 | 0.99 | 0.97 |
|225758  | 0.98 | 0.99 | 1.04 |
|4671894 | 0.96 | 1.0 | 1.0 |
|6fe59b24 | 1.04 | 0.99 | 0.98 |
|834752 | 0.96| 0.99 | 0.99 |
|b45268ac  | 1.02  | 0.99 | 0.99 |
|c2a8df0d  |1.06  | 0.99 | 1.0 |
|e5002df2 |  1.01 | 0.99 | 0.99 |

# Description

It builds on the clvm_rs patch https://github.com/Chia-Network/clvm_rs/pull/381 which introduced a way to record which nodes had back-references pointing to them. This helps tree hash computations by caching the hashes for those nodes, to avoid computing them twice.

As part of validating blocks (and transactions) we need to compute the tree hash of the puzzle reveal in order to validate that it matches the puzzle hash of the coin it spends. Since many puzzles share large parts of puzzle code in the puzzle reveal, there is a fair amount of shared sub-trees in the CLVM structure. Caching the hashes of these trees is  a significant cost saving.

# implementation

There are 3 commits, they are best reviewed one at a time.

1. introduce a new variant of `tree_hash()` which accepts a cache and a set of nodes that are good candidates for caching
2. update run_block_generator2() to use the cached version of `tree_hash()`
3. update the `tree_hash_from_bytes()` to use the cached version of `tree_hash()`