### PR TITLE
Use stable for CI tests, clippy, build

### DIFF
--- a/.github/workflows/build-crate-and-npm.yml
+++ b/.github/workflows/build-crate-and-npm.yml
@@ -27,15 +27,10 @@ jobs:
       with:
         components: rustfmt, clippy
 
-    - name: Set up rust (nightly)
-      uses: dtolnay/rust-toolchain@nightly
-      with:
-        components: rustfmt, clippy
-
-    - name: fmt (nightly)
-      run: cargo +nightly fmt -- --files-with-diff --check
-    - name: clippy (nightly)
-      run: cargo +nightly clippy
+    - name: fmt
+      run: cargo fmt -- --files-with-diff --check
+    - name: clippy
+      run: cargo clippy
     - name: tests
       run: cargo test && cargo test --release
     - name: build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -285,13 +285,10 @@ jobs:
           fetch-depth: 1
 
       - name: Install rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain
         with:
             components: rustfmt, clippy
       
-      - name: Set rustup override
-        run: rustup override set nightly
-
       - name: fmt
         run: |
             cargo fmt --all -- --files-with-diff --check
@@ -302,13 +299,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain
         with:
           components: clippy
         
-      - name: Set rustup override
-        run: rustup override set nightly
-
       - name: workspace
         run: |
             cargo clippy --workspace --all-features -- -Dwarnings


### PR DESCRIPTION
This change is to prevent nightly clippy lints from breaking CI like https://github.com/rust-lang/rust/issues/121621.