### PR TITLE
fix typo in workflow file

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -285,7 +285,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install rust
-        uses: dtolnay/rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
             components: rustfmt, clippy
 
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 


### PR DESCRIPTION
introduced here https://github.com/Chia-Network/chia_rs/actions/runs/8054706840
```
[Error: .github#L1](https://github.com/Chia-Network/chia_rs/commit/dde6811b64a858dfb01e6a9d6915b254a69da6b0#annotation_18556478120)
the `uses' attribute must be a path, a Docker image, or owner/repo@ref
```