### PR TITLE
improve fuzzer coverage

### DIFF
--- a/crates/chia-consensus/fuzz/fuzz_targets/parse-cond-args.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/parse-cond-args.rs
@@ -3,22 +3,29 @@ use libfuzzer_sys::fuzz_target;
 
 use chia_consensus::gen::conditions::parse_args;
 use clvmr::allocator::Allocator;
-use fuzzing_utils::{make_tree, BitCursor};
+use fuzzing_utils::{make_list, BitCursor};
 
-use chia_consensus::gen::flags::{COND_ARGS_NIL, STRICT_ARGS_COUNT};
+use chia_consensus::gen::flags::{COND_ARGS_NIL, ENABLE_SOFTFORK_CONDITION, STRICT_ARGS_COUNT};
 
 use chia_consensus::gen::opcodes::{
-    AGG_SIG_ME, AGG_SIG_UNSAFE, ASSERT_COIN_ANNOUNCEMENT, ASSERT_HEIGHT_ABSOLUTE,
-    ASSERT_HEIGHT_RELATIVE, ASSERT_MY_AMOUNT, ASSERT_MY_COIN_ID, ASSERT_MY_PARENT_ID,
-    ASSERT_MY_PUZZLEHASH, ASSERT_PUZZLE_ANNOUNCEMENT, ASSERT_SECONDS_ABSOLUTE,
-    ASSERT_SECONDS_RELATIVE, CREATE_COIN, CREATE_COIN_ANNOUNCEMENT, CREATE_PUZZLE_ANNOUNCEMENT,
-    REMARK, RESERVE_FEE,
+    AGG_SIG_AMOUNT, AGG_SIG_ME, AGG_SIG_PARENT, AGG_SIG_PARENT_AMOUNT, AGG_SIG_PARENT_PUZZLE,
+    AGG_SIG_PUZZLE, AGG_SIG_PUZZLE_AMOUNT, AGG_SIG_UNSAFE, ASSERT_COIN_ANNOUNCEMENT,
+    ASSERT_EPHEMERAL, ASSERT_HEIGHT_ABSOLUTE, ASSERT_HEIGHT_RELATIVE, ASSERT_MY_AMOUNT,
+    ASSERT_MY_COIN_ID, ASSERT_MY_PARENT_ID, ASSERT_MY_PUZZLEHASH, ASSERT_PUZZLE_ANNOUNCEMENT,
+    ASSERT_SECONDS_ABSOLUTE, ASSERT_SECONDS_RELATIVE, CREATE_COIN, CREATE_COIN_ANNOUNCEMENT,
+    CREATE_PUZZLE_ANNOUNCEMENT, REMARK, RESERVE_FEE,
 };
 
 fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();
-    let input = make_tree(&mut a, &mut BitCursor::new(data), false);
-    for flags in &[0, COND_ARGS_NIL, STRICT_ARGS_COUNT] {
+    let input = make_list(&mut a, &mut BitCursor::new(data));
+
+    for flags in &[
+        0,
+        COND_ARGS_NIL,
+        STRICT_ARGS_COUNT,
+        ENABLE_SOFTFORK_CONDITION,
+    ] {
         for op in &[
             AGG_SIG_ME,
             AGG_SIG_UNSAFE,
@@ -37,6 +44,13 @@ fuzz_target!(|data: &[u8]| {
             CREATE_COIN_ANNOUNCEMENT,
             CREATE_PUZZLE_ANNOUNCEMENT,
             RESERVE_FEE,
+            ASSERT_EPHEMERAL,
+            AGG_SIG_PARENT,
+            AGG_SIG_PUZZLE,
+            AGG_SIG_AMOUNT,
+            AGG_SIG_PUZZLE_AMOUNT,
+            AGG_SIG_PARENT_AMOUNT,
+            AGG_SIG_PARENT_PUZZLE,
         ] {
             let _ret = parse_args(&a, input, *op, *flags);
         }

--- a/crates/chia-consensus/fuzz/fuzz_targets/parse-spend.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/parse-spend.rs
@@ -3,11 +3,11 @@ use libfuzzer_sys::fuzz_target;
 
 use chia_consensus::gen::get_puzzle_and_solution::parse_coin_spend;
 use clvmr::allocator::Allocator;
-use fuzzing_utils::{make_tree, BitCursor};
+use fuzzing_utils::{make_list, BitCursor};
 
 fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();
-    let input = make_tree(&mut a, &mut BitCursor::new(data), false);
+    let input = make_list(&mut a, &mut BitCursor::new(data));
 
     let _ret = parse_coin_spend(&a, input);
 });

--- a/crates/chia-consensus/fuzz/fuzz_targets/parse-spends.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/parse-spends.rs
@@ -2,15 +2,25 @@
 use libfuzzer_sys::fuzz_target;
 
 use chia_consensus::gen::conditions::{parse_spends, MempoolVisitor};
-use clvmr::allocator::Allocator;
-use fuzzing_utils::{make_tree, BitCursor};
+use clvmr::{Allocator, NodePtr};
+use fuzzing_utils::{make_list, BitCursor};
 
-use chia_consensus::gen::flags::{COND_ARGS_NIL, NO_UNKNOWN_CONDS, STRICT_ARGS_COUNT};
+use chia_consensus::gen::flags::{
+    COND_ARGS_NIL, ENABLE_SOFTFORK_CONDITION, NO_UNKNOWN_CONDS, STRICT_ARGS_COUNT,
+};
 
 fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();
-    let input = make_tree(&mut a, &mut BitCursor::new(data), false);
-    for flags in &[0, COND_ARGS_NIL, STRICT_ARGS_COUNT, NO_UNKNOWN_CONDS] {
+    let input = make_list(&mut a, &mut BitCursor::new(data));
+    // spends is a list of spends
+    let input = a.new_pair(input, NodePtr::NIL).unwrap();
+    for flags in &[
+        0,
+        COND_ARGS_NIL,
+        STRICT_ARGS_COUNT,
+        NO_UNKNOWN_CONDS,
+        ENABLE_SOFTFORK_CONDITION,
+    ] {
         let _ret = parse_spends::<MempoolVisitor>(&a, input, 33000000000, *flags);
     }
 });


### PR DESCRIPTION
for `cargo fuzz run parse-conditions`

main:

```
#101362 REDUCE cov: 555 ft: 2458 corp: 167/8395b lim: 497 exec/s: 2472 rss: 120Mb L: 18/288
```

new:

```
#107417 REDUCE cov: 1525 ft: 3197 corp: 284/3923b lim: 857 exec/s: 8951 rss: 108Mb L: 17/107
```