### PR TITLE
Message conditions

### DIFF
--- a/crates/chia-consensus/fuzz/Cargo.toml
+++ b/crates/chia-consensus/fuzz/Cargo.toml
@@ -91,3 +91,10 @@ path = "fuzz_targets/fast-forward.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "parse-spend-id"
+path = "fuzz_targets/parse-spend-id.rs"
+test = false
+doc = false
+bench = false

--- a/crates/chia-consensus/fuzz/fuzz_targets/parse-cond-args.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/parse-cond-args.rs
@@ -5,7 +5,9 @@ use chia_consensus::gen::conditions::parse_args;
 use clvmr::allocator::Allocator;
 use fuzzing_utils::{make_list, BitCursor};
 
-use chia_consensus::gen::flags::{COND_ARGS_NIL, ENABLE_SOFTFORK_CONDITION, STRICT_ARGS_COUNT};
+use chia_consensus::gen::flags::{
+    COND_ARGS_NIL, ENABLE_MESSAGE_CONDITIONS, ENABLE_SOFTFORK_CONDITION, STRICT_ARGS_COUNT,
+};
 
 use chia_consensus::gen::opcodes::{
     AGG_SIG_AMOUNT, AGG_SIG_ME, AGG_SIG_PARENT, AGG_SIG_PARENT_AMOUNT, AGG_SIG_PARENT_PUZZLE,
@@ -13,7 +15,7 @@ use chia_consensus::gen::opcodes::{
     ASSERT_EPHEMERAL, ASSERT_HEIGHT_ABSOLUTE, ASSERT_HEIGHT_RELATIVE, ASSERT_MY_AMOUNT,
     ASSERT_MY_COIN_ID, ASSERT_MY_PARENT_ID, ASSERT_MY_PUZZLEHASH, ASSERT_PUZZLE_ANNOUNCEMENT,
     ASSERT_SECONDS_ABSOLUTE, ASSERT_SECONDS_RELATIVE, CREATE_COIN, CREATE_COIN_ANNOUNCEMENT,
-    CREATE_PUZZLE_ANNOUNCEMENT, REMARK, RESERVE_FEE,
+    CREATE_PUZZLE_ANNOUNCEMENT, RECEIVE_MESSAGE, REMARK, RESERVE_FEE, SEND_MESSAGE,
 };
 
 fuzz_target!(|data: &[u8]| {
@@ -25,6 +27,7 @@ fuzz_target!(|data: &[u8]| {
         COND_ARGS_NIL,
         STRICT_ARGS_COUNT,
         ENABLE_SOFTFORK_CONDITION,
+        ENABLE_MESSAGE_CONDITIONS,
     ] {
         for op in &[
             AGG_SIG_ME,
@@ -44,6 +47,8 @@ fuzz_target!(|data: &[u8]| {
             CREATE_COIN_ANNOUNCEMENT,
             CREATE_PUZZLE_ANNOUNCEMENT,
             RESERVE_FEE,
+            SEND_MESSAGE,
+            RECEIVE_MESSAGE,
             ASSERT_EPHEMERAL,
             AGG_SIG_PARENT,
             AGG_SIG_PUZZLE,

--- a/crates/chia-consensus/fuzz/fuzz_targets/parse-conditions.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/parse-conditions.rs
@@ -14,7 +14,8 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use chia_consensus::gen::flags::{
-    COND_ARGS_NIL, ENABLE_SOFTFORK_CONDITION, NO_UNKNOWN_CONDS, STRICT_ARGS_COUNT,
+    COND_ARGS_NIL, ENABLE_MESSAGE_CONDITIONS, ENABLE_SOFTFORK_CONDITION, NO_UNKNOWN_CONDS,
+    STRICT_ARGS_COUNT,
 };
 
 fuzz_target!(|data: &[u8]| {
@@ -48,6 +49,7 @@ fuzz_target!(|data: &[u8]| {
         STRICT_ARGS_COUNT,
         NO_UNKNOWN_CONDS,
         ENABLE_SOFTFORK_CONDITION,
+        ENABLE_MESSAGE_CONDITIONS,
     ] {
         let mut coin_spend = Spend {
             parent_id,

--- a/crates/chia-consensus/fuzz/fuzz_targets/parse-spend-id.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/parse-spend-id.rs
@@ -1,0 +1,50 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use chia_consensus::gen::messages::SpendId;
+use clvmr::allocator::Allocator;
+use fuzzing_utils::{make_list, BitCursor};
+
+fuzz_target!(|data: &[u8]| {
+    let mut a = Allocator::new();
+    let mut cursor = BitCursor::new(data);
+    let mode = cursor.read_bits(3).unwrap_or(0);
+    let mut input = make_list(&mut a, &mut cursor);
+
+    let Ok(s) = SpendId::parse(&a, &mut input, mode) else {
+        return;
+    };
+
+    match s {
+        SpendId::OwnedCoinId(_bytes) => unreachable!(),
+        SpendId::CoinId(coinid) => {
+            assert_eq!(mode, 0b111);
+            assert_eq!(a.atom_len(coinid), 32);
+        }
+        SpendId::Parent(parent) => {
+            assert_eq!(mode, 0b100);
+            assert_eq!(a.atom_len(parent), 32);
+        }
+        SpendId::Puzzle(puzzle) => {
+            assert_eq!(mode, 0b010);
+            assert_eq!(a.atom_len(puzzle), 32);
+        }
+        SpendId::Amount(_amount) => {
+            assert_eq!(mode, 0b001);
+        }
+        SpendId::PuzzleAmount(puzzle, _amount) => {
+            assert_eq!(a.atom_len(puzzle), 32);
+            assert_eq!(mode, 0b011);
+        }
+        SpendId::ParentAmount(parent, _amount) => {
+            assert_eq!(a.atom_len(parent), 32);
+            assert_eq!(mode, 0b101);
+        }
+        SpendId::ParentPuzzle(parent, puzzle) => {
+            assert_eq!(a.atom_len(parent), 32);
+            assert_eq!(a.atom_len(puzzle), 32);
+            assert_eq!(mode, 0b110);
+        }
+        SpendId::None => assert_eq!(mode, 0),
+    }
+});

--- a/crates/chia-consensus/fuzz/fuzz_targets/parse-spends.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/parse-spends.rs
@@ -6,7 +6,8 @@ use clvmr::{Allocator, NodePtr};
 use fuzzing_utils::{make_list, BitCursor};
 
 use chia_consensus::gen::flags::{
-    COND_ARGS_NIL, ENABLE_SOFTFORK_CONDITION, NO_UNKNOWN_CONDS, STRICT_ARGS_COUNT,
+    COND_ARGS_NIL, ENABLE_MESSAGE_CONDITIONS, ENABLE_SOFTFORK_CONDITION, NO_UNKNOWN_CONDS,
+    STRICT_ARGS_COUNT,
 };
 
 fuzz_target!(|data: &[u8]| {
@@ -20,6 +21,7 @@ fuzz_target!(|data: &[u8]| {
         STRICT_ARGS_COUNT,
         NO_UNKNOWN_CONDS,
         ENABLE_SOFTFORK_CONDITION,
+        ENABLE_MESSAGE_CONDITIONS,
     ] {
         let _ret = parse_spends::<MempoolVisitor>(&a, input, 33000000000, *flags);
     }

--- a/crates/chia-consensus/src/gen/condition_sanitizers.rs
+++ b/crates/chia-consensus/src/gen/condition_sanitizers.rs
@@ -1,5 +1,6 @@
 use super::sanitize_int::{sanitize_uint, SanitizedUint};
 use super::validation_error::{atom, ErrorCode, ValidationErr};
+use crate::gen::flags::NO_UNKNOWN_CONDS;
 use clvmr::allocator::{Allocator, NodePtr};
 
 pub fn sanitize_hash(
@@ -37,6 +38,76 @@ pub fn sanitize_announce_msg(
         Err(ValidationErr(n, code))
     } else {
         Ok(n)
+    }
+}
+
+pub fn sanitize_message_mode(
+    a: &Allocator,
+    node: NodePtr,
+    flags: u32,
+) -> Result<u32, ValidationErr> {
+    let Some(mode) = a.small_number(node) else {
+        return Err(ValidationErr(node, ErrorCode::InvalidMessageMode));
+    };
+    // only 6 bits are allowed to be set
+    if (mode & !0b111111) != 0 {
+        return Err(ValidationErr(node, ErrorCode::InvalidMessageMode));
+    }
+    // both the sender and the receiver must commit to *something*
+    // the mode flags are: parent, puzzle, amount. First for the sender, then
+    // for the receiver
+    if (flags & NO_UNKNOWN_CONDS) != 0 {
+        // in mempool mode, we only accept message modes where at least the
+        // parent or the puzzle hash is committed to, for both the sender and
+        // receiver
+        if (mode & 0b110) == 0 || (mode & 0b110000) == 0 {
+            return Err(ValidationErr(node, ErrorCode::InvalidMessageMode));
+        }
+    }
+    Ok(mode)
+}
+
+#[cfg(test)]
+use rstest::rstest;
+
+#[cfg(test)]
+#[rstest]
+#[case(0, false, true)]
+#[case(-1, false, false)]
+#[case(1, false, true)]
+#[case(10000000000, false, false)]
+#[case(0xffffffffffff, false, false)]
+#[case(-0xffffffffffff, false, false)]
+#[case(0b1001001, false, false)]
+// committing to only amount is not allowed in mempool mode
+#[case(0b001001, false, true)]
+#[case(0b010010, true, true)]
+#[case(0b100100, true, true)]
+#[case(0b101101, true, true)]
+// committing to only amount is not allowed in mempool mode
+#[case(0b100001, false, true)]
+#[case(0b111111, true, true)]
+#[case(0b111100, true, true)]
+#[case(0b100111, true, true)]
+// not committing to anything is not allowed in mempool mode
+#[case(0b000111, false, true)]
+#[case(0b111000, false, true)]
+fn test_sanitize_mode(#[case] value: i64, #[case] pass_mempool: bool, #[case] pass: bool) {
+    let mut a = Allocator::new();
+    let node = a.new_number(value.into()).unwrap();
+
+    let ret = sanitize_message_mode(&a, node, 0);
+    if pass {
+        assert_eq!(ret.unwrap() as i64, value);
+    } else {
+        assert_eq!(ret.unwrap_err().1, ErrorCode::InvalidMessageMode);
+    }
+
+    let ret = sanitize_message_mode(&a, node, NO_UNKNOWN_CONDS);
+    if pass_mempool {
+        assert_eq!(ret.unwrap() as i64, value);
+    } else {
+        assert_eq!(ret.unwrap_err().1, ErrorCode::InvalidMessageMode);
     }
 }
 

--- a/crates/chia-consensus/src/gen/flags.rs
+++ b/crates/chia-consensus/src/gen/flags.rs
@@ -33,6 +33,9 @@ pub const ALLOW_BACKREFS: u32 = 0x2000000;
 // what features are detected of the spends
 pub const ANALYZE_SPENDS: u32 = 0x4000000;
 
+// This enables support for the new SEND_MESSAGE and RECEIVE_MESSAGE conditions
+pub const ENABLE_MESSAGE_CONDITIONS: u32 = 0x8000000;
+
 pub const MEMPOOL_MODE: u32 = CLVM_MEMPOOL_MODE
     | NO_UNKNOWN_CONDS
     | COND_ARGS_NIL

--- a/crates/chia-consensus/src/gen/messages.rs
+++ b/crates/chia-consensus/src/gen/messages.rs
@@ -1,0 +1,271 @@
+use crate::gen::condition_sanitizers::sanitize_hash;
+use crate::gen::sanitize_int::{sanitize_uint, SanitizedUint};
+use crate::gen::validation_error::{first, rest, ErrorCode, ValidationErr};
+use chia_protocol::Bytes32;
+use clvmr::{Allocator, NodePtr};
+use std::sync::Arc;
+
+// these are mode flags used as the first argument to SEND_MESSAGE and
+// RECEIVE_MESSAGE. They indicate which properties of the sender and receiver we
+// commit to, that must match. The mode flags for the sender are shifted left 3 bits.
+pub const PARENT: u8 = 0b100;
+pub const PUZZLE: u8 = 0b010;
+pub const AMOUNT: u8 = 0b001;
+pub const PUZZLEAMOUNT: u8 = 0b011;
+pub const PARENTAMOUNT: u8 = 0b101;
+pub const PARENTPUZZLE: u8 = 0b110;
+pub const COINID: u8 = 0b111;
+
+#[derive(Debug)]
+pub enum SpendId {
+    OwnedCoinId(Arc<Bytes32>),
+    CoinId(NodePtr),
+    Parent(NodePtr),
+    Puzzle(NodePtr),
+    Amount(u64),
+    PuzzleAmount(NodePtr, u64),
+    ParentAmount(NodePtr, u64),
+    ParentPuzzle(NodePtr, NodePtr),
+    None,
+}
+
+impl SpendId {
+    // args is an in-out parameter. It's updated to point to then next argument
+    pub fn parse(a: &Allocator, args: &mut NodePtr, mode: u8) -> Result<SpendId, ValidationErr> {
+        // we have a special case for when all three mode flags are set. That means
+        // we're committing to parent, puzzle and amount. In this case you just
+        // specify the coin ID
+        if mode == COINID {
+            let coinid = sanitize_hash(a, first(a, *args)?, 32, ErrorCode::InvalidCoinId)?;
+            *args = rest(a, *args)?;
+            return Ok(Self::CoinId(coinid));
+        }
+
+        let parent = if (mode & PARENT) != 0 {
+            let parent = sanitize_hash(a, first(a, *args)?, 32, ErrorCode::InvalidParentId)?;
+            *args = rest(a, *args)?;
+            parent
+        } else {
+            NodePtr::NIL
+        };
+
+        let puzzle = if (mode & PUZZLE) != 0 {
+            let puzzle = sanitize_hash(a, first(a, *args)?, 32, ErrorCode::InvalidPuzzleHash)?;
+            *args = rest(a, *args)?;
+            puzzle
+        } else {
+            NodePtr::NIL
+        };
+
+        let amount = if (mode & AMOUNT) != 0 {
+            let amount = match sanitize_uint(a, first(a, *args)?, 8, ErrorCode::InvalidCoinAmount)?
+            {
+                SanitizedUint::PositiveOverflow => {
+                    return Err(ValidationErr(*args, ErrorCode::AmountExceedsMaximum));
+                }
+                SanitizedUint::NegativeOverflow => {
+                    return Err(ValidationErr(*args, ErrorCode::NegativeAmount));
+                }
+                SanitizedUint::Ok(amount) => amount,
+            };
+            *args = rest(a, *args)?;
+            amount
+        } else {
+            0
+        };
+
+        match mode {
+            PARENT => Ok(Self::Parent(parent)),
+            PUZZLE => Ok(Self::Puzzle(puzzle)),
+            AMOUNT => Ok(Self::Amount(amount)),
+            PARENTPUZZLE => Ok(Self::ParentPuzzle(parent, puzzle)),
+            PARENTAMOUNT => Ok(Self::ParentAmount(parent, amount)),
+            PUZZLEAMOUNT => Ok(Self::PuzzleAmount(puzzle, amount)),
+            0 => Ok(Self::None),
+            _ => Err(ValidationErr(*args, ErrorCode::InvalidMessageMode)),
+        }
+    }
+
+    pub fn from_self(
+        mode: u8,
+        parent: NodePtr,
+        puzzle: NodePtr,
+        amount: u64,
+        coin_id: &Arc<Bytes32>,
+    ) -> Result<SpendId, ValidationErr> {
+        if mode == COINID {
+            return Ok(Self::OwnedCoinId(coin_id.clone()));
+        }
+
+        match mode {
+            PARENT => Ok(Self::Parent(parent)),
+            PUZZLE => Ok(Self::Puzzle(puzzle)),
+            AMOUNT => Ok(Self::Amount(amount)),
+            PARENTPUZZLE => Ok(Self::ParentPuzzle(parent, puzzle)),
+            PARENTAMOUNT => Ok(Self::ParentAmount(parent, amount)),
+            PUZZLEAMOUNT => Ok(Self::PuzzleAmount(puzzle, amount)),
+            0 => Ok(Self::None),
+            _ => Err(ValidationErr(NodePtr::NIL, ErrorCode::InvalidMessageMode)),
+        }
+    }
+
+    pub fn make_key(&self, out: &mut Vec<u8>, a: &Allocator) {
+        match self {
+            Self::OwnedCoinId(coinid) => {
+                out.push(COINID);
+                out.extend_from_slice(coinid);
+            }
+            Self::CoinId(coinid) => {
+                out.push(COINID);
+                out.extend_from_slice(a.atom(*coinid).as_ref());
+            }
+            Self::Parent(parent) => {
+                out.push(PARENT);
+                out.extend_from_slice(a.atom(*parent).as_ref());
+            }
+            Self::Puzzle(puzzle) => {
+                out.push(PUZZLE);
+                out.extend_from_slice(a.atom(*puzzle).as_ref());
+            }
+            Self::Amount(amount) => {
+                out.push(AMOUNT);
+                out.extend_from_slice(&amount.to_be_bytes());
+            }
+            Self::PuzzleAmount(puzzle, amount) => {
+                out.push(PUZZLEAMOUNT);
+                out.extend_from_slice(a.atom(*puzzle).as_ref());
+                out.extend_from_slice(&amount.to_be_bytes());
+            }
+            Self::ParentAmount(parent, amount) => {
+                out.push(PARENTAMOUNT);
+                out.extend_from_slice(a.atom(*parent).as_ref());
+                out.extend_from_slice(&amount.to_be_bytes());
+            }
+            Self::ParentPuzzle(parent, puzzle) => {
+                out.push(PARENTPUZZLE);
+                out.extend_from_slice(a.atom(*parent).as_ref());
+                out.extend_from_slice(a.atom(*puzzle).as_ref());
+            }
+            Self::None => {
+                out.push(0);
+            }
+        }
+    }
+}
+
+pub struct Message {
+    pub src: SpendId,
+    pub dst: SpendId,
+    pub msg: NodePtr,
+    pub counter: i8,
+}
+
+impl Message {
+    pub fn make_key(&self, a: &Allocator) -> Vec<u8> {
+        let mut key = Vec::<u8>::new();
+        self.src.make_key(&mut key, a);
+        self.dst.make_key(&mut key, a);
+        key.extend_from_slice(a.atom(self.msg).as_ref());
+        key
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+    use rstest::rstest;
+
+    const BUF0: [u8; 32] = hex!("0000000000000000000000000000000000000000000000000000000000000000");
+    const BUF1: [u8; 32] = hex!("0101010101010101010101010101010101010101010101010101010101010101");
+    const BUF2: [u8; 32] = hex!("0202020202020202020202020202020202020202020202020202020202020202");
+
+    #[rstest]
+    #[case(0b000, "00")]
+    #[case(0b001, "010000000000000539")]
+    #[case(
+        0b010,
+        "020101010101010101010101010101010101010101010101010101010101010101"
+    )]
+    #[case(
+        0b100,
+        "040000000000000000000000000000000000000000000000000000000000000000"
+    )]
+    #[case(0b110, "0600000000000000000000000000000000000000000000000000000000000000000101010101010101010101010101010101010101010101010101010101010101")]
+    #[case(
+        0b111,
+        "070202020202020202020202020202020202020202020202020202020202020202"
+    )]
+    #[case(
+        0b011,
+        "0301010101010101010101010101010101010101010101010101010101010101010000000000000539"
+    )]
+    #[case(
+        0b101,
+        "0500000000000000000000000000000000000000000000000000000000000000000000000000000539"
+    )]
+    fn test_from_self(#[case] mode: u8, #[case] expected: &str) {
+        let mut a = Allocator::new();
+        let parent = a.new_atom(&BUF0).unwrap();
+        let puzzle = a.new_atom(&BUF1).unwrap();
+        let coin_id = Arc::<Bytes32>::new(Bytes32::new(BUF2));
+        let src = SpendId::from_self(mode, parent, puzzle, 1337, &coin_id).unwrap();
+
+        let mut key = Vec::<u8>::new();
+        src.make_key(&mut key, &a);
+        assert_eq!(key, hex::decode(expected).unwrap());
+    }
+
+    #[rstest]
+    #[case(0b000, "00")]
+    #[case(0b001, "010000000000000539")]
+    #[case(
+        0b010,
+        "020101010101010101010101010101010101010101010101010101010101010101"
+    )]
+    #[case(
+        0b100,
+        "040000000000000000000000000000000000000000000000000000000000000000"
+    )]
+    #[case(0b110, "0600000000000000000000000000000000000000000000000000000000000000000101010101010101010101010101010101010101010101010101010101010101")]
+    #[case(
+        0b111,
+        "070202020202020202020202020202020202020202020202020202020202020202"
+    )]
+    #[case(
+        0b011,
+        "0301010101010101010101010101010101010101010101010101010101010101010000000000000539"
+    )]
+    #[case(
+        0b101,
+        "0500000000000000000000000000000000000000000000000000000000000000000000000000000539"
+    )]
+    fn test_parse(#[case] mode: u8, #[case] expected: &str) {
+        let mut a = Allocator::new();
+        let mut args = NodePtr::NIL;
+        if mode == COINID {
+            let value = a.new_atom(&BUF2).unwrap();
+            args = a.new_pair(value, args).unwrap();
+        } else {
+            if (mode & AMOUNT) != 0 {
+                let value = a.new_small_number(1337).unwrap();
+                args = a.new_pair(value, args).unwrap();
+            }
+            if (mode & PUZZLE) != 0 {
+                let value = a.new_atom(&BUF1).unwrap();
+                args = a.new_pair(value, args).unwrap();
+            }
+            if (mode & PARENT) != 0 {
+                let value = a.new_atom(&BUF0).unwrap();
+                args = a.new_pair(value, args).unwrap();
+            }
+        }
+        let src = SpendId::parse(&a, &mut args, mode).unwrap();
+        // ensure we parsed all arguments
+        assert!(a.atom_eq(args, NodePtr::NIL));
+
+        let mut key = Vec::<u8>::new();
+        src.make_key(&mut key, &a);
+        assert_eq!(key, hex::decode(expected).unwrap());
+    }
+}

--- a/crates/chia-consensus/src/gen/mod.rs
+++ b/crates/chia-consensus/src/gen/mod.rs
@@ -3,6 +3,7 @@ mod condition_sanitizers;
 pub mod conditions;
 pub mod flags;
 pub mod get_puzzle_and_solution;
+pub mod messages;
 pub mod opcodes;
 pub mod run_block_generator;
 pub mod run_puzzle;

--- a/crates/chia-consensus/src/gen/validation_error.rs
+++ b/crates/chia-consensus/src/gen/validation_error.rs
@@ -51,6 +51,9 @@ pub enum ErrorCode {
     InvalidSoftforkCondition,
     InvalidSoftforkCost,
     TooManyAnnouncements,
+    InvalidMessageMode,
+    InvalidCoinId,
+    MessageNotSentOrReceived,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
@@ -136,6 +139,9 @@ impl From<ErrorCode> for u32 {
             ErrorCode::InvalidSoftforkCondition => 142,
             ErrorCode::InvalidSoftforkCost => 143,
             ErrorCode::TooManyAnnouncements => 144,
+            ErrorCode::InvalidMessageMode => 145,
+            ErrorCode::InvalidCoinId => 146,
+            ErrorCode::MessageNotSentOrReceived => 147,
         }
     }
 }

--- a/crates/chia-tools/src/bin/run-spend.rs
+++ b/crates/chia-tools/src/bin/run-spend.rs
@@ -115,6 +115,12 @@ impl DebugPrint for Condition {
             Self::AssertBeforeHeightAbsolute(h) => format!("ASSERT_BEFORE_HEIGHT_ABSOLUTE {h}"),
             Self::AssertEphemeral => "ASSERT_EPHEMERAL".to_string(),
             Self::Softfork(cost) => format!("SOFTFORK {cost}"),
+            Self::SendMessage(src, dst, msg) => {
+                format!("SEND_MESSAGE {src:?} {dst:?} {}", msg.debug_print(a))
+            }
+            Self::ReceiveMessage(src, dst, msg) => {
+                format!("RECEIVE_MESSAGE {src:?} {dst:?} {}", msg.debug_print(a))
+            }
             Self::Skip => "[Skip] REMARK ...".to_string(),
             Self::SkipRelativeCondition => "[SkipRelativeCondition]".to_string(),
         }

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -5,8 +5,9 @@ use crate::run_generator::{
 use chia_consensus::allocator::make_allocator;
 use chia_consensus::gen::conditions::MempoolVisitor;
 use chia_consensus::gen::flags::{
-    AGG_SIG_ARGS, ALLOW_BACKREFS, ANALYZE_SPENDS, COND_ARGS_NIL, ENABLE_SOFTFORK_CONDITION,
-    MEMPOOL_MODE, NO_RELATIVE_CONDITIONS_ON_EPHEMERAL, NO_UNKNOWN_CONDS, STRICT_ARGS_COUNT,
+    AGG_SIG_ARGS, ALLOW_BACKREFS, ANALYZE_SPENDS, COND_ARGS_NIL, ENABLE_MESSAGE_CONDITIONS,
+    ENABLE_SOFTFORK_CONDITION, MEMPOOL_MODE, NO_RELATIVE_CONDITIONS_ON_EPHEMERAL, NO_UNKNOWN_CONDS,
+    STRICT_ARGS_COUNT,
 };
 use chia_consensus::gen::run_puzzle::run_puzzle as native_run_puzzle;
 use chia_consensus::gen::solution_generator::solution_generator as native_solution_generator;
@@ -353,6 +354,7 @@ pub fn chia_rs(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add("AGG_SIG_ARGS", AGG_SIG_ARGS)?;
     m.add("ENABLE_FIXED_DIV", ENABLE_FIXED_DIV)?;
     m.add("ENABLE_SOFTFORK_CONDITION", ENABLE_SOFTFORK_CONDITION)?;
+    m.add("ENABLE_MESSAGE_CONDITIONS", ENABLE_MESSAGE_CONDITIONS)?;
     m.add(
         "NO_RELATIVE_CONDITIONS_ON_EPHEMERAL",
         NO_RELATIVE_CONDITIONS_ON_EPHEMERAL,


### PR DESCRIPTION
# Overview

This PR implements the message condition codes as described by [CHIP-25](https://github.com/Chia-Network/chips/pull/98).

## Enable/disable

Support for these new conditions is *disabled* by default, and only enabled by passing in the `ENABLE_MESSAGE_CONDITIONS` flag. (the enable/disable logic is implemented in `crates/chia-consensus/src/gen/opcodes.rs`).

## Error codes

There are 3 new error codes introduced by this PR. These will need to be added to `chia-blockchain` as well.

```
ErrorCode::InvalidMessageMode => 145,
ErrorCode::InvalidCoinId => 146,
ErrorCode::MessageNotSentOrReceived => 147,
```

## Deferred memory allocation

Since there's no CLVM cost associated with these new conditions, we need to be careful to mitigate abuse in the form of DoS attacks. When a message is sent or received, we record as little information as possible up front, to resolve later, after all spends has been executed.

Each message has a mask indicating which attributes of itself to take into account. We don't need to store those attributes in the message, just the mask.

Each message also specifies the attributes of the other end of the message (if you're the sender, you specify the receiver's attributes and vice versa). These attributes *do* need to be stored in the message. To avoid memory allocation, only the `NodePtr` are stored. This is encapsulated in the `SpendId` enum` (in `crates/chia-consensus/src/gen/messages.rs`).

Each message has a message `NodePtr`, a mask identifying its own properties to take into account and a `SpendId` indentifying the other end's properties.

When it's time to validate all messages, we turn each message into a key and increment (send message) and decrement (receive message) a counter for each key. At the end we ensure that all counters are 0. This is implemented at the end of the `validate_conditions()` function.

The key generation is where we actually allocate. It's generated in such a way that when the self-attributes matches the parsed-attributes, they are identical. This is how senders and receivers match up. See `SpendId::make_key()` in `crates/chia-consensus/src/gen/messages.rs`.

The justification of avoiding and deferring memory allocation is that one of the most expensive stress tests we have is `duplicate-coin-announce.txt` which takes almost 3 seconds to run. Avoiding the copying of the coin ID (and message) was a material speed-up in earlier tests.

## fast-forward

Spends that send a message that's identified by their parent ID are not eligible for fast forward. Likewise, spends receiving a message identified by their own parent ID are also not eligible for fast forward. This includes messages identified by their coin ID, since the parent ID is part of that.

## deduplication

Spends that send or receive messages are not eligible for de-duplication. De-duplicating such spend would leave the other end of the message dangling. This has some false negatives. Specifically for coins sending a message to itself. It would be safe to de-duplicate such spend, but it's more complicated to carve out that special case. Maybe we can do that in the future if we encounter a use case.

## Testing

There are a large number of test cases in `crates/chia-consensus/src/gen/conditions.rs`.

`test_message_strict_args_count()` makes sure we allow unknown additional parameters, unless `STRICT_ARGS_COUNT` is set (i.e. mempool mode)

`test_message_conditions_single_spend()` has test cases where a single spend sends a message to itself. Some valid in mempool mode, some not.

`test_limit_messages()` ensures that the 1024 limit applies to these new conditions, just like it does to the existing create announcement and assert announcement.

`test_message_conditions_failures()` ensures parse failures are correctly caught and yields the expected error code.

`test_message_conditions_two_spends()` has test cases where one spend sends a message to another spend.

`test_all_message_conditions()` programatically generates all combinations of messages that can be sent from one spend to another. These are only positive tests.

`test_message_eligible_for_ff()` tests all combinations of messages between coins where one coin is eligible for fast-forward. The test ensures that it remains eligible as long as its parent ID is not committed to by the message (both by sending or receiving a message).

## Fuzzing

The `SpendId::parse()` has a fuzzing driver and the `parse-conditions` was extended to enable the message conditions.

# TODO

* [x] Figure out under what circumstances should spends be eligible for fast-forward and dedup. There should probably be more thorough tests and more deliberate logic for this
* [ ] ~~implement stress tests and attempts to flood these messages to ensure the implementation doesn't fall over~~ (I will update the stress tests in a separate PR)