### PR TITLE
Change precommit bench build to dev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         name: build benchmarks
         description: run cargo bench on the workspace
         stages: [pre-push]
-        entry: cargo bench --no-run --workspace
+        entry: cargo bench --no-run --workspace --profile dev
         language: system
         pass_filenames: false
       - id: tests


### PR DESCRIPTION
This speeds up the precommit hook by about 50%, cutting it from 3:02 to 1:37 on my machine.