### PR TITLE
Bump version 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,14 +276,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chia"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
- "chia-bls 0.5.1",
+ "chia-bls 0.6.0",
  "chia-client",
  "chia-consensus",
  "chia-protocol",
  "chia-ssl",
- "chia-traits 0.5.2",
+ "chia-traits 0.6.0",
  "chia-wallet",
  "clvm-traits",
  "clvm-utils",
@@ -308,12 +308,12 @@ dependencies = [
 
 [[package]]
 name = "chia-bls"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "arbitrary",
  "blst",
- "chia-traits 0.5.2",
+ "chia-traits 0.6.0",
  "chia_py_streamable_macro",
  "criterion",
  "hex",
@@ -330,17 +330,17 @@ dependencies = [
 name = "chia-bls-fuzz"
 version = "0.0.0"
 dependencies = [
- "chia-bls 0.5.1",
+ "chia-bls 0.6.0",
  "libfuzzer-sys",
  "pyo3",
 ]
 
 [[package]]
 name = "chia-client"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "chia-protocol",
- "chia-traits 0.5.2",
+ "chia-traits 0.6.0",
  "futures-util",
  "thiserror",
  "tokio",
@@ -350,10 +350,10 @@ dependencies = [
 
 [[package]]
 name = "chia-consensus"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "chia-protocol",
- "chia-traits 0.5.2",
+ "chia-traits 0.6.0",
  "chia-wallet",
  "clvm-derive",
  "clvm-traits",
@@ -371,11 +371,11 @@ dependencies = [
 
 [[package]]
 name = "chia-fuzz"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "chia-consensus",
  "chia-protocol",
- "chia-traits 0.5.2",
+ "chia-traits 0.6.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -385,13 +385,13 @@ dependencies = [
 
 [[package]]
 name = "chia-protocol"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "arbitrary",
- "chia-bls 0.5.1",
- "chia-traits 0.5.2",
+ "chia-bls 0.6.0",
+ "chia-traits 0.6.0",
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.3.0",
+ "chia_streamable_macro 0.6.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -407,7 +407,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "chia-protocol",
- "chia-traits 0.5.2",
+ "chia-traits 0.6.0",
  "clvm-traits",
  "clvmr",
  "hex",
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "chia-ssl"
-version = "0.2.14"
+version = "0.6.0"
 dependencies = [
  "lazy_static",
  "rand",
@@ -430,13 +430,13 @@ dependencies = [
 
 [[package]]
 name = "chia-tools"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "blocking-threadpool",
- "chia-bls 0.5.1",
+ "chia-bls 0.6.0",
  "chia-consensus",
  "chia-protocol",
- "chia-traits 0.5.2",
+ "chia-traits 0.6.0",
  "chia-wallet",
  "clap",
  "clvm-traits",
@@ -454,7 +454,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe532ed59df94db00cc1fb85edc3c4dd7287d0590eefb356d960671b93081334"
 dependencies = [
- "chia_streamable_macro 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chia_streamable_macro 0.3.0",
  "hex",
  "sha2",
  "thiserror",
@@ -462,10 +462,10 @@ dependencies = [
 
 [[package]]
 name = "chia-traits"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.3.0",
+ "chia_streamable_macro 0.6.0",
  "hex",
  "pyo3",
  "sha2",
@@ -474,10 +474,10 @@ dependencies = [
 
 [[package]]
 name = "chia-wallet"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "arbitrary",
- "chia-bls 0.5.1",
+ "chia-bls 0.6.0",
  "chia-protocol",
  "clvm-traits",
  "clvm-utils",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "chia-wallet-fuzz"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "chia-wallet",
  "clvm-traits",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "chia_py_streamable_macro"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -511,14 +511,14 @@ dependencies = [
 
 [[package]]
 name = "chia_rs"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
- "chia-bls 0.5.1",
+ "chia-bls 0.6.0",
  "chia-consensus",
  "chia-protocol",
- "chia-traits 0.5.2",
+ "chia-traits 0.6.0",
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.3.0",
+ "chia_streamable_macro 0.6.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -530,6 +530,8 @@ dependencies = [
 [[package]]
 name = "chia_streamable_macro"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "342cdb29dd8c1214d60fac24100ab1567756270710e93336db910a531fe8a264"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -539,9 +541,7 @@ dependencies = [
 
 [[package]]
 name = "chia_streamable_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342cdb29dd8c1214d60fac24100ab1567756270710e93336db910a531fe8a264"
+version = "0.6.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -631,7 +631,7 @@ checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "clvm-derive"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "clvm-traits"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
- "chia-bls 0.5.1",
+ "chia-bls 0.6.0",
  "clvm-derive",
  "clvmr",
  "hex",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-utils"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "clvm-traits",
  "clvmr",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-utils-fuzz"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "chia-consensus",
  "chia-fuzz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 
 [package]
 name = "chia"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A meta-crate that exports all of the Chia crates in the workspace."

--- a/crates/chia-bls/Cargo.toml
+++ b/crates/chia-bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-bls"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "BLS signature, verification and aggregation funcions for the Chia blockchain"
@@ -12,8 +12,8 @@ repository = "https://github.com/Chia-Network/chia_rs"
 py-bindings = ["dep:pyo3", "chia_py_streamable_macro", "chia-traits/py-bindings"]
 
 [dependencies]
-chia-traits = { version = "0.5.1", path = "../chia-traits" }
-chia_py_streamable_macro = { version = "0.5.1", path = "../chia_py_streamable_macro", optional = true }
+chia-traits = { version = "0.6.0", path = "../chia-traits" }
+chia_py_streamable_macro = { version = "0.6.0", path = "../chia_py_streamable_macro", optional = true }
 tiny-bip39 = "1.0.0"
 anyhow = "1.0.71"
 sha2 = "0.10.8"

--- a/crates/chia-client/Cargo.toml
+++ b/crates/chia-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-client"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Chia light client and async peer connections."
@@ -9,8 +9,8 @@ homepage = "https://github.com/Chia-Network/chia_rs"
 repository = "https://github.com/Chia-Network/chia_rs"
 
 [dependencies]
-chia-protocol = { version = "0.5.1", path = "../chia-protocol" }
-chia-traits = { version = "0.5.1", path = "../chia-traits" }
+chia-protocol = { version = "0.6.0", path = "../chia-protocol" }
+chia-traits = { version = "0.6.0", path = "../chia-traits" }
 tokio = { version = "1.32.0", features = ["rt", "sync"] }
 tokio-tungstenite = "0.21.0"
 futures-util = "0.3.28"

--- a/crates/chia-consensus/Cargo.toml
+++ b/crates/chia-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-consensus"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Utility functions and types used by the Chia blockchain full node"
@@ -15,12 +15,12 @@ py-bindings = ["dep:pyo3"]
 clvmr = "0.6.1"
 hex = "0.4.3"
 pyo3 = { version = ">=0.19.0", optional = true }
-clvm-utils = { version = "0.5.1", path = "../clvm-utils" }
-chia-traits = { version = "0.5.2", path = "../chia-traits" }
-clvm-traits = { version = "0.5.2", path = "../clvm-traits" }
-clvm-derive = { version = "0.5.2", path = "../clvm-derive" }
-chia-protocol = { version = "0.5.1", path = "../chia-protocol" }
-chia-wallet = { version = "0.5.1", path = "../chia-wallet" }
+clvm-utils = { version = "0.6.0", path = "../clvm-utils" }
+chia-traits = { version = "0.6.0", path = "../chia-traits" }
+clvm-traits = { version = "0.6.0", path = "../clvm-traits" }
+clvm-derive = { version = "0.6.0", path = "../clvm-derive" }
+chia-protocol = { version = "0.6.0", path = "../chia-protocol" }
+chia-wallet = { version = "0.6.0", path = "../chia-wallet" }
 hex-literal = "0.4.1"
 thiserror = "1.0.44"
 

--- a/crates/chia-consensus/fuzz/Cargo.toml
+++ b/crates/chia-consensus/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-fuzz"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2021"

--- a/crates/chia-protocol/Cargo.toml
+++ b/crates/chia-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-protocol"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Chia network protocol message types"
@@ -15,13 +15,13 @@ py-bindings = ["dep:pyo3", "dep:chia_py_streamable_macro", "chia-traits/py-bindi
 pyo3 = { version = "0.19.0", features = ["multiple-pymethods", "num-bigint"], optional = true }
 sha2 = "0.10.8"
 hex = "0.4.3"
-chia_streamable_macro = { version = "0.3.0", path = "../chia_streamable_macro" }
-chia_py_streamable_macro = { version = "0.5.1", path = "../chia_py_streamable_macro", optional = true }
+chia_streamable_macro = { version = "0.6.0", path = "../chia_streamable_macro" }
+chia_py_streamable_macro = { version = "0.6.0", path = "../chia_py_streamable_macro", optional = true }
 clvmr = "0.6.1"
-chia-traits = { version = "0.5.1", path = "../chia-traits" }
-clvm-traits = { version = "0.5.1", path = "../clvm-traits", features = ["derive"] }
-clvm-utils = { version = "0.5.1", path = "../clvm-utils" }
-chia-bls = { version = "0.5.1", path = "../chia-bls" }
+chia-traits = { version = "0.6.0", path = "../chia-traits" }
+clvm-traits = { version = "0.6.0", path = "../clvm-traits", features = ["derive"] }
+clvm-utils = { version = "0.6.0", path = "../clvm-utils" }
+chia-bls = { version = "0.6.0", path = "../chia-bls" }
 arbitrary = { version = "1.3.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/chia-ssl/Cargo.toml
+++ b/crates/chia-ssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-ssl"
-version = "0.2.14"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Chia SSL X.509 certificate generator"

--- a/crates/chia-tools/Cargo.toml
+++ b/crates/chia-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-tools"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Utility functions and types used by the Chia blockchain full node"
@@ -9,13 +9,13 @@ homepage = "https://github.com/Chia-Network/chia_rs"
 repository = "https://github.com/Chia-Network/chia_rs"
 
 [dependencies]
-chia-protocol = { version = "0.5.1", path = "../chia-protocol" }
-chia-traits = { version = "0.5.2", path = "../chia-traits" }
-clvm-utils = { version = "0.5.1", path = "../clvm-utils" }
-clvm-traits = { version = "0.5.2", path = "../clvm-traits" }
-chia-wallet = { version = "0.5.1", path = "../chia-wallet" }
-chia-bls = { version = "0.5.1", path = "../chia-bls" }
-chia-consensus = { version = "0.5.2", path = "../chia-consensus" }
+chia-protocol = { version = "0.6.0", path = "../chia-protocol" }
+chia-traits = { version = "0.6.0", path = "../chia-traits" }
+clvm-utils = { version = "0.6.0", path = "../clvm-utils" }
+clvm-traits = { version = "0.6.0", path = "../clvm-traits" }
+chia-wallet = { version = "0.6.0", path = "../chia-wallet" }
+chia-bls = { version = "0.6.0", path = "../chia-bls" }
+chia-consensus = { version = "0.6.0", path = "../chia-consensus" }
 clvmr = { version = "0.6.0", features = ["counters"] }
 rusqlite = { version = "0.30.0", features = ["bundled"] }
 clap = { version = "4.3.9", features = ["derive"] }

--- a/crates/chia-traits/Cargo.toml
+++ b/crates/chia-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-traits"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Chia traits for Streamable types (chia's serialization format)"
@@ -11,8 +11,8 @@ py-bindings = ["dep:pyo3", "dep:chia_py_streamable_macro"]
 
 [dependencies]
 pyo3 = { version = "0.19.0", features = ["multiple-pymethods"], optional = true }
-chia_py_streamable_macro = { version = "0.5.1", path = "../chia_py_streamable_macro", optional = true }
-chia_streamable_macro = { version = "0.3.0", path = "../chia_streamable_macro" }
+chia_py_streamable_macro = { version = "0.6.0", path = "../chia_py_streamable_macro", optional = true }
+chia_streamable_macro = { version = "0.6.0", path = "../chia_streamable_macro" }
 sha2 = "0.10.8"
 hex = "0.4.3"
 thiserror = "1.0.44"

--- a/crates/chia-wallet/Cargo.toml
+++ b/crates/chia-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-wallet"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Chia primitives needed for building wallets."
@@ -13,10 +13,10 @@ clvmr = "0.6.1"
 sha2 = "0.10.8"
 num-bigint = "0.4.3"
 hex-literal = "0.4.1"
-clvm-utils = { version = "0.5.1", path = "../clvm-utils" }
-clvm-traits = { version = "0.5.1", path = "../clvm-traits", features = ["chia-bls"] }
-chia-bls = { version = "0.5.1", path = "../chia-bls" }
-chia-protocol = { version = "0.5.1", path = "../chia-protocol" }
+clvm-utils = { version = "0.6.0", path = "../clvm-utils" }
+clvm-traits = { version = "0.6.0", path = "../clvm-traits", features = ["chia-bls"] }
+chia-bls = { version = "0.6.0", path = "../chia-bls" }
+chia-protocol = { version = "0.6.0", path = "../chia-protocol" }
 arbitrary = "1.3.0"
 
 [dev-dependencies]

--- a/crates/chia-wallet/fuzz/Cargo.toml
+++ b/crates/chia-wallet/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia-wallet-fuzz"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2021"
@@ -13,7 +13,7 @@ libfuzzer-sys = "0.4"
 clvmr = "0.6.1"
 pyo3 = { version = ">=0.19.0", features = ["auto-initialize"]}
 chia-wallet = { path = ".." }
-clvm-traits = { version = "0.5.2", path = "../../clvm-traits" }
+clvm-traits = { version = "0.6.0", path = "../../clvm-traits" }
 
 [[bin]]
 name = "roundtrip"

--- a/crates/chia_py_streamable_macro/Cargo.toml
+++ b/crates/chia_py_streamable_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia_py_streamable_macro"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Derive macro to create python bindings for Chia types"

--- a/crates/chia_streamable_macro/Cargo.toml
+++ b/crates/chia_streamable_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia_streamable_macro"
-version = "0.3.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Streamable derive macro for serializing/deserializing types in Chia protocol format"

--- a/crates/clvm-derive/Cargo.toml
+++ b/crates/clvm-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm-derive"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Derive macros for implementing CLVM traits."

--- a/crates/clvm-traits/Cargo.toml
+++ b/crates/clvm-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm-traits"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Traits for encoding and decoding CLVM objects."
@@ -19,8 +19,8 @@ py-bindings = ["dep:pyo3"]
 [dependencies]
 pyo3 = { version = ">=0.19.0", optional = true }
 clvmr = "0.6.1"
-clvm-derive = { version = "0.5.2", path = "../clvm-derive", optional = true }
-chia-bls = { version = "0.5.1", path = "../chia-bls", optional = true }
+clvm-derive = { version = "0.6.0", path = "../clvm-derive", optional = true }
+chia-bls = { version = "0.6.0", path = "../chia-bls", optional = true }
 num-bigint = "0.4.3"
 thiserror = "1.0.44"
 

--- a/crates/clvm-utils/Cargo.toml
+++ b/crates/clvm-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm-utils"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Utility functions for processing clvm programs and structures"
@@ -10,7 +10,7 @@ repository = "https://github.com/Chia-Network/chia_rs"
 
 [dependencies]
 clvmr = "0.6.1"
-clvm-traits = { version = "0.5.1", path = "../clvm-traits" }
+clvm-traits = { version = "0.6.0", path = "../clvm-traits" }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/crates/clvm-utils/fuzz/Cargo.toml
+++ b/crates/clvm-utils/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm-utils-fuzz"
-version = "0.4.0"
+version = "0.6.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2021"

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chia_rs"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -19,11 +19,11 @@ clvmr = "0.6.1"
 hex = "0.4.3"
 sha2 = "0.10.8"
 pyo3 = { version = "=0.19.0", features = ["multiple-pymethods"] }
-chia-consensus = { version = "=0.5.2", path = "../crates/chia-consensus", features = ["py-bindings"] }
-chia-bls = { version = "=0.5.1", path = "../crates/chia-bls", features = ["py-bindings"]  }
-chia-protocol = { version = "=0.5.1", path = "../crates/chia-protocol", features = ["py-bindings"]  }
-chia-traits = { version = "=0.5.2", path = "../crates/chia-traits", features = ["py-bindings"]  }
-clvm-traits = { version = "=0.5.2", path = "../crates/clvm-traits", features = ["derive", "py-bindings"] }
-clvm-utils = { version = "=0.5.1", path = "../crates/clvm-utils" }
-chia_py_streamable_macro = { version = "=0.5.1", path = "../crates/chia_py_streamable_macro" }
-chia_streamable_macro = { version = "=0.3.0", path = "../crates/chia_streamable_macro" }
+chia-consensus = { version = "=0.6.0", path = "../crates/chia-consensus", features = ["py-bindings"] }
+chia-bls = { version = "=0.6.0", path = "../crates/chia-bls", features = ["py-bindings"]  }
+chia-protocol = { version = "=0.6.0", path = "../crates/chia-protocol", features = ["py-bindings"]  }
+chia-traits = { version = "=0.6.0", path = "../crates/chia-traits", features = ["py-bindings"]  }
+clvm-traits = { version = "=0.6.0", path = "../crates/clvm-traits", features = ["derive", "py-bindings"] }
+clvm-utils = { version = "=0.6.0", path = "../crates/clvm-utils" }
+chia_py_streamable_macro = { version = "=0.6.0", path = "../crates/chia_py_streamable_macro" }
+chia_streamable_macro = { version = "=0.6.0", path = "../crates/chia_streamable_macro" }


### PR DESCRIPTION
first commit: fixes an issue in `bump-version.py` from when crates were moved into a subdirectory.
second commit: bump version to 0.6.0