### PR TITLE
Add leaf audit to proof deserialization

### DIFF
--- a/crates/chia-consensus/src/merkle_tree.rs
+++ b/crates/chia-consensus/src/merkle_tree.rs
@@ -665,7 +665,7 @@ mod tests {
         let mut array: [u8; 32] = [0; 32];
         rng.fill(&mut array);
         random_data.push(array);
-        
+
         let mut bad_proof: Vec<u8> = Vec::new();
         bad_proof.push(MIDDLE);
         bad_proof.push(TRUNCATED);
@@ -676,7 +676,7 @@ mod tests {
         bad_proof.push(TERMINAL);
         bad_proof.extend_from_slice(&[0x0; 32]);
         let rebuilt = MerkleSet::from_proof(&bad_proof[0..bad_proof.len()]);
-        assert!(matches!(rebuilt, Err(SetError)));  // this is failing the audit
+        assert!(matches!(rebuilt, Err(SetError))); // this is failing the audit
     }
 
     #[test]

--- a/crates/chia-consensus/src/merkle_tree.rs
+++ b/crates/chia-consensus/src/merkle_tree.rs
@@ -652,6 +652,7 @@ mod tests {
         }
     }
 
+    #[test]
     fn test_bad_proofs_2() {
         // Create a random number generator
         let mut rng = SmallRng::seed_from_u64(1337);

--- a/crates/chia-consensus/src/merkle_tree.rs
+++ b/crates/chia-consensus/src/merkle_tree.rs
@@ -533,9 +533,9 @@ mod tests {
     use super::*;
     use crate::merkle_set::compute_merkle_set_root;
     use crate::merkle_set::test::merkle_set_test_cases;
+    use hex_literal::hex;
     use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
-    use sha2::digest::typenum::Min;
 
     impl MerkleSet {
         // this checks the correctness of the tree and its merkle root by
@@ -672,7 +672,9 @@ mod tests {
         bad_proof.extend_from_slice(&random_data[0]);
         bad_proof.push(MIDDLE);
         bad_proof.push(TERMINAL);
-        bad_proof.extend_from_slice(&[0x1; 32]); // this ought to be on the right
+        let bytes: [u8; 32] =
+            hex!("8000000000000000000000000000000000000000000000000000000000000000");
+        bad_proof.extend_from_slice(&bytes); // this ought to be on the right
         bad_proof.push(TERMINAL);
         bad_proof.extend_from_slice(&[0x0; 32]);
         let rebuilt = MerkleSet::from_proof(&bad_proof[0..bad_proof.len()]);

--- a/crates/chia-consensus/src/merkle_tree.rs
+++ b/crates/chia-consensus/src/merkle_tree.rs
@@ -535,6 +535,7 @@ mod tests {
     use crate::merkle_set::test::merkle_set_test_cases;
     use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
+    use sha2::digest::typenum::Min;
 
     impl MerkleSet {
         // this checks the correctness of the tree and its merkle root by

--- a/crates/chia-consensus/src/merkle_tree.rs
+++ b/crates/chia-consensus/src/merkle_tree.rs
@@ -81,7 +81,9 @@ impl MerkleSet {
         bits_stack.push(Vec::new());
 
         while let Some(op) = ops.pop() {
-            let Some(bits) = bits_stack.pop() else {return Err(SetError);};
+            let Some(bits) = bits_stack.pop() else {
+                return Err(SetError);
+            };
             match op {
                 ParseOp::Node => {
                     let mut b = [0; 1];

--- a/crates/chia-consensus/src/merkle_tree.rs
+++ b/crates/chia-consensus/src/merkle_tree.rs
@@ -652,6 +652,32 @@ mod tests {
         }
     }
 
+    fn test_bad_proofs_2() {
+        // Create a random number generator
+        let mut rng = SmallRng::seed_from_u64(1337);
+        // Generate a random length for the Vec
+        let vec_length: usize = rng.gen_range(5..=500);
+
+        // Generate a Vec of random [u8; 32] arrays
+        let mut random_data: Vec<[u8; 32]> = Vec::with_capacity(vec_length);
+
+        let mut array: [u8; 32] = [0; 32];
+        rng.fill(&mut array);
+        random_data.push(array);
+        
+        let mut bad_proof: Vec<u8> = Vec::new();
+        bad_proof.push(MIDDLE);
+        bad_proof.push(TRUNCATED);
+        bad_proof.extend_from_slice(&random_data[0]);
+        bad_proof.push(MIDDLE);
+        bad_proof.push(TERMINAL);
+        bad_proof.extend_from_slice(&[0x1; 32]); // this ought to be on the right
+        bad_proof.push(TERMINAL);
+        bad_proof.extend_from_slice(&[0x0; 32]);
+        let rebuilt = MerkleSet::from_proof(&bad_proof[0..bad_proof.len()]);
+        assert!(matches!(rebuilt, Err(SetError)));  // this is failing the audit
+    }
+
     #[test]
     fn test_deserialize_malicious_proof() {
         let malicious_proof = vec![MIDDLE].repeat(40000);

--- a/crates/chia-consensus/src/merkle_tree.rs
+++ b/crates/chia-consensus/src/merkle_tree.rs
@@ -86,7 +86,7 @@ impl MerkleSet {
                     ParseOp::Node => {
                         let mut b = [0; 1];
                         proof.read_exact(&mut b).map_err(|_| SetError)?;
-    
+
                         match b[0] {
                             EMPTY => {
                                 values.push((self.nodes_vec.len() as u32, NodeType::Empty));
@@ -98,7 +98,7 @@ impl MerkleSet {
                                 // audit the leaf is correctly positioned by comparing its bits with the traced route
                                 for (pos, v) in bits.iter().enumerate() {
                                     if get_bit(&hash, pos as u8) != *v {
-                                        return Err(SetError)
+                                        return Err(SetError);
                                     }
                                 }
                                 values.push((self.nodes_vec.len() as u32, NodeType::Term));
@@ -118,14 +118,14 @@ impl MerkleSet {
                                 ops.push(ParseOp::Node);
                                 ops.push(ParseOp::Node);
 
-                                bits_stack.push(Vec::new());  // we don't audit mid, so this is just placeholder value
-                                let mut new_bits = bits.clone();  
-                                new_bits.push(true);  // this gets processed second so it is the right
+                                bits_stack.push(Vec::new()); // we don't audit mid, so this is just placeholder value
+                                let mut new_bits = bits.clone();
+                                new_bits.push(true); // this gets processed second so it is the right
                                 bits_stack.push(new_bits);
                                 let mut new_bits = bits.clone();
-                                new_bits.push(false);  // this gets processed first so it is left branch
+                                new_bits.push(false); // this gets processed first so it is left branch
                                 bits_stack.push(new_bits);
-    
+
                                 depth += 1;
                             }
                             _ => {
@@ -136,7 +136,7 @@ impl MerkleSet {
                     ParseOp::Middle => {
                         let right = values.pop().expect("internal error");
                         let left = values.pop().expect("internal error");
-    
+
                         // Note that proofs are expected to include every tree layer
                         // (i.e. no collapsing), however, the node hashes are
                         // computed on a collapsed tree (or as-if it was collapsed).
@@ -148,7 +148,7 @@ impl MerkleSet {
                             (NodeType::MidDbl, NodeType::Empty) => NodeType::MidDbl,
                             (_, _) => NodeType::Mid,
                         };
-    
+
                         // since our tree is complete (i.e. no collapsing) when we
                         // generate it from a proof, the collapsing for purposes of
                         // hash computation just means we copy the child hash to its

--- a/crates/chia-consensus/src/merkle_tree.rs
+++ b/crates/chia-consensus/src/merkle_tree.rs
@@ -81,110 +81,107 @@ impl MerkleSet {
         bits_stack.push(Vec::new());
 
         while let Some(op) = ops.pop() {
-            if let Some(bits) = bits_stack.pop() {
-                match op {
-                    ParseOp::Node => {
-                        let mut b = [0; 1];
-                        proof.read_exact(&mut b).map_err(|_| SetError)?;
+            let Some(bits) = bits_stack.pop() else {return Err(SetError);};
+            match op {
+                ParseOp::Node => {
+                    let mut b = [0; 1];
+                    proof.read_exact(&mut b).map_err(|_| SetError)?;
 
-                        match b[0] {
-                            EMPTY => {
-                                values.push((self.nodes_vec.len() as u32, NodeType::Empty));
-                                self.nodes_vec.push((ArrayTypes::Empty, BLANK));
-                            }
-                            TERMINAL => {
-                                let mut hash = [0; 32];
-                                proof.read_exact(&mut hash).map_err(|_| SetError)?;
-                                // audit the leaf is correctly positioned by comparing its bits with the traced route
-                                for (pos, v) in bits.iter().enumerate() {
-                                    if get_bit(&hash, pos as u8) != *v {
-                                        return Err(SetError);
-                                    }
-                                }
-                                values.push((self.nodes_vec.len() as u32, NodeType::Term));
-                                self.nodes_vec.push((ArrayTypes::Leaf, hash));
-                            }
-                            TRUNCATED => {
-                                let mut hash = [0; 32];
-                                proof.read_exact(&mut hash).map_err(|_| SetError)?;
-                                values.push((self.nodes_vec.len() as u32, NodeType::Mid));
-                                self.nodes_vec.push((ArrayTypes::Truncated, hash));
-                            }
-                            MIDDLE => {
-                                if depth > 256 {
+                    match b[0] {
+                        EMPTY => {
+                            values.push((self.nodes_vec.len() as u32, NodeType::Empty));
+                            self.nodes_vec.push((ArrayTypes::Empty, BLANK));
+                        }
+                        TERMINAL => {
+                            let mut hash = [0; 32];
+                            proof.read_exact(&mut hash).map_err(|_| SetError)?;
+                            // audit the leaf is correctly positioned by comparing its bits with the traced route
+                            for (pos, v) in bits.iter().enumerate() {
+                                if get_bit(&hash, pos as u8) != *v {
                                     return Err(SetError);
                                 }
-                                ops.push(ParseOp::Middle);
-                                ops.push(ParseOp::Node);
-                                ops.push(ParseOp::Node);
-
-                                bits_stack.push(Vec::new()); // we don't audit mid, so this is just placeholder value
-                                let mut new_bits = bits.clone();
-                                new_bits.push(true); // this gets processed second so it is the right
-                                bits_stack.push(new_bits);
-                                let mut new_bits = bits.clone();
-                                new_bits.push(false); // this gets processed first so it is left branch
-                                bits_stack.push(new_bits);
-
-                                depth += 1;
                             }
-                            _ => {
+                            values.push((self.nodes_vec.len() as u32, NodeType::Term));
+                            self.nodes_vec.push((ArrayTypes::Leaf, hash));
+                        }
+                        TRUNCATED => {
+                            let mut hash = [0; 32];
+                            proof.read_exact(&mut hash).map_err(|_| SetError)?;
+                            values.push((self.nodes_vec.len() as u32, NodeType::Mid));
+                            self.nodes_vec.push((ArrayTypes::Truncated, hash));
+                        }
+                        MIDDLE => {
+                            if depth > 256 {
                                 return Err(SetError);
                             }
+                            ops.push(ParseOp::Middle);
+                            ops.push(ParseOp::Node);
+                            ops.push(ParseOp::Node);
+
+                            bits_stack.push(Vec::new()); // we don't audit mid, so this is just placeholder value
+                            let mut new_bits = bits.clone();
+                            new_bits.push(true); // this gets processed second so it is the right
+                            bits_stack.push(new_bits);
+                            let mut new_bits = bits.clone();
+                            new_bits.push(false); // this gets processed first so it is left branch
+                            bits_stack.push(new_bits);
+
+                            depth += 1;
+                        }
+                        _ => {
+                            return Err(SetError);
                         }
                     }
-                    ParseOp::Middle => {
-                        let right = values.pop().expect("internal error");
-                        let left = values.pop().expect("internal error");
-
-                        // Note that proofs are expected to include every tree layer
-                        // (i.e. no collapsing), however, the node hashes are
-                        // computed on a collapsed tree (or as-if it was collapsed).
-                        // This section propagates the MidDbl type up the tree, to
-                        // allow collapsing of the hash computation
-                        let new_node_type = match (left.1, right.1) {
-                            (NodeType::Term, NodeType::Term) => NodeType::MidDbl,
-                            (NodeType::Empty, NodeType::MidDbl) => NodeType::MidDbl,
-                            (NodeType::MidDbl, NodeType::Empty) => NodeType::MidDbl,
-                            (_, _) => NodeType::Mid,
-                        };
-
-                        // since our tree is complete (i.e. no collapsing) when we
-                        // generate it from a proof, the collapsing for purposes of
-                        // hash computation just means we copy the child hash to its
-                        // parent hash (in the cases where the tree would have been
-                        // collapsed).
-                        let node_hash = match (left.1, right.1) {
-                            // We collapse this layer for purposes of hash
-                            // computation, by simply copying the hash from the node
-                            // leading to the leafs, left or right.
-                            (NodeType::Empty, NodeType::MidDbl) => {
-                                values.push(right);
-                                self.nodes_vec[right.0 as usize].1
-                            }
-                            (NodeType::MidDbl, NodeType::Empty) => {
-                                values.push(left);
-                                self.nodes_vec[left.0 as usize].1
-                            }
-                            // this is the case where we do *not* collapse the tree,
-                            // but compute a new hash for the node.
-                            (_, _) => {
-                                values.push((self.nodes_vec.len() as u32, new_node_type));
-                                hash(
-                                    self.nodes_vec[left.0 as usize].0.into(),
-                                    self.nodes_vec[right.0 as usize].0.into(),
-                                    &self.nodes_vec[left.0 as usize].1,
-                                    &self.nodes_vec[right.0 as usize].1,
-                                )
-                            }
-                        };
-                        self.nodes_vec
-                            .push((ArrayTypes::Middle(left.0, right.0), node_hash));
-                        depth -= 1;
-                    }
                 }
-            } else {
-                return Err(SetError);
+                ParseOp::Middle => {
+                    let right = values.pop().expect("internal error");
+                    let left = values.pop().expect("internal error");
+
+                    // Note that proofs are expected to include every tree layer
+                    // (i.e. no collapsing), however, the node hashes are
+                    // computed on a collapsed tree (or as-if it was collapsed).
+                    // This section propagates the MidDbl type up the tree, to
+                    // allow collapsing of the hash computation
+                    let new_node_type = match (left.1, right.1) {
+                        (NodeType::Term, NodeType::Term) => NodeType::MidDbl,
+                        (NodeType::Empty, NodeType::MidDbl) => NodeType::MidDbl,
+                        (NodeType::MidDbl, NodeType::Empty) => NodeType::MidDbl,
+                        (_, _) => NodeType::Mid,
+                    };
+
+                    // since our tree is complete (i.e. no collapsing) when we
+                    // generate it from a proof, the collapsing for purposes of
+                    // hash computation just means we copy the child hash to its
+                    // parent hash (in the cases where the tree would have been
+                    // collapsed).
+                    let node_hash = match (left.1, right.1) {
+                        // We collapse this layer for purposes of hash
+                        // computation, by simply copying the hash from the node
+                        // leading to the leafs, left or right.
+                        (NodeType::Empty, NodeType::MidDbl) => {
+                            values.push(right);
+                            self.nodes_vec[right.0 as usize].1
+                        }
+                        (NodeType::MidDbl, NodeType::Empty) => {
+                            values.push(left);
+                            self.nodes_vec[left.0 as usize].1
+                        }
+                        // this is the case where we do *not* collapse the tree,
+                        // but compute a new hash for the node.
+                        (_, _) => {
+                            values.push((self.nodes_vec.len() as u32, new_node_type));
+                            hash(
+                                self.nodes_vec[left.0 as usize].0.into(),
+                                self.nodes_vec[right.0 as usize].0.into(),
+                                &self.nodes_vec[left.0 as usize].1,
+                                &self.nodes_vec[right.0 as usize].1,
+                            )
+                        }
+                    };
+                    self.nodes_vec
+                        .push((ArrayTypes::Middle(left.0, right.0), node_hash));
+                    depth -= 1;
+                }
             }
         }
         if proof.position() != proof.get_ref().len() as u64 {


### PR DESCRIPTION
Creates a stack of bits vecs and pops them to match the flow of the while loop of deserialisation.