### PR TITLE
Implement Copy for Coin and CoinState

### DIFF
--- a/crates/chia-consensus/src/gen/solution_generator.rs
+++ b/crates/chia-consensus/src/gen/solution_generator.rs
@@ -142,8 +142,8 @@ mod tests {
         );
 
         let result = solution_generator([
-            (coin1.clone(), PUZZLE1.as_ref(), SOLUTION1.as_ref()),
-            (coin2.clone(), PUZZLE2.as_ref(), SOLUTION2.as_ref()),
+            (coin1, PUZZLE1.as_ref(), SOLUTION1.as_ref()),
+            (coin2, PUZZLE2.as_ref(), SOLUTION2.as_ref()),
         ])
         .expect("solution_generator");
 
@@ -194,7 +194,7 @@ mod tests {
         let generator_output = run_generator(&result);
         assert_eq!(generator_output, EXPECTED_GENERATOR_OUTPUT);
 
-        let result = solution_generator([(coin2.clone(), PUZZLE2.as_ref(), SOLUTION2.as_ref())])
+        let result = solution_generator([(coin2, PUZZLE2.as_ref(), SOLUTION2.as_ref())])
             .expect("solution_generator");
 
         assert_eq!(
@@ -234,8 +234,8 @@ mod tests {
         );
 
         let result = solution_generator_backrefs([
-            (coin1.clone(), PUZZLE1.as_ref(), SOLUTION1.as_ref()),
-            (coin2.clone(), PUZZLE2.as_ref(), SOLUTION2.as_ref()),
+            (coin1, PUZZLE1.as_ref(), SOLUTION1.as_ref()),
+            (coin2, PUZZLE2.as_ref(), SOLUTION2.as_ref()),
         ])
         .expect("solution_generator");
 

--- a/crates/chia-protocol/src/coin.rs
+++ b/crates/chia-protocol/src/coin.rs
@@ -10,6 +10,7 @@ use sha2::{Digest, Sha256};
 use pyo3::prelude::*;
 
 #[streamable]
+#[derive(Copy)]
 pub struct Coin {
     parent_coin_info: Bytes32,
     puzzle_hash: Bytes32,

--- a/crates/chia-protocol/src/coin_state.rs
+++ b/crates/chia-protocol/src/coin_state.rs
@@ -2,6 +2,7 @@ use crate::coin::Coin;
 use chia_streamable_macro::streamable;
 
 #[streamable]
+#[derive(Copy)]
 pub struct CoinState {
     coin: Coin,
     spent_height: Option<u32>,

--- a/crates/chia-protocol/src/spend_bundle.rs
+++ b/crates/chia-protocol/src/spend_bundle.rs
@@ -109,7 +109,7 @@ impl SpendBundle {
     fn removals(&self) -> Vec<Coin> {
         let mut ret = Vec::<Coin>::with_capacity(self.coin_spends.len());
         for cs in &self.coin_spends {
-            ret.push(cs.coin.clone());
+            ret.push(cs.coin);
         }
         ret
     }
@@ -189,7 +189,7 @@ mod tests {
             1,
         );
         let spend = CoinSpend::new(
-            test_coin.clone(),
+            test_coin,
             Program::new(vec![1_u8].into()),
             Program::new(solution.into()),
         );


### PR DESCRIPTION
Every field of `Coin` and `CoinState` implements `Copy`, so it seems like a good idea for them to as well.

It's also recommended to do so whenever possible without potential public API breakage in the future:
https://doc.rust-lang.org/std/marker/trait.Copy.html#when-should-my-type-be-copy