### PR TITLE
Simplify lineage proof and remove chia-consensus singleton types

### DIFF
--- a/crates/chia-consensus/src/error.rs
+++ b/crates/chia-consensus/src/error.rs
@@ -41,6 +41,9 @@ pub enum Error {
     #[error("coin mismatch")]
     CoinMismatch,
 
+    #[error("expected lineage proof, found eve proof")]
+    ExpectedLineageProof,
+
     #[error("{0}")]
     Custom(String),
 }

--- a/crates/chia-consensus/src/fast_forward.rs
+++ b/crates/chia-consensus/src/fast_forward.rs
@@ -1,12 +1,10 @@
 use crate::error::{Error, Result};
 use chia_protocol::Bytes32;
 use chia_protocol::Coin;
-use chia_wallet::singleton::SingletonArgs;
-use chia_wallet::singleton::SingletonSolution;
-use chia_wallet::singleton::SingletonStruct;
-use chia_wallet::singleton::SINGLETON_TOP_LAYER_PUZZLE_HASH;
-use clvm_traits::FromClvm;
-use clvm_traits::ToClvm;
+use chia_wallet::singleton::{
+    SingletonArgs, SingletonSolution, SingletonStruct, SINGLETON_TOP_LAYER_PUZZLE_HASH,
+};
+use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::CurriedProgram;
 use clvm_utils::{tree_hash, tree_hash_atom, tree_hash_pair};
 use clvmr::allocator::{Allocator, NodePtr};

--- a/crates/chia-consensus/src/fast_forward.rs
+++ b/crates/chia-consensus/src/fast_forward.rs
@@ -1,42 +1,15 @@
 use crate::error::{Error, Result};
 use chia_protocol::Bytes32;
 use chia_protocol::Coin;
+use chia_wallet::singleton::SingletonArgs;
+use chia_wallet::singleton::SingletonSolution;
+use chia_wallet::singleton::SingletonStruct;
 use chia_wallet::singleton::SINGLETON_TOP_LAYER_PUZZLE_HASH;
-use clvm_traits::{FromClvm, ToClvm};
+use clvm_traits::FromClvm;
+use clvm_traits::ToClvm;
 use clvm_utils::CurriedProgram;
 use clvm_utils::{tree_hash, tree_hash_atom, tree_hash_pair};
 use clvmr::allocator::{Allocator, NodePtr};
-
-#[derive(FromClvm, ToClvm, Debug)]
-#[clvm(tuple)]
-pub struct SingletonStruct {
-    pub mod_hash: Bytes32,
-    pub launcher_id: Bytes32,
-    pub launcher_puzzle_hash: Bytes32,
-}
-
-#[derive(FromClvm, ToClvm, Debug)]
-#[clvm(curry)]
-pub struct SingletonArgs<I> {
-    pub singleton_struct: SingletonStruct,
-    pub inner_puzzle: I,
-}
-
-#[derive(FromClvm, ToClvm, Debug)]
-#[clvm(list)]
-pub struct LineageProof {
-    pub parent_parent_coin_id: Bytes32,
-    pub parent_inner_puzzle_hash: Bytes32,
-    pub parent_amount: u64,
-}
-
-#[derive(FromClvm, ToClvm, Debug)]
-#[clvm(list)]
-pub struct SingletonSolution<I> {
-    pub lineage_proof: LineageProof,
-    pub amount: u64,
-    pub inner_solution: I,
-}
 
 // TODO: replace this with a generic function to compute the hash of curried
 // puzzles

--- a/crates/chia-consensus/src/fast_forward.rs
+++ b/crates/chia-consensus/src/fast_forward.rs
@@ -4,6 +4,7 @@ use chia_protocol::Coin;
 use chia_wallet::singleton::{
     SingletonArgs, SingletonSolution, SingletonStruct, SINGLETON_TOP_LAYER_PUZZLE_HASH,
 };
+use chia_wallet::Proof;
 use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::CurriedProgram;
 use clvm_utils::{tree_hash, tree_hash_atom, tree_hash_pair};
@@ -79,7 +80,7 @@ pub fn fast_forward_singleton(
     let mut new_solution = SingletonSolution::<NodePtr>::from_clvm(a, solution)?;
 
     let lineage_proof = match &mut new_solution.lineage_proof {
-        chia_wallet::Proof::Lineage(proof) => proof,
+        Proof::Lineage(proof) => proof,
         _ => return Err(Error::ExpectedLineageProof),
     };
 
@@ -156,7 +157,6 @@ mod tests {
     use crate::gen::run_puzzle::run_puzzle;
     use chia_protocol::CoinSpend;
     use chia_traits::streamable::Streamable;
-    use chia_wallet::Proof;
     use clvm_traits::ToNodePtr;
     use clvmr::serde::{node_from_bytes, node_to_bytes};
     use hex_literal::hex;
@@ -340,10 +340,7 @@ mod tests {
     fn parse_solution(a: &mut Allocator, solution: &[u8]) -> SingletonSolution<NodePtr> {
         let new_solution = node_from_bytes(a, solution).expect("parse solution");
         let solution = SingletonSolution::from_clvm(a, new_solution).expect("parse solution");
-        assert!(matches!(
-            solution.lineage_proof,
-            chia_wallet::Proof::Lineage(_)
-        ));
+        assert!(matches!(solution.lineage_proof, Proof::Lineage(_)));
         solution
     }
 

--- a/crates/chia-tools/src/bin/run-spend.rs
+++ b/crates/chia-tools/src/bin/run-spend.rs
@@ -10,7 +10,7 @@ use chia_wallet::cat::{CatArgs, CatSolution, CAT_PUZZLE_HASH};
 use chia_wallet::did::{DidArgs, DidSolution, DID_INNER_PUZZLE_HASH};
 use chia_wallet::singleton::{SingletonArgs, SingletonSolution, SINGLETON_TOP_LAYER_PUZZLE_HASH};
 use chia_wallet::standard::{StandardArgs, StandardSolution, STANDARD_PUZZLE_HASH};
-use chia_wallet::Proof;
+use chia_wallet::MaybeEveProof;
 
 /// Run a puzzle given a solution and print the resulting conditions
 #[derive(Parser, Debug)]
@@ -233,16 +233,17 @@ fn print_puzzle_info(a: &Allocator, puzzle: NodePtr, solution: NodePtr) {
                 uncurried.args.singleton_struct.launcher_puzzle_hash
             );
 
-            let Ok(sol) = SingletonSolution::<NodePtr>::from_clvm(a, solution) else {
+            let Ok(sol) = SingletonSolution::<NodePtr, MaybeEveProof>::from_clvm(a, solution)
+            else {
                 println!("-- failed to parse solution");
                 return;
             };
             println!("  solution");
-            match sol.proof {
-                Proof::Lineage(lp) => {
+            match sol.lineage_proof {
+                MaybeEveProof::Lineage(lp) => {
                     println!("    lineage-proof: {lp:?}");
                 }
-                Proof::Eve(ep) => {
+                MaybeEveProof::Eve(ep) => {
                     println!("    eve-proof: {ep:?}");
                 }
             }

--- a/crates/chia-tools/src/bin/run-spend.rs
+++ b/crates/chia-tools/src/bin/run-spend.rs
@@ -1,5 +1,6 @@
 use chia_consensus::gen::conditions::Condition;
 use chia_traits::Streamable;
+use chia_wallet::Proof;
 use clap::Parser;
 use clvm_traits::{FromClvm, ToNodePtr};
 use clvm_utils::tree_hash;
@@ -10,7 +11,6 @@ use chia_wallet::cat::{CatArgs, CatSolution, CAT_PUZZLE_HASH};
 use chia_wallet::did::{DidArgs, DidSolution, DID_INNER_PUZZLE_HASH};
 use chia_wallet::singleton::{SingletonArgs, SingletonSolution, SINGLETON_TOP_LAYER_PUZZLE_HASH};
 use chia_wallet::standard::{StandardArgs, StandardSolution, STANDARD_PUZZLE_HASH};
-use chia_wallet::MaybeEveProof;
 
 /// Run a puzzle given a solution and print the resulting conditions
 #[derive(Parser, Debug)]
@@ -233,17 +233,16 @@ fn print_puzzle_info(a: &Allocator, puzzle: NodePtr, solution: NodePtr) {
                 uncurried.args.singleton_struct.launcher_puzzle_hash
             );
 
-            let Ok(sol) = SingletonSolution::<NodePtr, MaybeEveProof>::from_clvm(a, solution)
-            else {
+            let Ok(sol) = SingletonSolution::<NodePtr>::from_clvm(a, solution) else {
                 println!("-- failed to parse solution");
                 return;
             };
             println!("  solution");
             match sol.lineage_proof {
-                MaybeEveProof::Lineage(lp) => {
+                Proof::Lineage(lp) => {
                     println!("    lineage-proof: {lp:?}");
                 }
-                MaybeEveProof::Eve(ep) => {
+                Proof::Eve(ep) => {
                     println!("    eve-proof: {ep:?}");
                 }
             }

--- a/crates/chia-wallet/fuzz/fuzz_targets/roundtrip.rs
+++ b/crates/chia-wallet/fuzz/fuzz_targets/roundtrip.rs
@@ -7,14 +7,14 @@ fuzz_target!(|data: &[u8]| {
     {
         use std::fmt;
 
-        use chia_wallet::{nft::NftMetadata, Proof};
+        use chia_wallet::{nft::NftMetadata, MaybeEveProof};
         use clvm_traits::{FromClvm, ToClvm};
         use clvmr::{allocator::NodePtr, Allocator};
         use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
 
         let mut u = Unstructured::new(data);
         roundtrip::<NftMetadata>(&mut u);
-        roundtrip::<Proof>(&mut u);
+        roundtrip::<MaybeEveProof>(&mut u);
 
         fn roundtrip<'a, T>(u: &mut Unstructured<'a>)
         where

--- a/crates/chia-wallet/fuzz/fuzz_targets/roundtrip.rs
+++ b/crates/chia-wallet/fuzz/fuzz_targets/roundtrip.rs
@@ -7,14 +7,14 @@ fuzz_target!(|data: &[u8]| {
     {
         use std::fmt;
 
-        use chia_wallet::{nft::NftMetadata, MaybeEveProof};
+        use chia_wallet::{nft::NftMetadata, Proof};
         use clvm_traits::{FromClvm, ToClvm};
         use clvmr::{allocator::NodePtr, Allocator};
         use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
 
         let mut u = Unstructured::new(data);
         roundtrip::<NftMetadata>(&mut u);
-        roundtrip::<MaybeEveProof>(&mut u);
+        roundtrip::<Proof>(&mut u);
 
         fn roundtrip<'a, T>(u: &mut Unstructured<'a>)
         where

--- a/crates/chia-wallet/src/proof.rs
+++ b/crates/chia-wallet/src/proof.rs
@@ -4,7 +4,7 @@ use clvm_traits::{FromClvm, ToClvm};
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
 #[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
 #[clvm(untagged, tuple)]
-pub enum Proof {
+pub enum MaybeEveProof {
     Lineage(LineageProof),
     Eve(EveProof),
 }
@@ -13,9 +13,9 @@ pub enum Proof {
 #[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct LineageProof {
-    pub parent_coin_info: Bytes32,
-    pub inner_puzzle_hash: Bytes32,
-    pub amount: u64,
+    pub parent_parent_coin_id: Bytes32,
+    pub parent_inner_puzzle_hash: Bytes32,
+    pub parent_amount: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]

--- a/crates/chia-wallet/src/proof.rs
+++ b/crates/chia-wallet/src/proof.rs
@@ -4,7 +4,7 @@ use clvm_traits::{FromClvm, ToClvm};
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
 #[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
 #[clvm(untagged, tuple)]
-pub enum MaybeEveProof {
+pub enum Proof {
     Lineage(LineageProof),
     Eve(EveProof),
 }

--- a/crates/chia-wallet/src/puzzles/singleton.rs
+++ b/crates/chia-wallet/src/puzzles/singleton.rs
@@ -2,7 +2,7 @@ use chia_protocol::Bytes32;
 use clvm_traits::{FromClvm, ToClvm};
 use hex_literal::hex;
 
-use crate::Proof;
+use crate::LineageProof;
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(curry)]
@@ -21,8 +21,8 @@ pub struct SingletonStruct {
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(list)]
-pub struct SingletonSolution<I> {
-    pub proof: Proof,
+pub struct SingletonSolution<I, P = LineageProof> {
+    pub lineage_proof: P,
     pub amount: u64,
     pub inner_solution: I,
 }

--- a/crates/chia-wallet/src/puzzles/singleton.rs
+++ b/crates/chia-wallet/src/puzzles/singleton.rs
@@ -2,7 +2,7 @@ use chia_protocol::Bytes32;
 use clvm_traits::{FromClvm, ToClvm};
 use hex_literal::hex;
 
-use crate::LineageProof;
+use crate::Proof;
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(curry)]
@@ -21,8 +21,8 @@ pub struct SingletonStruct {
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(list)]
-pub struct SingletonSolution<I, P = LineageProof> {
-    pub lineage_proof: P,
+pub struct SingletonSolution<I> {
+    pub lineage_proof: Proof,
     pub amount: u64,
     pub inner_solution: I,
 }


### PR DESCRIPTION
There were duplicated types between `chia-wallet` and `chia-consensus`, so this makes `chia-consensus` use `chia-wallet`'s types instead and simplifies the API for lineage proofs.