### PR TITLE
expose aggregate_verify_gt() in chia-bls

### DIFF
--- a/crates/chia-bls/benches/verify.rs
+++ b/crates/chia-bls/benches/verify.rs
@@ -1,6 +1,8 @@
-use chia_bls::secret_key::SecretKey;
 use chia_bls::signature;
-use chia_bls::signature::sign;
+use chia_bls::{
+    aggregate_verify, aggregate_verify_gt, hash_to_g2, sign, GTElement, PublicKey, SecretKey,
+    Signature,
+};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -17,14 +19,44 @@ fn verify_benchmark(c: &mut Criterion) {
     let sig_small = sign(&sk, msg_small);
     let sig_large = sign(&sk, msg_large);
 
+    let mut agg_sig = Signature::default();
+    let mut gts = Vec::<GTElement>::new();
+    let mut pks = Vec::<PublicKey>::new();
+    for idx in 0..1000 {
+        let derived = sk.derive_hardened(idx as u32);
+        let pk = derived.public_key();
+        let sig = sign(&derived, msg_small);
+        agg_sig.aggregate(&sig);
+
+        let mut augmented = pk.to_bytes().to_vec();
+        augmented.extend_from_slice(msg_small);
+        gts.push(hash_to_g2(augmented.as_slice()).pair(&pk));
+        pks.push(pk);
+    }
+
+    c.bench_function("aggregate_verify_gt, small msg", |b| {
+        b.iter(|| {
+            assert!(aggregate_verify_gt(&agg_sig, &gts));
+        });
+    });
+
+    c.bench_function("aggregate_verify, small msg", |b| {
+        b.iter(|| {
+            assert!(aggregate_verify(
+                &agg_sig,
+                pks.iter().map(|pk| (pk, &msg_small[..]))
+            ));
+        });
+    });
+
     c.bench_function("verify, small msg", |b| {
         b.iter(|| {
-            signature::verify(&sig_small, &pk, black_box(&msg_small));
+            assert!(signature::verify(&sig_small, &pk, black_box(&msg_small)));
         });
     });
     c.bench_function("verify, 4kiB msg", |b| {
         b.iter(|| {
-            signature::verify(&sig_large, &pk, black_box(&msg_large));
+            assert!(signature::verify(&sig_large, &pk, black_box(&msg_large)));
         });
     });
 }

--- a/crates/chia-bls/src/lib.rs
+++ b/crates/chia-bls/src/lib.rs
@@ -13,8 +13,8 @@ pub use gtelement::GTElement;
 pub use public_key::{hash_to_g1, hash_to_g1_with_dst, PublicKey};
 pub use secret_key::SecretKey;
 pub use signature::{
-    aggregate, aggregate_pairing, aggregate_verify, hash_to_g2, hash_to_g2_with_dst, sign,
-    sign_raw, verify, Signature,
+    aggregate, aggregate_pairing, aggregate_verify, aggregate_verify_gt, hash_to_g2,
+    hash_to_g2_with_dst, sign, sign_raw, verify, Signature,
 };
 
 pub type G1Element = PublicKey;


### PR DESCRIPTION
to prepare for the BLS cache.

Validating an aggregate signature in BLS can be broken down into the following steps:

1. for each (public key, message)-pair
1.1 augment the message by pre-pending the public key. The public key is also known as G1.
1.2 map the augmented message to G2 (`hash_to_g2()`)
1.3 pair the G1 and G2 points to get a GT point
2. multiply all GT points together
3. pair the generator (a G1 point) with the signature (a G2 point)
4. if the aggregate GT point equals the signature pair, the signature is valid.

The pairing operation is quite expensive. As you can see from the benchmark, validating a signature against 1000 GT points is 2 orders of magnitude faster than validating 1000 (key, message)-pairs. The BLS cache caches the GT points to avoid having to compute the pairings multiple times.

The benchmark gives an indication on the speed-up of caching the pairings:

| benchmark | time |
| --- | --- |
| aggregate_verify_gt, small msg | 2.1471 ms |
| aggregate_verify, small msg | 349.57 ms |
| verify, small msg | 944.59 µs |
| verify, 4kiB msg | 949.05 µs |