### PR TITLE
Add TreeHasher to simplify currying puzzle hashes

### DIFF
--- a/crates/chia-consensus/src/gen/get_puzzle_and_solution.rs
+++ b/crates/chia-consensus/src/gen/get_puzzle_and_solution.rs
@@ -46,7 +46,7 @@ pub fn get_puzzle_and_solution_for_coin(
         }
 
         let puzzle_hash = tree_hash(a, puzzle);
-        if puzzle_hash != find_ph.as_ref() {
+        if puzzle_hash != find_ph.into() {
             continue;
         }
 

--- a/crates/chia-consensus/src/gen/run_block_generator.rs
+++ b/crates/chia-consensus/src/gen/run_block_generator.rs
@@ -5,7 +5,7 @@ use crate::gen::flags::ALLOW_BACKREFS;
 use crate::gen::spend_visitor::SpendVisitor;
 use crate::gen::validation_error::{first, ErrorCode, ValidationErr};
 use crate::generator_rom::{CLVM_DESERIALIZER, COST_PER_BYTE, GENERATOR_ROM};
-use clvm_utils::tree_hash_cached;
+use clvm_utils::{tree_hash_cached, TreeHash};
 use clvmr::allocator::{Allocator, NodePtr};
 use clvmr::chia_dialect::ChiaDialect;
 use clvmr::cost::Cost;
@@ -155,7 +155,7 @@ pub fn run_block_generator2<GenBuf: AsRef<[u8]>, V: SpendVisitor>(
 
     let mut ret = SpendBundleConditions::default();
     let mut state = ParseState::default();
-    let mut cache = HashMap::<NodePtr, [u8; 32]>::new();
+    let mut cache = HashMap::<NodePtr, TreeHash>::new();
 
     while let Some((spend, rest)) = a.next(all_spends) {
         all_spends = rest;

--- a/crates/chia-protocol/src/bytes.rs
+++ b/crates/chia-protocol/src/bytes.rs
@@ -1,5 +1,6 @@
 use chia_traits::{chia_error, read_bytes, Streamable};
 use clvm_traits::{ClvmDecoder, ClvmEncoder, FromClvm, FromClvmError, ToClvm, ToClvmError};
+use clvm_utils::TreeHash;
 use sha2::{Digest, Sha256};
 use std::array::TryFromSliceError;
 use std::fmt;
@@ -340,6 +341,18 @@ pub type Bytes32 = BytesImpl<32>;
 pub type Bytes48 = BytesImpl<48>;
 pub type Bytes96 = BytesImpl<96>;
 pub type Bytes100 = BytesImpl<100>;
+
+impl From<Bytes32> for TreeHash {
+    fn from(value: Bytes32) -> Self {
+        Self::new(value.0)
+    }
+}
+
+impl From<TreeHash> for Bytes32 {
+    fn from(value: TreeHash) -> Self {
+        Self(value.to_bytes())
+    }
+}
 
 #[cfg(feature = "py-bindings")]
 impl<const N: usize> ToPyObject for BytesImpl<N> {

--- a/crates/chia-puzzles/src/derive_synthetic.rs
+++ b/crates/chia-puzzles/src/derive_synthetic.rs
@@ -18,7 +18,7 @@ pub trait DeriveSynthetic {
     where
         Self: Sized,
     {
-        self.derive_synthetic_hidden(&DEFAULT_HIDDEN_PUZZLE_HASH)
+        self.derive_synthetic_hidden(&DEFAULT_HIDDEN_PUZZLE_HASH.to_bytes())
     }
 }
 

--- a/crates/chia-puzzles/src/puzzles/cat.rs
+++ b/crates/chia-puzzles/src/puzzles/cat.rs
@@ -1,7 +1,7 @@
 use chia_bls::PublicKey;
 use chia_protocol::{Bytes32, Coin};
 use clvm_traits::{FromClvm, ToClvm};
-use clvm_utils::{curry_tree_hash, tree_hash_atom};
+use clvm_utils::TreeHash;
 use hex_literal::hex;
 
 use crate::LineageProof;
@@ -49,26 +49,6 @@ pub struct CoinProof {
     pub parent_coin_info: Bytes32,
     pub inner_puzzle_hash: Bytes32,
     pub amount: u64,
-}
-
-pub fn cat_puzzle_hash(asset_id: Bytes32, inner_puzzle_hash: Bytes32) -> Bytes32 {
-    let mod_hash = tree_hash_atom(&CAT_PUZZLE_HASH);
-    let asset_id_hash = tree_hash_atom(&asset_id);
-    curry_tree_hash(
-        CAT_PUZZLE_HASH,
-        &[mod_hash, asset_id_hash, inner_puzzle_hash.to_bytes()],
-    )
-    .into()
-}
-
-pub fn everything_with_signature_asset_id(public_key: &PublicKey) -> Bytes32 {
-    let pk_tree_hash = tree_hash_atom(&public_key.to_bytes());
-    curry_tree_hash(EVERYTHING_WITH_SIGNATURE_TAIL_PUZZLE_HASH, &[pk_tree_hash]).into()
-}
-
-pub fn genesis_by_coin_id_asset_id(genesis_coin_id: Bytes32) -> Bytes32 {
-    let coin_id_hash = tree_hash_atom(&genesis_coin_id);
-    curry_tree_hash(GENESIS_BY_COIN_ID_TAIL_PUZZLE_HASH, &[coin_id_hash]).into()
 }
 
 /// This is the puzzle reveal of the [CAT2 standard](https://chialisp.com/cats) puzzle.
@@ -131,11 +111,11 @@ pub const CAT_PUZZLE: [u8; 1672] = hex!(
 );
 
 /// This is the puzzle hash of the [CAT2 standard](https://chialisp.com/cats) puzzle.
-pub const CAT_PUZZLE_HASH: [u8; 32] = hex!(
+pub const CAT_PUZZLE_HASH: TreeHash = TreeHash::new(hex!(
     "
     37bef360ee858133b69d595a906dc45d01af50379dad515eb9518abb7c1d2a7a
     "
-);
+));
 
 /// This is the puzzle reveal of the [CAT2 multi-issuance TAIL](https://chialisp.com/cats#multi) puzzle.
 pub const EVERYTHING_WITH_SIGNATURE_TAIL_PUZZLE: [u8; 41] = hex!(
@@ -146,11 +126,11 @@ pub const EVERYTHING_WITH_SIGNATURE_TAIL_PUZZLE: [u8; 41] = hex!(
 );
 
 /// This is the puzzle hash of the [CAT2 multi-issuance TAIL](https://chialisp.com/cats#multi) puzzle.
-pub const EVERYTHING_WITH_SIGNATURE_TAIL_PUZZLE_HASH: [u8; 32] = hex!(
+pub const EVERYTHING_WITH_SIGNATURE_TAIL_PUZZLE_HASH: TreeHash = TreeHash::new(hex!(
     "
     1720d13250a7c16988eaf530331cefa9dd57a76b2c82236bec8bbbff91499b89
     "
-);
+));
 
 /// This is the puzzle reveal of the [CAT2 single-issuance TAIL](https://chialisp.com/cats/#single) puzzle.
 pub const GENESIS_BY_COIN_ID_TAIL_PUZZLE: [u8; 45] = hex!(
@@ -161,11 +141,11 @@ pub const GENESIS_BY_COIN_ID_TAIL_PUZZLE: [u8; 45] = hex!(
 );
 
 /// This is the puzzle hash of the [CAT2 single-issuance TAIL](https://chialisp.com/cats/#single) puzzle.
-pub const GENESIS_BY_COIN_ID_TAIL_PUZZLE_HASH: [u8; 32] = hex!(
+pub const GENESIS_BY_COIN_ID_TAIL_PUZZLE_HASH: TreeHash = TreeHash::new(hex!(
     "
     493afb89eed93ab86741b2aa61b8f5de495d33ff9b781dfc8919e602b2afa150
     "
-);
+));
 
 /// This is the puzzle reveal of the old [CAT1 standard](https://chialisp.com/cats) puzzle.
 ///
@@ -229,23 +209,23 @@ pub const CAT_PUZZLE_V1: [u8; 1420] = hex!(
 /// It is recommended not to use CAT1 for anything other than backwards compatibility (e.g. offer compression),
 /// due to security issues uncovered in an audit. You can read more about the vulnerability that prompted the creation
 /// of CAT2 in the [CATbleed Post Mortem](https://github.com/Chia-Network/post-mortem/blob/main/2022-08/2022-08-19-CATbleed.md).
-pub const CAT_PUZZLE_HASH_V1: [u8; 32] = hex!(
+pub const CAT_PUZZLE_HASH_V1: TreeHash = TreeHash::new(hex!(
     "
     72dec062874cd4d3aab892a0906688a1ae412b0109982e1797a170add88bdcdc
     "
-);
+));
 
 #[cfg(test)]
 mod tests {
     use clvm_traits::ToNodePtr;
-    use clvm_utils::{tree_hash, CurriedProgram};
+    use clvm_utils::{tree_hash, CurriedProgram, ToTreeHash};
     use clvmr::{serde::node_from_bytes, Allocator};
 
     use super::*;
 
     use crate::{
         assert_puzzle_hash,
-        standard::{standard_puzzle_hash, StandardArgs, STANDARD_PUZZLE},
+        standard::{StandardArgs, STANDARD_PUZZLE, STANDARD_PUZZLE_HASH},
     };
 
     #[test]
@@ -280,13 +260,24 @@ mod tests {
         .to_node_ptr(&mut a)
         .unwrap();
 
-        let expected_tree_hash = hex::encode(tree_hash(&a, curried_ptr));
-        let actual_tree_hash = hex::encode(cat_puzzle_hash(
-            asset_id,
-            standard_puzzle_hash(&inner_args.synthetic_key),
-        ));
+        let allocated_tree_hash = hex::encode(tree_hash(&a, curried_ptr));
 
-        assert_eq!(expected_tree_hash, actual_tree_hash);
+        let tree_hash = hex::encode(
+            CurriedProgram {
+                program: CAT_PUZZLE_HASH,
+                args: CatArgs {
+                    mod_hash: CAT_PUZZLE_HASH.into(),
+                    inner_puzzle: CurriedProgram {
+                        program: STANDARD_PUZZLE_HASH,
+                        args: &inner_args,
+                    },
+                    tail_program_hash: asset_id,
+                },
+            }
+            .tree_hash(),
+        );
+
+        assert_eq!(allocated_tree_hash, tree_hash);
     }
 
     #[test]
@@ -302,10 +293,19 @@ mod tests {
         .to_node_ptr(&mut a)
         .unwrap();
 
-        let expected_tree_hash = hex::encode(tree_hash(&a, curried_ptr));
-        let actual_tree_hash = hex::encode(everything_with_signature_asset_id(&public_key));
+        let allocated_tree_hash = hex::encode(tree_hash(&a, curried_ptr));
 
-        assert_eq!(expected_tree_hash, actual_tree_hash);
+        let tree_hash = hex::encode(
+            CurriedProgram {
+                program: EVERYTHING_WITH_SIGNATURE_TAIL_PUZZLE_HASH,
+                args: EverythingWithSignatureTailArgs {
+                    public_key: public_key.clone(),
+                },
+            }
+            .tree_hash(),
+        );
+
+        assert_eq!(allocated_tree_hash, tree_hash);
     }
 
     #[test]
@@ -321,9 +321,16 @@ mod tests {
         .to_node_ptr(&mut a)
         .unwrap();
 
-        let expected_tree_hash = hex::encode(tree_hash(&a, curried_ptr));
-        let actual_tree_hash = hex::encode(genesis_by_coin_id_asset_id(genesis_coin_id));
+        let allocated_tree_hash = hex::encode(tree_hash(&a, curried_ptr));
 
-        assert_eq!(expected_tree_hash, actual_tree_hash);
+        let tree_hash = hex::encode(
+            CurriedProgram {
+                program: GENESIS_BY_COIN_ID_TAIL_PUZZLE_HASH,
+                args: GenesisByCoinIdTailArgs { genesis_coin_id },
+            }
+            .tree_hash(),
+        );
+
+        assert_eq!(allocated_tree_hash, tree_hash);
     }
 }

--- a/crates/chia-puzzles/src/puzzles/cat.rs
+++ b/crates/chia-puzzles/src/puzzles/cat.rs
@@ -298,9 +298,7 @@ mod tests {
         let tree_hash = hex::encode(
             CurriedProgram {
                 program: EVERYTHING_WITH_SIGNATURE_TAIL_PUZZLE_HASH,
-                args: EverythingWithSignatureTailArgs {
-                    public_key: public_key.clone(),
-                },
+                args: EverythingWithSignatureTailArgs { public_key },
             }
             .tree_hash(),
         );

--- a/crates/chia-puzzles/src/puzzles/did.rs
+++ b/crates/chia-puzzles/src/puzzles/did.rs
@@ -3,6 +3,7 @@ use clvm_traits::{
     clvm_list, match_list, match_tuple, ClvmDecoder, ClvmEncoder, FromClvm, FromClvmError, Raw,
     ToClvm, ToClvmError,
 };
+use clvm_utils::TreeHash;
 use hex_literal::hex;
 
 use crate::singleton::SingletonStruct;
@@ -92,11 +93,11 @@ pub const DID_INNER_PUZZLE: [u8; 1012] = hex!(
 );
 
 /// This is the puzzle hash of the [DID1 standard](https://chialisp.com/dids) puzzle.
-pub const DID_INNER_PUZZLE_HASH: [u8; 32] = hex!(
+pub const DID_INNER_PUZZLE_HASH: TreeHash = TreeHash::new(hex!(
     "
     33143d2bef64f14036742673afd158126b94284b4530a28c354fac202b0c910e
     "
-);
+));
 
 #[cfg(test)]
 mod tests {

--- a/crates/chia-puzzles/src/puzzles/nft.rs
+++ b/crates/chia-puzzles/src/puzzles/nft.rs
@@ -1,5 +1,6 @@
 use chia_protocol::Bytes32;
 use clvm_traits::{ClvmDecoder, ClvmEncoder, FromClvm, FromClvmError, Raw, ToClvm, ToClvmError};
+use clvm_utils::TreeHash;
 use hex_literal::hex;
 
 use crate::singleton::SingletonStruct;
@@ -177,11 +178,11 @@ pub const NFT_STATE_LAYER_PUZZLE: [u8; 827] = hex!(
 );
 
 /// This is the puzzle hash of the [NFT1 state layer](https://chialisp.com/nfts) puzzle.
-pub const NFT_STATE_LAYER_PUZZLE_HASH: [u8; 32] = hex!(
+pub const NFT_STATE_LAYER_PUZZLE_HASH: TreeHash = TreeHash::new(hex!(
     "
     a04d9f57764f54a43e4030befb4d80026e870519aaa66334aef8304f5d0393c2
     "
-);
+));
 
 /// This is the puzzle reveal of the [NFT1 ownership layer](https://chialisp.com/nfts) puzzle.
 pub const NFT_OWNERSHIP_LAYER_PUZZLE: [u8; 1226] = hex!(
@@ -229,11 +230,11 @@ pub const NFT_OWNERSHIP_LAYER_PUZZLE: [u8; 1226] = hex!(
 );
 
 /// This is the puzzle hash of the [NFT1 ownership layer](https://chialisp.com/nfts) puzzle.
-pub const NFT_OWNERSHIP_LAYER_PUZZLE_HASH: [u8; 32] = hex!(
+pub const NFT_OWNERSHIP_LAYER_PUZZLE_HASH: TreeHash = TreeHash::new(hex!(
     "
     c5abea79afaa001b5427dfa0c8cf42ca6f38f5841b78f9b3c252733eb2de2726
     "
-);
+));
 
 /// This is the puzzle reveal of the [NFT1 royalty transfer](https://chialisp.com/nfts) puzzle.
 pub const NFT_ROYALTY_TRANSFER_PUZZLE: [u8; 687] = hex!(
@@ -264,11 +265,11 @@ pub const NFT_ROYALTY_TRANSFER_PUZZLE: [u8; 687] = hex!(
 );
 
 /// This is the puzzle hash of the [NFT1 royalty transfer](https://chialisp.com/nfts) puzzle.
-pub const NFT_ROYALTY_TRANSFER_PUZZLE_HASH: [u8; 32] = hex!(
+pub const NFT_ROYALTY_TRANSFER_PUZZLE_HASH: TreeHash = TreeHash::new(hex!(
     "
     025dee0fb1e9fa110302a7e9bfb6e381ca09618e2778b0184fa5c6b275cfce1f
     "
-);
+));
 
 /// This is the puzzle reveal of the [NFT1 metadata updater](https://chialisp.com/nfts) puzzle.
 pub const NFT_METADATA_UPDATER_PUZZLE: [u8; 241] = hex!(
@@ -285,11 +286,11 @@ pub const NFT_METADATA_UPDATER_PUZZLE: [u8; 241] = hex!(
 );
 
 /// This is the puzzle hash of the [NFT1 metadata updater](https://chialisp.com/nfts) puzzle.
-pub const NFT_METADATA_UPDATER_PUZZLE_HASH: [u8; 32] = hex!(
+pub const NFT_METADATA_UPDATER_PUZZLE_HASH: TreeHash = TreeHash::new(hex!(
     "
     fe8a4b4e27a2e29a4d3fc7ce9d527adbcaccbab6ada3903ccf3ba9a769d2d78b
     "
-);
+));
 
 /// This is the puzzle reveal of the [NFT1 intermediate launcher](https://chialisp.com/nfts) puzzle.
 pub const NFT_INTERMEDIATE_LAUNCHER_PUZZLE: [u8; 65] = hex!(
@@ -301,11 +302,11 @@ pub const NFT_INTERMEDIATE_LAUNCHER_PUZZLE: [u8; 65] = hex!(
 );
 
 /// This is the puzzle hash of the [NFT1 intermediate launcher](https://chialisp.com/nfts) puzzle.
-pub const NFT_INTERMEDIATE_LAUNCHER_PUZZLE_HASH: [u8; 32] = hex!(
+pub const NFT_INTERMEDIATE_LAUNCHER_PUZZLE_HASH: TreeHash = TreeHash::new(hex!(
     "
     7a32d2d9571d3436791c0ad3d7fcfdb9c43ace2b0f0ff13f98d29f0cc093f445
     "
-);
+));
 
 #[cfg(test)]
 mod tests {

--- a/crates/chia-puzzles/src/puzzles/offer.rs
+++ b/crates/chia-puzzles/src/puzzles/offer.rs
@@ -1,5 +1,6 @@
 use chia_protocol::{Bytes, Bytes32};
 use clvm_traits::{FromClvm, ToClvm};
+use clvm_utils::TreeHash;
 use hex_literal::hex;
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
@@ -59,11 +60,11 @@ pub const SETTLEMENT_PAYMENTS_PUZZLE: [u8; 293] = hex!(
 );
 
 /// This is the puzzle hash of the [offer settlement payments](https://chialisp.com/offers) puzzle.
-pub const SETTLEMENT_PAYMENTS_PUZZLE_HASH: [u8; 32] = hex!(
+pub const SETTLEMENT_PAYMENTS_PUZZLE_HASH: TreeHash = TreeHash::new(hex!(
     "
     cfbfdeed5c4ca2de3d0bf520b9cb4bb7743a359bd2e6a188d19ce7dffc21d3e7
     "
-);
+));
 
 /// This is the puzzle reveal of the old [offer settlement payments](https://chialisp.com/offers) puzzle.
 ///
@@ -87,11 +88,11 @@ pub const SETTLEMENT_PAYMENTS_PUZZLE_V1: [u8; 267] = hex!(
 ///
 /// **Warning:**
 /// It is recommended not to use settlement payments v1 for anything other than backwards compatibility (e.g. offer compression).
-pub const SETTLEMENT_PAYMENTS_PUZZLE_HASH_V1: [u8; 32] = hex!(
+pub const SETTLEMENT_PAYMENTS_PUZZLE_HASH_V1: TreeHash = TreeHash::new(hex!(
     "
     bae24162efbd568f89bc7a340798a6118df0189eb9e3f8697bcea27af99f8f79
     "
-);
+));
 
 #[cfg(test)]
 mod tests {

--- a/crates/chia-puzzles/src/puzzles/singleton.rs
+++ b/crates/chia-puzzles/src/puzzles/singleton.rs
@@ -1,5 +1,6 @@
 use chia_protocol::Bytes32;
 use clvm_traits::{FromClvm, ToClvm};
+use clvm_utils::TreeHash;
 use hex_literal::hex;
 
 use crate::Proof;
@@ -62,11 +63,11 @@ pub const SINGLETON_LAUNCHER_PUZZLE: [u8; 175] = hex!(
 );
 
 /// This is the puzzle hash of the [singleton launcher](https://chialisp.com/singletons#launcher) puzzle.
-pub const SINGLETON_LAUNCHER_PUZZLE_HASH: [u8; 32] = hex!(
+pub const SINGLETON_LAUNCHER_PUZZLE_HASH: TreeHash = TreeHash::new(hex!(
     "
     eff07522495060c066f66f32acc2a77e3a3e737aca8baea4d1a64ea4cdc13da9
     "
-);
+));
 
 /// This is the puzzle reveal of the [singleton](https://chialisp.com/singletons) puzzle.
 pub const SINGLETON_TOP_LAYER_PUZZLE: [u8; 967] = hex!(
@@ -106,11 +107,11 @@ pub const SINGLETON_TOP_LAYER_PUZZLE: [u8; 967] = hex!(
 );
 
 /// This is the puzzle hash of the [singleton](https://chialisp.com/singletons) puzzle.
-pub const SINGLETON_TOP_LAYER_PUZZLE_HASH: [u8; 32] = hex!(
+pub const SINGLETON_TOP_LAYER_PUZZLE_HASH: TreeHash = TreeHash::new(hex!(
     "
     7faa3253bfddd1e0decb0906b2dc6247bbc4cf608f58345d173adb63e8b47c9f
     "
-);
+));
 
 #[cfg(test)]
 mod tests {

--- a/crates/chia-tools/src/bin/gen-corpus.rs
+++ b/crates/chia-tools/src/bin/gen-corpus.rs
@@ -94,7 +94,7 @@ fn main() {
                             };
 
                         let run_puzzle = seen_puzzles.lock().unwrap().insert(mod_hash);
-                        let fast_forward = (*mod_hash == SINGLETON_TOP_LAYER_PUZZLE_HASH)
+                        let fast_forward = (mod_hash == SINGLETON_TOP_LAYER_PUZZLE_HASH.into())
                             && seen_singletons.lock().unwrap().insert(puzzle_hash);
 
                         if !run_puzzle && !fast_forward && !args.spend_bundles {

--- a/crates/clvm-utils/Cargo.toml
+++ b/crates/clvm-utils/Cargo.toml
@@ -11,7 +11,8 @@ repository = "https://github.com/Chia-Network/chia_rs"
 [dependencies]
 clvmr = "0.6.1"
 clvm-traits = { version = "0.7.0", path = "../clvm-traits" }
+hex = "0.4.3"
 
 [dev-dependencies]
-hex = "0.4.3"
 rstest = "0.16.0"
+clvm-traits = { version = "0.7.0", path = "../clvm-traits", features = ["derive"] }

--- a/crates/clvm-utils/fuzz/fuzz_targets/tree-hash.rs
+++ b/crates/clvm-utils/fuzz/fuzz_targets/tree-hash.rs
@@ -1,7 +1,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use clvm_utils::{tree_hash, tree_hash_cached};
+use clvm_utils::{tree_hash, tree_hash_cached, TreeHash};
 use clvmr::{Allocator, NodePtr};
 use fuzzing_utils::{make_tree, BitCursor};
 use std::collections::{HashMap, HashSet};
@@ -11,7 +11,7 @@ use clvmr::serde::{node_from_bytes_backrefs_record, node_to_bytes_backrefs};
 fn test_hash(a: &Allocator, node: NodePtr, backrefs: &HashSet<NodePtr>) {
     let hash1 = tree_hash(a, node);
 
-    let mut cache = HashMap::<NodePtr, [u8; 32]>::new();
+    let mut cache = HashMap::<NodePtr, TreeHash>::new();
     let hash2 = tree_hash_cached(a, node, backrefs, &mut cache);
     assert_eq!(hash1, hash2);
 }

--- a/crates/clvm-utils/src/curry_tree_hash.rs
+++ b/crates/clvm-utils/src/curry_tree_hash.rs
@@ -1,6 +1,6 @@
-use crate::{tree_hash_atom, tree_hash_pair};
+use crate::{tree_hash_atom, tree_hash_pair, TreeHash};
 
-pub fn curry_tree_hash(program_hash: [u8; 32], arg_hashes: &[[u8; 32]]) -> [u8; 32] {
+pub fn curry_tree_hash(program_hash: TreeHash, arg_hashes: &[TreeHash]) -> TreeHash {
     let nil = tree_hash_atom(&[]);
     let op_q = tree_hash_atom(&[1]);
     let op_a = tree_hash_atom(&[2]);

--- a/crates/clvm-utils/src/hash_encoder.rs
+++ b/crates/clvm-utils/src/hash_encoder.rs
@@ -1,0 +1,107 @@
+use clvm_traits::{ClvmEncoder, ToClvm, ToClvmError};
+
+use crate::{tree_hash_atom, tree_hash_pair, TreeHash};
+
+pub trait ToTreeHash {
+    fn tree_hash(&self) -> TreeHash;
+}
+
+impl<T> ToTreeHash for T
+where
+    T: ToClvm<TreeHash>,
+{
+    fn tree_hash(&self) -> TreeHash {
+        self.to_clvm(&mut TreeHasher).unwrap()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct TreeHasher;
+
+impl ClvmEncoder for TreeHasher {
+    type Node = TreeHash;
+
+    fn encode_atom(&mut self, bytes: &[u8]) -> Result<Self::Node, ToClvmError> {
+        Ok(tree_hash_atom(bytes))
+    }
+
+    fn encode_pair(
+        &mut self,
+        first: Self::Node,
+        rest: Self::Node,
+    ) -> Result<Self::Node, ToClvmError> {
+        Ok(tree_hash_pair(first, rest))
+    }
+}
+
+impl ToClvm<TreeHash> for TreeHash {
+    fn to_clvm(
+        &self,
+        _encoder: &mut impl ClvmEncoder<Node = TreeHash>,
+    ) -> Result<TreeHash, ToClvmError> {
+        Ok(*self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use clvm_traits::ToClvm;
+
+    use crate::{curry_tree_hash, CurriedProgram};
+
+    #[test]
+    fn test_tree_hash() {
+        assert_eq!(
+            hex::encode(().tree_hash()),
+            "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a"
+        );
+        assert_eq!(
+            hex::encode([1, 2, 3].tree_hash()),
+            "bcd55bcd0daebba8cb158547e8480dc968570faf958f1e31a9887d6ae3dba591"
+        );
+        assert_eq!(
+            hex::encode("hello".tree_hash()),
+            "cceeb7a985ecc3dabcb4c8f666cd637f16f008e3c963db6aa6f83a7b288c54ef"
+        );
+        assert_eq!(
+            hex::encode(((1, 2), (3, 4)).tree_hash()),
+            "2824018d148bc6aed0847e2c86aaa8a5407b916169f15b12cea31fa932fc4c8d"
+        );
+
+        // This is the default hidden puzzle for the standard transaction.
+        // Its tree hash is known, and its CLVM is `(=)`.
+        assert_eq!(
+            hex::encode([9].tree_hash()),
+            "711d6c4e32c92e53179b199484cf8c897542bc57f2b22582799f9d657eec4699"
+        );
+    }
+
+    #[test]
+    fn test_curry_tree_hash() {
+        let hash_1 = [1, 2, 3].tree_hash();
+        let hash_2 = [4, 5, 6].tree_hash();
+        let hash_3 = [7, 8, 9].tree_hash();
+
+        let manual = curry_tree_hash(hash_1, &[hash_2, hash_3]);
+
+        #[derive(ToClvm)]
+        #[clvm(curry)]
+        struct Args<T> {
+            a: T,
+            b: T,
+        }
+
+        let hash = CurriedProgram {
+            program: hash_1,
+            args: Args {
+                a: hash_2,
+                b: hash_3,
+            },
+        }
+        .tree_hash();
+
+        assert_eq!(hash, manual);
+    }
+}

--- a/crates/clvm-utils/src/lib.rs
+++ b/crates/clvm-utils/src/lib.rs
@@ -26,8 +26,10 @@
 
 mod curried_program;
 mod curry_tree_hash;
+mod hash_encoder;
 mod tree_hash;
 
 pub use curried_program::*;
 pub use curry_tree_hash::*;
+pub use hash_encoder::*;
 pub use tree_hash::*;


### PR DESCRIPTION
Instead of having to special case untyped currying code with `curry_tree_hash` for each puzzle type, you can use `CurriedProgram` directly now. Here is an example:

```rs
let puzzle_hash = CurriedProgram {
    program: CAT_PUZZLE_HASH,
    args: CatArgs {
        mod_hash: CAT_PUZZLE_HASH.into(),
        tail_program_hash: CurriedProgram {
            program: GENESIS_BY_COIN_ID_TAIL_PUZZLE_HASH,
            args: GenesisByCoinIdTailArgs {
                genesis_coin_id: Bytes32::default(),
            },
        }
        .tree_hash()
        .into(),
        inner_puzzle: CurriedProgram {
            program: STANDARD_PUZZLE_HASH,
            args: StandardArgs {
                synthetic_key: PublicKey::default(),
            },
        },
    },
}
.tree_hash();
```