### PR TITLE
Add more derives and constructors for various types

### DIFF
--- a/crates/chia-bls/src/signature.rs
+++ b/crates/chia-bls/src/signature.rs
@@ -696,12 +696,12 @@ mod tests {
         for idx in 0..4 {
             let derived = sk.derive_hardened(idx as u32);
             let pk = derived.public_key();
-            data.push((pk.clone(), msg));
+            data.push((pk, msg));
             let sig = sign(&derived, msg);
             agg1.aggregate(&sig);
             agg2 += &sig;
             sigs.push(sig);
-            pairs.push((pk.clone(), aug_msg_to_g2(&pk, msg)));
+            pairs.push((pk, aug_msg_to_g2(&pk, msg)));
         }
         let agg3 = aggregate(&sigs);
         let agg4 = &sigs[0] + &sigs[1] + &sigs[2] + &sigs[3];
@@ -771,10 +771,10 @@ mod tests {
         let mut pairs = Vec::<(PublicKey, Signature)>::new();
         for _idx in 0..2 {
             let pk = sk.public_key();
-            data.push((pk.clone(), msg));
+            data.push((pk, msg));
             agg.aggregate(&sign(&sk, *msg));
 
-            pairs.push((pk.clone(), aug_msg_to_g2(&pk, msg)));
+            pairs.push((pk, aug_msg_to_g2(&pk, msg)));
         }
 
         assert_eq!(agg.to_bytes(), <[u8; 96]>::from_hex("a1cca6540a4a06d096cb5b5fc76af5fd099476e70b623b8c6e4cf02ffde94fc0f75f4e17c67a9e350940893306798a3519368b02dc3464b7270ea4ca233cfa85a38da9e25c9314e81270b54d1e773a2ec5c3e14c62dac7abdebe52f4688310d3").unwrap());

--- a/crates/chia-puzzles/src/proof.rs
+++ b/crates/chia-puzzles/src/proof.rs
@@ -1,7 +1,7 @@
 use chia_protocol::Bytes32;
 use clvm_traits::{FromClvm, ToClvm};
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(untagged, tuple)]
 pub enum Proof {
@@ -9,7 +9,47 @@ pub enum Proof {
     Eve(EveProof),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+impl Proof {
+    pub fn lineage(
+        parent_parent_coin_id: Bytes32,
+        parent_inner_puzzle_hash: Bytes32,
+        parent_amount: u64,
+    ) -> Self {
+        Self::Lineage(LineageProof::new(
+            parent_parent_coin_id,
+            parent_inner_puzzle_hash,
+            parent_amount,
+        ))
+    }
+
+    pub fn eve(parent_coin_info: Bytes32, amount: u64) -> Self {
+        Self::Eve(EveProof::new(parent_coin_info, amount))
+    }
+
+    pub fn is_lineage(&self) -> bool {
+        matches!(self, Self::Lineage(_))
+    }
+
+    pub fn is_eve(&self) -> bool {
+        matches!(self, Self::Eve(_))
+    }
+
+    pub fn as_lineage(&self) -> Option<LineageProof> {
+        match self {
+            Self::Lineage(proof) => Some(*proof),
+            _ => None,
+        }
+    }
+
+    pub fn as_eve(&self) -> Option<EveProof> {
+        match self {
+            Self::Eve(proof) => Some(*proof),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct LineageProof {
@@ -18,10 +58,33 @@ pub struct LineageProof {
     pub parent_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+impl LineageProof {
+    pub fn new(
+        parent_parent_coin_id: Bytes32,
+        parent_inner_puzzle_hash: Bytes32,
+        parent_amount: u64,
+    ) -> Self {
+        Self {
+            parent_parent_coin_id,
+            parent_inner_puzzle_hash,
+            parent_amount,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct EveProof {
     pub parent_coin_info: Bytes32,
     pub amount: u64,
+}
+
+impl EveProof {
+    pub fn new(parent_coin_info: Bytes32, amount: u64) -> Self {
+        Self {
+            parent_coin_info,
+            amount,
+        }
+    }
 }

--- a/crates/chia-puzzles/src/puzzles/cat.rs
+++ b/crates/chia-puzzles/src/puzzles/cat.rs
@@ -7,6 +7,7 @@ use hex_literal::hex;
 use crate::LineageProof;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct CatArgs<I> {
     pub mod_hash: Bytes32,
@@ -25,6 +26,7 @@ impl<I> CatArgs<I> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct EverythingWithSignatureTailArgs {
     pub public_key: PublicKey,
@@ -37,6 +39,7 @@ impl EverythingWithSignatureTailArgs {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct GenesisByCoinIdTailArgs {
     pub genesis_coin_id: Bytes32,
@@ -49,6 +52,7 @@ impl GenesisByCoinIdTailArgs {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct CatSolution<I> {
     pub inner_puzzle_solution: I,
@@ -61,6 +65,7 @@ pub struct CatSolution<I> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct CoinProof {
     pub parent_coin_info: Bytes32,

--- a/crates/chia-puzzles/src/puzzles/cat.rs
+++ b/crates/chia-puzzles/src/puzzles/cat.rs
@@ -6,7 +6,7 @@ use hex_literal::hex;
 
 use crate::LineageProof;
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(curry)]
 pub struct CatArgs<I> {
     pub mod_hash: Bytes32,
@@ -14,19 +14,41 @@ pub struct CatArgs<I> {
     pub inner_puzzle: I,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+impl<I> CatArgs<I> {
+    pub fn new(asset_id: Bytes32, inner_puzzle: I) -> Self {
+        Self {
+            mod_hash: CAT_PUZZLE_HASH.into(),
+            tail_program_hash: asset_id,
+            inner_puzzle,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(curry)]
 pub struct EverythingWithSignatureTailArgs {
     pub public_key: PublicKey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+impl EverythingWithSignatureTailArgs {
+    pub fn new(public_key: PublicKey) -> Self {
+        Self { public_key }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(curry)]
 pub struct GenesisByCoinIdTailArgs {
     pub genesis_coin_id: Bytes32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+impl GenesisByCoinIdTailArgs {
+    pub fn new(genesis_coin_id: Bytes32) -> Self {
+        Self { genesis_coin_id }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(list)]
 pub struct CatSolution<I> {
     pub inner_puzzle_solution: I,
@@ -38,7 +60,7 @@ pub struct CatSolution<I> {
     pub extra_delta: i64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(list)]
 pub struct CoinProof {
     pub parent_coin_info: Bytes32,

--- a/crates/chia-puzzles/src/puzzles/cat.rs
+++ b/crates/chia-puzzles/src/puzzles/cat.rs
@@ -292,9 +292,7 @@ mod tests {
         let mod_ptr = node_from_bytes(&mut a, &EVERYTHING_WITH_SIGNATURE_TAIL_PUZZLE).unwrap();
         let curried_ptr = CurriedProgram {
             program: mod_ptr,
-            args: EverythingWithSignatureTailArgs {
-                public_key: public_key.clone(),
-            },
+            args: EverythingWithSignatureTailArgs { public_key },
         }
         .to_node_ptr(&mut a)
         .unwrap();

--- a/crates/chia-puzzles/src/puzzles/did.rs
+++ b/crates/chia-puzzles/src/puzzles/did.rs
@@ -8,6 +8,7 @@ use hex_literal::hex;
 use crate::singleton::SingletonStruct;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct DidArgs<I, M> {
     pub inner_puzzle: I,
@@ -18,6 +19,7 @@ pub struct DidArgs<I, M> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum DidSolution<I> {
     InnerSpend(I),
 }

--- a/crates/chia-puzzles/src/puzzles/did.rs
+++ b/crates/chia-puzzles/src/puzzles/did.rs
@@ -7,7 +7,7 @@ use hex_literal::hex;
 
 use crate::singleton::SingletonStruct;
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(curry)]
 pub struct DidArgs<I, M> {
     pub inner_puzzle: I,
@@ -17,7 +17,7 @@ pub struct DidArgs<I, M> {
     pub metadata: M,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DidSolution<I> {
     InnerSpend(I),
 }

--- a/crates/chia-puzzles/src/puzzles/nft.rs
+++ b/crates/chia-puzzles/src/puzzles/nft.rs
@@ -5,6 +5,7 @@ use hex_literal::hex;
 use crate::singleton::{SingletonStruct, SINGLETON_LAUNCHER_PUZZLE_HASH};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct NftIntermediateLauncherArgs {
     pub launcher_puzzle_hash: Bytes32,
@@ -23,6 +24,7 @@ impl NftIntermediateLauncherArgs {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct NftStateLayerArgs<I, M> {
     pub mod_hash: Bytes32,
@@ -43,6 +45,7 @@ impl<I, M> NftStateLayerArgs<I, M> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct NftStateLayerSolution<I> {
     pub inner_solution: I,
@@ -55,6 +58,7 @@ impl<I> NftStateLayerSolution<I> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct NftOwnershipLayerArgs<I, P> {
     pub mod_hash: Bytes32,
@@ -75,6 +79,7 @@ impl<I, P> NftOwnershipLayerArgs<I, P> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct NftOwnershipLayerSolution<I> {
     pub inner_solution: I,
@@ -86,7 +91,8 @@ impl<I> NftOwnershipLayerSolution<I> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct NftRoyaltyTransferPuzzleArgs {
     pub singleton_struct: SingletonStruct,

--- a/crates/chia-puzzles/src/puzzles/offer.rs
+++ b/crates/chia-puzzles/src/puzzles/offer.rs
@@ -3,6 +3,7 @@ use clvm_traits::{FromClvm, ToClvm};
 use hex_literal::hex;
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(tuple)]
 pub struct SettlementPaymentsSolution {
     pub notarized_payments: Vec<NotarizedPayment>,
@@ -15,6 +16,7 @@ impl SettlementPaymentsSolution {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(tuple)]
 pub struct NotarizedPayment {
     pub nonce: Bytes32,
@@ -28,6 +30,7 @@ impl NotarizedPayment {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(tuple, untagged)]
 pub enum Payment {
     WithoutMemos(PaymentWithoutMemos),
@@ -73,6 +76,7 @@ impl Payment {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct PaymentWithoutMemos {
     pub puzzle_hash: Bytes32,
@@ -89,6 +93,7 @@ impl PaymentWithoutMemos {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct PaymentWithMemos {
     pub puzzle_hash: Bytes32,

--- a/crates/chia-puzzles/src/puzzles/singleton.rs
+++ b/crates/chia-puzzles/src/puzzles/singleton.rs
@@ -5,6 +5,7 @@ use hex_literal::hex;
 use crate::Proof;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct SingletonArgs<I> {
     pub singleton_struct: SingletonStruct,
@@ -21,6 +22,7 @@ impl<I> SingletonArgs<I> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(tuple)]
 pub struct SingletonStruct {
     pub mod_hash: Bytes32,
@@ -39,6 +41,7 @@ impl SingletonStruct {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct SingletonSolution<I> {
     pub lineage_proof: Proof,
@@ -46,12 +49,23 @@ pub struct SingletonSolution<I> {
     pub inner_solution: I,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct LauncherSolution<T> {
     pub singleton_puzzle_hash: Bytes32,
     pub amount: u64,
     pub key_value_list: T,
+}
+
+impl LauncherSolution<()> {
+    pub fn new(singleton_puzzle_hash: Bytes32, amount: u64) -> Self {
+        Self {
+            singleton_puzzle_hash,
+            amount,
+            key_value_list: (),
+        }
+    }
 }
 
 /// This is the puzzle reveal of the [singleton launcher](https://chialisp.com/singletons#launcher) puzzle.

--- a/crates/chia-puzzles/src/puzzles/singleton.rs
+++ b/crates/chia-puzzles/src/puzzles/singleton.rs
@@ -4,14 +4,23 @@ use hex_literal::hex;
 
 use crate::Proof;
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(curry)]
 pub struct SingletonArgs<I> {
     pub singleton_struct: SingletonStruct,
     pub inner_puzzle: I,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+impl<I> SingletonArgs<I> {
+    pub fn new(launcher_id: Bytes32, inner_puzzle: I) -> Self {
+        Self {
+            singleton_struct: SingletonStruct::new(launcher_id),
+            inner_puzzle,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(tuple)]
 pub struct SingletonStruct {
     pub mod_hash: Bytes32,
@@ -19,7 +28,17 @@ pub struct SingletonStruct {
     pub launcher_puzzle_hash: Bytes32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+impl SingletonStruct {
+    pub fn new(launcher_id: Bytes32) -> Self {
+        Self {
+            mod_hash: SINGLETON_TOP_LAYER_PUZZLE_HASH.into(),
+            launcher_id,
+            launcher_puzzle_hash: SINGLETON_LAUNCHER_PUZZLE_HASH.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(list)]
 pub struct SingletonSolution<I> {
     pub lineage_proof: Proof,
@@ -33,16 +52,6 @@ pub struct LauncherSolution<T> {
     pub singleton_puzzle_hash: Bytes32,
     pub amount: u64,
     pub key_value_list: T,
-}
-
-impl SingletonStruct {
-    pub fn new(launcher_id: Bytes32) -> Self {
-        Self {
-            mod_hash: SINGLETON_TOP_LAYER_PUZZLE_HASH.into(),
-            launcher_id,
-            launcher_puzzle_hash: SINGLETON_LAUNCHER_PUZZLE_HASH.into(),
-        }
-    }
 }
 
 /// This is the puzzle reveal of the [singleton launcher](https://chialisp.com/singletons#launcher) puzzle.

--- a/crates/chia-puzzles/src/puzzles/standard.rs
+++ b/crates/chia-puzzles/src/puzzles/standard.rs
@@ -1,21 +1,47 @@
 use chia_bls::PublicKey;
 use chia_protocol::Bytes32;
-use clvm_traits::{FromClvm, ToClvm};
+use clvm_traits::{clvm_quote, FromClvm, ToClvm};
 use clvm_utils::{curry_tree_hash, tree_hash_atom};
 use hex_literal::hex;
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(curry)]
 pub struct StandardArgs {
     pub synthetic_key: PublicKey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+impl StandardArgs {
+    pub fn new(synthetic_key: PublicKey) -> Self {
+        Self { synthetic_key }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[clvm(list)]
 pub struct StandardSolution<P, S> {
     pub original_public_key: Option<PublicKey>,
     pub delegated_puzzle: P,
     pub solution: S,
+}
+
+impl<P, S> StandardSolution<P, S> {
+    pub fn new(original_public_key: Option<PublicKey>, delegated_puzzle: P, solution: S) -> Self {
+        Self {
+            original_public_key,
+            delegated_puzzle,
+            solution,
+        }
+    }
+}
+
+impl<T> StandardSolution<(u8, T), ()> {
+    pub fn from_conditions(conditions: T) -> Self {
+        Self {
+            original_public_key: None,
+            delegated_puzzle: clvm_quote!(conditions),
+            solution: (),
+        }
+    }
 }
 
 pub fn standard_puzzle_hash(synthetic_key: &PublicKey) -> Bytes32 {

--- a/crates/chia-puzzles/src/puzzles/standard.rs
+++ b/crates/chia-puzzles/src/puzzles/standard.rs
@@ -5,6 +5,7 @@ use clvm_utils::{curry_tree_hash, tree_hash_atom};
 use hex_literal::hex;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct StandardArgs {
     pub synthetic_key: PublicKey,
@@ -17,6 +18,7 @@ impl StandardArgs {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct StandardSolution<P, S> {
     pub original_public_key: Option<PublicKey>,


### PR DESCRIPTION
The following changes have been made:
* Derive `Copy` for `PublicKey`
* Derive `Copy` for most puzzle types
* Derive `Arbitrary` under the `arbitrary` feature for all puzzle types
* Add constructors to most puzzles, solutions, and types (primarily with 3 or fewer arguments)
* Simplify `derive_synthetic` to use `DEFAULT_HIDDEN_PUZZLE_HASH` by default
* Add helper methods to enum types
* Add missing settlement payments (offer) types