### PR TITLE
Derive Copy and Arbitrary for types when possible

### DIFF
--- a/crates/chia-bls/src/signature.rs
+++ b/crates/chia-bls/src/signature.rs
@@ -696,12 +696,12 @@ mod tests {
         for idx in 0..4 {
             let derived = sk.derive_hardened(idx as u32);
             let pk = derived.public_key();
-            data.push((pk.clone(), msg));
+            data.push((pk, msg));
             let sig = sign(&derived, msg);
             agg1.aggregate(&sig);
             agg2 += &sig;
             sigs.push(sig);
-            pairs.push((pk.clone(), aug_msg_to_g2(&pk, msg)));
+            pairs.push((pk, aug_msg_to_g2(&pk, msg)));
         }
         let agg3 = aggregate(&sigs);
         let agg4 = &sigs[0] + &sigs[1] + &sigs[2] + &sigs[3];
@@ -771,10 +771,10 @@ mod tests {
         let mut pairs = Vec::<(PublicKey, Signature)>::new();
         for _idx in 0..2 {
             let pk = sk.public_key();
-            data.push((pk.clone(), msg));
+            data.push((pk, msg));
             agg.aggregate(&sign(&sk, *msg));
 
-            pairs.push((pk.clone(), aug_msg_to_g2(&pk, msg)));
+            pairs.push((pk, aug_msg_to_g2(&pk, msg)));
         }
 
         assert_eq!(agg.to_bytes(), <[u8; 96]>::from_hex("a1cca6540a4a06d096cb5b5fc76af5fd099476e70b623b8c6e4cf02ffde94fc0f75f4e17c67a9e350940893306798a3519368b02dc3464b7270ea4ca233cfa85a38da9e25c9314e81270b54d1e773a2ec5c3e14c62dac7abdebe52f4688310d3").unwrap());

--- a/crates/chia-puzzles/src/proof.rs
+++ b/crates/chia-puzzles/src/proof.rs
@@ -1,7 +1,7 @@
 use chia_protocol::Bytes32;
 use clvm_traits::{FromClvm, ToClvm};
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(untagged, tuple)]
 pub enum Proof {
@@ -9,7 +9,7 @@ pub enum Proof {
     Eve(EveProof),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct LineageProof {
@@ -18,7 +18,7 @@ pub struct LineageProof {
     pub parent_amount: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct EveProof {

--- a/crates/chia-puzzles/src/puzzles/cat.rs
+++ b/crates/chia-puzzles/src/puzzles/cat.rs
@@ -6,7 +6,8 @@ use hex_literal::hex;
 
 use crate::LineageProof;
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct CatArgs<I> {
     pub mod_hash: Bytes32,
@@ -14,19 +15,22 @@ pub struct CatArgs<I> {
     pub inner_puzzle: I,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct EverythingWithSignatureTailArgs {
     pub public_key: PublicKey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct GenesisByCoinIdTailArgs {
     pub genesis_coin_id: Bytes32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct CatSolution<I> {
     pub inner_puzzle_solution: I,
@@ -38,7 +42,8 @@ pub struct CatSolution<I> {
     pub extra_delta: i64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct CoinProof {
     pub parent_coin_info: Bytes32,
@@ -292,9 +297,7 @@ mod tests {
         let mod_ptr = node_from_bytes(&mut a, &EVERYTHING_WITH_SIGNATURE_TAIL_PUZZLE).unwrap();
         let curried_ptr = CurriedProgram {
             program: mod_ptr,
-            args: EverythingWithSignatureTailArgs {
-                public_key: public_key.clone(),
-            },
+            args: EverythingWithSignatureTailArgs { public_key },
         }
         .to_node_ptr(&mut a)
         .unwrap();

--- a/crates/chia-puzzles/src/puzzles/did.rs
+++ b/crates/chia-puzzles/src/puzzles/did.rs
@@ -7,7 +7,8 @@ use hex_literal::hex;
 
 use crate::singleton::SingletonStruct;
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct DidArgs<I, M> {
     pub inner_puzzle: I,
@@ -17,7 +18,8 @@ pub struct DidArgs<I, M> {
     pub metadata: M,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum DidSolution<I> {
     InnerSpend(I),
 }

--- a/crates/chia-puzzles/src/puzzles/nft.rs
+++ b/crates/chia-puzzles/src/puzzles/nft.rs
@@ -4,7 +4,8 @@ use hex_literal::hex;
 
 use crate::singleton::SingletonStruct;
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct NftIntermediateLauncherArgs {
     pub launcher_puzzle_hash: Bytes32,
@@ -12,7 +13,8 @@ pub struct NftIntermediateLauncherArgs {
     pub mint_total: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct NftStateLayerArgs<I, M> {
     pub mod_hash: Bytes32,
@@ -21,13 +23,15 @@ pub struct NftStateLayerArgs<I, M> {
     pub inner_puzzle: I,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct NftStateLayerSolution<I> {
     pub inner_solution: I,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct NftOwnershipLayerArgs<I, P> {
     pub mod_hash: Bytes32,
@@ -36,13 +40,15 @@ pub struct NftOwnershipLayerArgs<I, P> {
     pub inner_puzzle: I,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct NftOwnershipLayerSolution<I> {
     pub inner_solution: I,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct NftRoyaltyTransferPuzzleArgs {
     pub singleton_struct: SingletonStruct,

--- a/crates/chia-puzzles/src/puzzles/singleton.rs
+++ b/crates/chia-puzzles/src/puzzles/singleton.rs
@@ -4,14 +4,16 @@ use hex_literal::hex;
 
 use crate::Proof;
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct SingletonArgs<I> {
     pub singleton_struct: SingletonStruct,
     pub inner_puzzle: I,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(tuple)]
 pub struct SingletonStruct {
     pub mod_hash: Bytes32,
@@ -19,7 +21,8 @@ pub struct SingletonStruct {
     pub launcher_puzzle_hash: Bytes32,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct SingletonSolution<I> {
     pub lineage_proof: Proof,
@@ -27,7 +30,8 @@ pub struct SingletonSolution<I> {
     pub inner_solution: I,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct LauncherSolution<T> {
     pub singleton_puzzle_hash: Bytes32,

--- a/crates/chia-puzzles/src/puzzles/standard.rs
+++ b/crates/chia-puzzles/src/puzzles/standard.rs
@@ -4,13 +4,15 @@ use clvm_traits::{FromClvm, ToClvm};
 use clvm_utils::{curry_tree_hash, tree_hash_atom};
 use hex_literal::hex;
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(curry)]
 pub struct StandardArgs {
     pub synthetic_key: PublicKey,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, ToClvm, FromClvm)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToClvm, FromClvm)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[clvm(list)]
 pub struct StandardSolution<P, S> {
     pub original_public_key: Option<PublicKey>,


### PR DESCRIPTION
Implement `Copy` whenever possible for `PublicKey` and puzzles types and `Arbitrary` for puzzle types.