### PR TITLE
Validate AGG_SIG_UNSAFE messages to not end in one of the banned suffixes

### DIFF
--- a/crates/chia-bls/src/cached_bls.rs
+++ b/crates/chia-bls/src/cached_bls.rs
@@ -95,6 +95,7 @@ mod python {
     #[pymethods]
     impl BlsCache {
         #[new]
+        #[pyo3(signature = (size=None))]
         pub fn init(size: Option<u32>) -> PyResult<Self> {
             let Some(size) = size else {
                 return Ok(Self::default());

--- a/crates/chia-consensus/benches/run-generator.rs
+++ b/crates/chia-consensus/benches/run-generator.rs
@@ -1,3 +1,4 @@
+use chia_consensus::consensus_constants::TEST_CONSTANTS;
 use chia_consensus::gen::conditions::MempoolVisitor;
 use chia_consensus::gen::flags::ALLOW_BACKREFS;
 use chia_consensus::gen::run_block_generator::{run_block_generator, run_block_generator2};
@@ -56,6 +57,7 @@ fn run(c: &mut Criterion) {
                         &block_refs,
                         11_000_000_000,
                         ALLOW_BACKREFS,
+                        &TEST_CONSTANTS,
                     );
                     let _ = black_box(conds);
                     start.elapsed()
@@ -73,6 +75,7 @@ fn run(c: &mut Criterion) {
                         &block_refs,
                         11_000_000_000,
                         ALLOW_BACKREFS,
+                        &TEST_CONSTANTS,
                     );
                     let _ = black_box(conds);
                     start.elapsed()

--- a/crates/chia-consensus/fuzz/fuzz_targets/fast-forward.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/fast-forward.rs
@@ -1,4 +1,5 @@
 #![no_main]
+use chia_consensus::consensus_constants::TEST_CONSTANTS;
 use chia_consensus::fast_forward::fast_forward_singleton;
 use chia_consensus::gen::conditions::{MempoolVisitor, ELIGIBLE_FOR_FF};
 use chia_consensus::gen::run_puzzle::run_puzzle;
@@ -90,6 +91,7 @@ fn test_ff(
         spend.coin.amount,
         11_000_000_000,
         0,
+        &TEST_CONSTANTS,
     );
 
     // run new spend
@@ -101,6 +103,7 @@ fn test_ff(
         new_coin.amount,
         11_000_000_000,
         0,
+        &TEST_CONSTANTS,
     );
 
     // These are the kinds of failures that can happen because of the

--- a/crates/chia-consensus/fuzz/fuzz_targets/parse-conditions.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/parse-conditions.rs
@@ -1,6 +1,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
+use chia_consensus::consensus_constants::TEST_CONSTANTS;
 use chia_consensus::gen::conditions::{
     parse_conditions, MempoolVisitor, ParseState, Spend, SpendBundleConditions,
 };
@@ -81,6 +82,7 @@ fuzz_target!(|data: &[u8]| {
             input,
             *flags,
             &mut max_cost,
+            &TEST_CONSTANTS,
             &mut visitor,
         );
     }

--- a/crates/chia-consensus/fuzz/fuzz_targets/parse-spends.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/parse-spends.rs
@@ -5,6 +5,7 @@ use chia_consensus::gen::conditions::{parse_spends, MempoolVisitor};
 use clvmr::{Allocator, NodePtr};
 use fuzzing_utils::{make_list, BitCursor};
 
+use chia_consensus::consensus_constants::TEST_CONSTANTS;
 use chia_consensus::gen::flags::{
     COND_ARGS_NIL, ENABLE_MESSAGE_CONDITIONS, ENABLE_SOFTFORK_CONDITION, NO_UNKNOWN_CONDS,
     STRICT_ARGS_COUNT,
@@ -23,6 +24,7 @@ fuzz_target!(|data: &[u8]| {
         ENABLE_SOFTFORK_CONDITION,
         ENABLE_MESSAGE_CONDITIONS,
     ] {
-        let _ret = parse_spends::<MempoolVisitor>(&a, input, 33_000_000_000, *flags);
+        let _ret =
+            parse_spends::<MempoolVisitor>(&a, input, 33_000_000_000, *flags, &TEST_CONSTANTS);
     }
 });

--- a/crates/chia-consensus/fuzz/fuzz_targets/process-spend.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/process-spend.rs
@@ -1,4 +1,5 @@
 #![no_main]
+use chia_consensus::consensus_constants::TEST_CONSTANTS;
 use chia_consensus::gen::conditions::{
     process_single_spend, MempoolVisitor, ParseState, SpendBundleConditions,
 };
@@ -30,6 +31,7 @@ fuzz_target!(|data: &[u8]| {
             conds,
             *flags,
             &mut cost_left,
+            &TEST_CONSTANTS,
         );
     }
 });

--- a/crates/chia-consensus/fuzz/fuzz_targets/run-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/run-generator.rs
@@ -1,5 +1,6 @@
 #![no_main]
 use chia_consensus::allocator::make_allocator;
+use chia_consensus::consensus_constants::TEST_CONSTANTS;
 use chia_consensus::gen::conditions::MempoolVisitor;
 use chia_consensus::gen::flags::ALLOW_BACKREFS;
 use chia_consensus::gen::run_block_generator::{run_block_generator, run_block_generator2};
@@ -15,6 +16,7 @@ fuzz_target!(|data: &[u8]| {
         &[],
         110_000_000,
         ALLOW_BACKREFS,
+        &TEST_CONSTANTS,
     );
     drop(a1);
 
@@ -25,6 +27,7 @@ fuzz_target!(|data: &[u8]| {
         &[],
         110_000_000,
         ALLOW_BACKREFS,
+        &TEST_CONSTANTS,
     );
     drop(a2);
 

--- a/crates/chia-consensus/fuzz/fuzz_targets/run-puzzle.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/run-puzzle.rs
@@ -1,4 +1,5 @@
 #![no_main]
+use chia_consensus::consensus_constants::TEST_CONSTANTS;
 use chia_consensus::gen::conditions::MempoolVisitor;
 use chia_consensus::gen::flags::ALLOW_BACKREFS;
 use chia_consensus::gen::run_puzzle::run_puzzle;
@@ -22,5 +23,6 @@ fuzz_target!(|data: &[u8]| {
         spend.coin.amount,
         11_000_000_000,
         ALLOW_BACKREFS,
+        &TEST_CONSTANTS,
     );
 });

--- a/crates/chia-consensus/src/consensus_constants.rs
+++ b/crates/chia-consensus/src/consensus_constants.rs
@@ -74,8 +74,15 @@ pub struct ConsensusConstants {
     /// We override this value based on the chain being run (testnet0, testnet1, mainnet, etc).
     genesis_challenge: Bytes32,
 
-    /// Forks of chia should change this value to provide replay attack protection.
+    /// Forks of chia should change these values to provide replay attack protection.
     agg_sig_me_additional_data: Bytes32,
+    /// By convention, the below additional data is derived from the agg_sig_me_additional_data
+    agg_sig_parent_additional_data: Bytes32,
+    agg_sig_puzzle_additional_data: Bytes32,
+    agg_sig_amount_additional_data: Bytes32,
+    agg_sig_puzzle_amount_additional_data: Bytes32,
+    agg_sig_parent_amount_additional_data: Bytes32,
+    agg_sig_parent_puzzle_additional_data: Bytes32,
 
     /// The block at height must pay out to this pool puzzle hash.
     genesis_pre_farm_pool_puzzle_hash: Bytes32,
@@ -162,6 +169,24 @@ pub const TEST_CONSTANTS: ConsensusConstants = ConsensusConstants {
     )),
     agg_sig_me_additional_data: Bytes32::new(hex!(
         "ccd5bb71183532bff220ba46c268991a3ff07eb358e8255a65c30a2dce0e5fbb"
+    )),
+    agg_sig_parent_additional_data: Bytes32::new(hex!(
+        "baf5d69c647c91966170302d18521b0a85663433d161e72c826ed08677b53a74"
+    )),
+    agg_sig_puzzle_additional_data: Bytes32::new(hex!(
+        "284fa2ef486c7a41cc29fc99c9d08376161e93dd37817edb8219f42dca7592c4"
+    )),
+    agg_sig_amount_additional_data: Bytes32::new(hex!(
+        "cda186a9cd030f7a130fae45005e81cae7a90e0fa205b75f6aebc0d598e0348e"
+    )),
+    agg_sig_puzzle_amount_additional_data: Bytes32::new(hex!(
+        "0f7d90dff0613e6901e24dae59f1e690f18b8f5fbdcf1bb192ac9deaf7de22ad"
+    )),
+    agg_sig_parent_amount_additional_data: Bytes32::new(hex!(
+        "585796bd90bb553c0430b87027ffee08d88aba0162c6e1abbbcc6b583f2ae7f9"
+    )),
+    agg_sig_parent_puzzle_additional_data: Bytes32::new(hex!(
+        "2ebfdae17b29d83bae476a25ea06f0c4bd57298faddbbc3ec5ad29b9b86ce5df"
     )),
     genesis_pre_farm_pool_puzzle_hash: Bytes32::new(hex!(
         "d23da14695a188ae5708dd152263c4db883eb27edeb936178d4d988b8f3ce5fc"

--- a/crates/chia-consensus/src/fast_forward.rs
+++ b/crates/chia-consensus/src/fast_forward.rs
@@ -155,6 +155,7 @@ pub fn fast_forward_singleton(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::consensus_constants::TEST_CONSTANTS;
     use crate::gen::conditions::MempoolVisitor;
     use crate::gen::run_puzzle::run_puzzle;
     use chia_protocol::CoinSpend;
@@ -233,6 +234,7 @@ mod tests {
             spend.coin.amount,
             11_000_000_000,
             0,
+            &TEST_CONSTANTS,
         )
         .expect("run_puzzle");
 
@@ -245,6 +247,7 @@ mod tests {
             new_coin.amount,
             11_000_000_000,
             0,
+            &TEST_CONSTANTS,
         )
         .expect("run_puzzle");
 

--- a/crates/chia-consensus/src/gen/run_block_generator.rs
+++ b/crates/chia-consensus/src/gen/run_block_generator.rs
@@ -1,3 +1,4 @@
+use crate::consensus_constants::ConsensusConstants;
 use crate::gen::conditions::{
     parse_spends, process_single_spend, validate_conditions, ParseState, SpendBundleConditions,
 };
@@ -43,6 +44,7 @@ pub fn run_block_generator<GenBuf: AsRef<[u8]>, V: SpendVisitor>(
     block_refs: &[GenBuf],
     max_cost: u64,
     flags: u32,
+    constants: &ConsensusConstants,
 ) -> Result<SpendBundleConditions, ValidationErr> {
     let mut cost_left = max_cost;
     let byte_cost = program.len() as u64 * COST_PER_BYTE;
@@ -76,7 +78,7 @@ pub fn run_block_generator<GenBuf: AsRef<[u8]>, V: SpendVisitor>(
 
     // we pass in what's left of max_cost here, to fail early in case the
     // cost of a condition brings us over the cost limit
-    let mut result = parse_spends::<V>(a, generator_output, cost_left, flags)?;
+    let mut result = parse_spends::<V>(a, generator_output, cost_left, flags, constants)?;
     result.cost += max_cost - cost_left;
     Ok(result)
 }
@@ -116,6 +118,7 @@ pub fn run_block_generator2<GenBuf: AsRef<[u8]>, V: SpendVisitor>(
     block_refs: &[GenBuf],
     max_cost: u64,
     flags: u32,
+    constants: &ConsensusConstants,
 ) -> Result<SpendBundleConditions, ValidationErr> {
     let byte_cost = program.len() as u64 * COST_PER_BYTE;
 
@@ -181,6 +184,7 @@ pub fn run_block_generator2<GenBuf: AsRef<[u8]>, V: SpendVisitor>(
             conditions,
             flags,
             &mut cost_left,
+            constants,
         )?;
     }
     if a.atom_len(all_spends) != 0 {

--- a/crates/chia-consensus/src/gen/run_block_generator.rs
+++ b/crates/chia-consensus/src/gen/run_block_generator.rs
@@ -5,7 +5,7 @@ use crate::gen::conditions::{
 use crate::gen::flags::ALLOW_BACKREFS;
 use crate::gen::spend_visitor::SpendVisitor;
 use crate::gen::validation_error::{first, ErrorCode, ValidationErr};
-use crate::generator_rom::{CLVM_DESERIALIZER, COST_PER_BYTE, GENERATOR_ROM};
+use crate::generator_rom::{CLVM_DESERIALIZER, GENERATOR_ROM};
 use clvm_utils::{tree_hash_cached, TreeHash};
 use clvmr::allocator::{Allocator, NodePtr};
 use clvmr::chia_dialect::ChiaDialect;
@@ -47,7 +47,7 @@ pub fn run_block_generator<GenBuf: AsRef<[u8]>, V: SpendVisitor>(
     constants: &ConsensusConstants,
 ) -> Result<SpendBundleConditions, ValidationErr> {
     let mut cost_left = max_cost;
-    let byte_cost = program.len() as u64 * COST_PER_BYTE;
+    let byte_cost = program.len() as u64 * constants.cost_per_byte;
 
     subtract_cost(a, &mut cost_left, byte_cost)?;
 
@@ -120,7 +120,7 @@ pub fn run_block_generator2<GenBuf: AsRef<[u8]>, V: SpendVisitor>(
     flags: u32,
     constants: &ConsensusConstants,
 ) -> Result<SpendBundleConditions, ValidationErr> {
-    let byte_cost = program.len() as u64 * COST_PER_BYTE;
+    let byte_cost = program.len() as u64 * constants.cost_per_byte;
 
     let mut cost_left = max_cost;
     subtract_cost(a, &mut cost_left, byte_cost)?;

--- a/crates/chia-consensus/src/gen/run_puzzle.rs
+++ b/crates/chia-consensus/src/gen/run_puzzle.rs
@@ -1,3 +1,4 @@
+use crate::consensus_constants::ConsensusConstants;
 use crate::gen::conditions::{parse_conditions, ParseState, Spend, SpendBundleConditions};
 use crate::gen::flags::ALLOW_BACKREFS;
 use crate::gen::spend_visitor::SpendVisitor;
@@ -12,6 +13,7 @@ use clvmr::run_program::run_program;
 use clvmr::serde::{node_from_bytes, node_from_bytes_backrefs};
 use std::sync::Arc;
 
+#[allow(clippy::too_many_arguments)]
 pub fn run_puzzle<V: SpendVisitor>(
     a: &mut Allocator,
     puzzle: &[u8],
@@ -20,6 +22,7 @@ pub fn run_puzzle<V: SpendVisitor>(
     amount: u64,
     max_cost: u64,
     flags: u32,
+    constants: &ConsensusConstants,
 ) -> Result<SpendBundleConditions, ValidationErr> {
     let deserialize = if (flags & ALLOW_BACKREFS) != 0 {
         node_from_bytes_backrefs
@@ -67,6 +70,7 @@ pub fn run_puzzle<V: SpendVisitor>(
         conditions,
         flags,
         &mut cost_left,
+        constants,
         &mut visitor,
     )?;
     ret.cost = max_cost - cost_left;

--- a/crates/chia-consensus/src/gen/test_generators.rs
+++ b/crates/chia-consensus/src/gen/test_generators.rs
@@ -1,6 +1,7 @@
 use super::conditions::{MempoolVisitor, NewCoin, Spend, SpendBundleConditions};
 use super::run_block_generator::{run_block_generator, run_block_generator2};
 use crate::allocator::make_allocator;
+use crate::consensus_constants::TEST_CONSTANTS;
 use crate::gen::flags::{ALLOW_BACKREFS, ENABLE_MESSAGE_CONDITIONS, MEMPOOL_MODE};
 use chia_protocol::{Bytes, Bytes48};
 use clvmr::allocator::NodePtr;
@@ -229,6 +230,7 @@ fn run_generator(#[case] name: &str) {
             &block_refs,
             11_000_000_000,
             *flags,
+            &TEST_CONSTANTS,
         );
 
         let (expected_cost, output) = match conds {
@@ -243,6 +245,7 @@ fn run_generator(#[case] name: &str) {
             &block_refs,
             11_000_000_000,
             *flags,
+            &TEST_CONSTANTS,
         );
         let output_hard_fork = match conds {
             Ok(mut conditions) => {

--- a/crates/chia-tools/src/bin/analyze-chain.rs
+++ b/crates/chia-tools/src/bin/analyze-chain.rs
@@ -7,6 +7,7 @@ use std::time::SystemTime;
 
 use rusqlite::Connection;
 
+use chia_consensus::consensus_constants::TEST_CONSTANTS;
 use chia_consensus::gen::conditions::{parse_spends, MempoolVisitor};
 use chia_consensus::gen::flags::MEMPOOL_MODE;
 use chia_consensus::generator_rom::{COST_PER_BYTE, GENERATOR_ROM};
@@ -161,9 +162,14 @@ fn main() {
         let start_conditions = SystemTime::now();
         // we pass in what's left of max_cost here, to fail early in case the
         // cost of a condition brings us over the cost limit
-        let Ok(conds) =
-            parse_spends::<MempoolVisitor>(&a, generator_output, ti.cost - clvm_cost, MEMPOOL_MODE)
-        else {
+        // TODO: Use real constants
+        let Ok(conds) = parse_spends::<MempoolVisitor>(
+            &a,
+            generator_output,
+            ti.cost - clvm_cost,
+            MEMPOOL_MODE,
+            &TEST_CONSTANTS,
+        ) else {
             panic!("failed to parse conditions in block {height}");
         };
         let conditions_timing = start_conditions

--- a/crates/chia-tools/src/bin/test-block-generators.rs
+++ b/crates/chia-tools/src/bin/test-block-generators.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 
 use chia_bls::PublicKey;
+use chia_consensus::consensus_constants::TEST_CONSTANTS;
 use chia_consensus::gen::conditions::{EmptyVisitor, NewCoin, Spend, SpendBundleConditions};
 use chia_consensus::gen::flags::{ALLOW_BACKREFS, MEMPOOL_MODE};
 use chia_consensus::gen::run_block_generator::{run_block_generator, run_block_generator2};
@@ -125,6 +126,9 @@ fn compare(a: &Allocator, lhs: &SpendBundleConditions, rhs: &SpendBundleConditio
 fn main() {
     let args = Args::parse();
 
+    // TODO: Use the real consants here
+    let constants = &TEST_CONSTANTS;
+
     assert!(!(args.validate && !(args.mempool || args.rust_generator || args.test_backrefs)), "it doesn't make sense to validate the output against identical runs. Specify --mempool, --rust-generator or --test-backrefs");
 
     let num_cores = args
@@ -175,8 +179,9 @@ fn main() {
                     prg.as_ref()
                 };
 
-                let mut conditions = block_runner(&mut a, generator, &block_refs, ti.cost, flags)
-                    .expect("failed to run block generator");
+                let mut conditions =
+                    block_runner(&mut a, generator, &block_refs, ti.cost, flags, constants)
+                        .expect("failed to run block generator");
 
                 if args.rust_generator || args.test_backrefs {
                     assert!(conditions.cost <= ti.cost);
@@ -197,6 +202,7 @@ fn main() {
                         &block_refs,
                         ti.cost,
                         0,
+                        constants,
                     )
                     .expect("failed to run block generator");
                     assert_eq!(baseline.cost, ti.cost);

--- a/tests/run_gen.py
+++ b/tests/run_gen.py
@@ -1,10 +1,89 @@
 #!/usr/bin/env python3
 
-from chia_rs import run_block_generator, SpendBundleConditions, run_block_generator2
+from chia_rs import (
+    run_block_generator,
+    SpendBundleConditions,
+    run_block_generator2,
+    ConsensusConstants,
+)
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
 from time import time
 import sys
 from time import perf_counter
 from typing import Optional, Tuple
+
+DEFAULT_CONSTANTS = ConsensusConstants(
+    SLOT_BLOCKS_TARGET=uint32(32),
+    MIN_BLOCKS_PER_CHALLENGE_BLOCK=uint8(16),
+    MAX_SUB_SLOT_BLOCKS=uint32(128),
+    NUM_SPS_SUB_SLOT=uint32(64),
+    SUB_SLOT_ITERS_STARTING=uint64(2**27),
+    DIFFICULTY_CONSTANT_FACTOR=uint128(2**67),
+    DIFFICULTY_STARTING=uint64(7),
+    DIFFICULTY_CHANGE_MAX_FACTOR=uint32(3),
+    SUB_EPOCH_BLOCKS=uint32(384),
+    EPOCH_BLOCKS=uint32(4608),
+    SIGNIFICANT_BITS=uint8(8),
+    DISCRIMINANT_SIZE_BITS=uint16(1024),
+    NUMBER_ZERO_BITS_PLOT_FILTER=uint8(9),
+    MIN_PLOT_SIZE=uint8(32),
+    MAX_PLOT_SIZE=uint8(50),
+    SUB_SLOT_TIME_TARGET=uint16(600),
+    NUM_SP_INTERVALS_EXTRA=uint8(3),
+    MAX_FUTURE_TIME2=uint32(2 * 60),
+    NUMBER_OF_TIMESTAMPS=uint8(11),
+    GENESIS_CHALLENGE=bytes32.fromhex(
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    ),
+    AGG_SIG_ME_ADDITIONAL_DATA=bytes32.fromhex(
+        "ccd5bb71183532bff220ba46c268991a3ff07eb358e8255a65c30a2dce0e5fbb"
+    ),
+    AGG_SIG_PARENT_ADDITIONAL_DATA=bytes32.fromhex(
+        "baf5d69c647c91966170302d18521b0a85663433d161e72c826ed08677b53a74"
+    ),
+    AGG_SIG_PUZZLE_ADDITIONAL_DATA=bytes32.fromhex(
+        "284fa2ef486c7a41cc29fc99c9d08376161e93dd37817edb8219f42dca7592c4"
+    ),
+    AGG_SIG_AMOUNT_ADDITIONAL_DATA=bytes32.fromhex(
+        "cda186a9cd030f7a130fae45005e81cae7a90e0fa205b75f6aebc0d598e0348e"
+    ),
+    AGG_SIG_PUZZLE_AMOUNT_ADDITIONAL_DATA=bytes32.fromhex(
+        "0f7d90dff0613e6901e24dae59f1e690f18b8f5fbdcf1bb192ac9deaf7de22ad"
+    ),
+    AGG_SIG_PARENT_AMOUNT_ADDITIONAL_DATA=bytes32.fromhex(
+        "585796bd90bb553c0430b87027ffee08d88aba0162c6e1abbbcc6b583f2ae7f9"
+    ),
+    AGG_SIG_PARENT_PUZZLE_ADDITIONAL_DATA=bytes32.fromhex(
+        "2ebfdae17b29d83bae476a25ea06f0c4bd57298faddbbc3ec5ad29b9b86ce5df"
+    ),
+    GENESIS_PRE_FARM_POOL_PUZZLE_HASH=bytes32.fromhex(
+        "d23da14695a188ae5708dd152263c4db883eb27edeb936178d4d988b8f3ce5fc"
+    ),
+    GENESIS_PRE_FARM_FARMER_PUZZLE_HASH=bytes32.fromhex(
+        "3d8765d3a597ec1d99663f6c9816d915b9f68613ac94009884c4addaefcce6af"
+    ),
+    MAX_VDF_WITNESS_SIZE=uint8(64),
+    MEMPOOL_BLOCK_BUFFER=uint8(10),
+    MAX_COIN_AMOUNT=uint64((1 << 64) - 1),
+    MAX_BLOCK_COST_CLVM=uint64(11000000000),
+    COST_PER_BYTE=uint64(12000),
+    WEIGHT_PROOF_THRESHOLD=uint8(2),
+    BLOCKS_CACHE_SIZE=uint32(4608 + (128 * 4)),
+    WEIGHT_PROOF_RECENT_BLOCKS=uint32(1000),
+    MAX_BLOCK_COUNT_PER_REQUESTS=uint32(32),
+    MAX_GENERATOR_SIZE=uint32(1000000),
+    MAX_GENERATOR_REF_LIST_SIZE=uint32(512),
+    POOL_SUB_SLOT_ITERS=uint64(37600000000),
+    SOFT_FORK2_HEIGHT=uint32(0),
+    SOFT_FORK4_HEIGHT=uint32(5716000),
+    SOFT_FORK5_HEIGHT=uint32(0),
+    HARD_FORK_HEIGHT=uint32(5496000),
+    HARD_FORK_FIX_HEIGHT=uint32(5496000),
+    PLOT_FILTER_128_HEIGHT=uint32(10542000),
+    PLOT_FILTER_64_HEIGHT=uint32(15592000),
+    PLOT_FILTER_32_HEIGHT=uint32(20643000),
+)
 
 
 def run_gen(
@@ -31,7 +110,7 @@ def run_gen(
 
     start_time = perf_counter()
     try:
-        ret = block_runner(generator, block_refs, max_cost, flags)
+        ret = block_runner(generator, block_refs, max_cost, flags, DEFAULT_CONSTANTS)
         run_time = perf_counter() - start_time
         return ret + (run_time,)
     except Exception as e:

--- a/tests/test_run_block_generator.py
+++ b/tests/test_run_block_generator.py
@@ -1,5 +1,5 @@
 from chia_rs import run_block_generator, run_block_generator2
-from run_gen import print_spend_bundle_conditions
+from run_gen import print_spend_bundle_conditions, DEFAULT_CONSTANTS
 
 
 def test_run_block_generator_cost() -> None:
@@ -13,11 +13,15 @@ def test_run_block_generator_cost() -> None:
     generator = bytes.fromhex(
         open("generator-tests/block-834768.txt", "r").read().split("\n")[0]
     )
-    err, conds = run_block_generator(generator, [], original_consensus_cost, 0)
+    err, conds = run_block_generator(
+        generator, [], original_consensus_cost, 0, DEFAULT_CONSTANTS
+    )
     assert err is None
     assert conds is not None
 
-    err2, conds2 = run_block_generator2(generator, [], hard_fork_consensus_cost, 0)
+    err2, conds2 = run_block_generator2(
+        generator, [], hard_fork_consensus_cost, 0, DEFAULT_CONSTANTS
+    )
     assert err2 is None
     assert conds2 is not None
 
@@ -30,24 +34,32 @@ def test_run_block_generator_cost() -> None:
         assert l1 == l2
 
     # we exceed the cost limit by 1
-    err, conds = run_block_generator(generator, [], original_consensus_cost - 1, 0)
+    err, conds = run_block_generator(
+        generator, [], original_consensus_cost - 1, 0, DEFAULT_CONSTANTS
+    )
     # BLOCK_COST_EXCEEDS_MAX = 23
     assert err == 23
     assert conds is None
 
-    err, conds = run_block_generator2(generator, [], hard_fork_consensus_cost - 1, 0)
+    err, conds = run_block_generator2(
+        generator, [], hard_fork_consensus_cost - 1, 0, DEFAULT_CONSTANTS
+    )
     # BLOCK_COST_EXCEEDS_MAX = 23
     assert err == 23
     assert conds is None
 
     # the byte cost alone exceeds the limit by 1
-    err, conds = run_block_generator(generator, [], len(generator) * 12000 - 1, 0)
+    err, conds = run_block_generator(
+        generator, [], len(generator) * 12000 - 1, 0, DEFAULT_CONSTANTS
+    )
     # BLOCK_COST_EXCEEDS_MAX = 23
     assert err == 23
     assert conds is None
 
     # the byte cost alone exceeds the limit by 1
-    err, conds = run_block_generator2(generator, [], len(generator) * 12000 - 1, 0)
+    err, conds = run_block_generator2(
+        generator, [], len(generator) * 12000 - 1, 0, DEFAULT_CONSTANTS
+    )
     # BLOCK_COST_EXCEEDS_MAX = 23
     assert err == 23
     assert conds is None

--- a/tests/test_run_puzzle.py
+++ b/tests/test_run_puzzle.py
@@ -1,7 +1,7 @@
 from chia_rs import run_puzzle, run_chia_program, ALLOW_BACKREFS
 from chia_rs.sized_bytes import bytes32
 import pytest
-from run_gen import print_spend_bundle_conditions
+from run_gen import print_spend_bundle_conditions, DEFAULT_CONSTANTS
 from clvm.SExp import SExp
 from clvm.casts import int_from_bytes
 from clvm_tools import binutils
@@ -51,7 +51,9 @@ def test_block_834752(flags: int, input_file: str) -> None:
 
     output = ""
     for parent, amount, puzzle, solution in puzzles:
-        conds = run_puzzle(puzzle, solution, parent, amount, 11000000000, flags)
+        conds = run_puzzle(
+            puzzle, solution, parent, amount, 11000000000, flags, DEFAULT_CONSTANTS
+        )
         output += print_spend_bundle_conditions(conds)
 
     assert (
@@ -118,7 +120,9 @@ def test_failure(flags: int) -> None:
     solution2 = binutils.assemble("(2)").as_bin()
 
     # the puzzle expects (1)
-    conds = run_puzzle(puzzle, solution1, parent, amount, 11000000000, flags)
+    conds = run_puzzle(
+        puzzle, solution1, parent, amount, 11000000000, flags, DEFAULT_CONSTANTS
+    )
     output += print_spend_bundle_conditions(conds)
     print(output)
     assert (
@@ -134,4 +138,6 @@ addition_amount: 0
 
     with pytest.raises(ValueError, match="ValidationError"):
         # the puzzle does not expect (2)
-        run_puzzle(puzzle, solution2, parent, amount, 11000000000, flags)
+        run_puzzle(
+            puzzle, solution2, parent, amount, 11000000000, flags, DEFAULT_CONSTANTS
+        )

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -279,15 +279,15 @@ def supports_fast_forward(spend: CoinSpend) -> bool : ...
 def fast_forward_singleton(spend: CoinSpend, new_coin: Coin, new_parent: Coin) -> bytes: ...
 
 def run_block_generator(
-    program: ReadableBuffer, args: List[ReadableBuffer], max_cost: int, flags: int
+    program: ReadableBuffer, args: List[ReadableBuffer], max_cost: int, flags: int, constants: ConsensusConstants
 ) -> Tuple[Optional[int], Optional[SpendBundleConditions]]: ...
 
 def run_block_generator2(
-    program: ReadableBuffer, args: List[ReadableBuffer], max_cost: int, flags: int
+    program: ReadableBuffer, args: List[ReadableBuffer], max_cost: int, flags: int, constants: ConsensusConstants
 ) -> Tuple[Optional[int], Optional[SpendBundleConditions]]: ...
 
 def run_puzzle(
-    puzzle: bytes, solution: bytes, parent_id: bytes32, amount: int, max_cost: int, flags: int
+    puzzle: bytes, solution: bytes, parent_id: bytes32, amount: int, max_cost: int, flags: int, constants: ConsensusConstants
 ) -> SpendBundleConditions: ...
 
 def deserialize_proof(

--- a/wheel/python/chia_rs/chia_rs.pyi
+++ b/wheel/python/chia_rs/chia_rs.pyi
@@ -22,15 +22,15 @@ def supports_fast_forward(spend: CoinSpend) -> bool : ...
 def fast_forward_singleton(spend: CoinSpend, new_coin: Coin, new_parent: Coin) -> bytes: ...
 
 def run_block_generator(
-    program: ReadableBuffer, args: List[ReadableBuffer], max_cost: int, flags: int
+    program: ReadableBuffer, args: List[ReadableBuffer], max_cost: int, flags: int, constants: ConsensusConstants
 ) -> Tuple[Optional[int], Optional[SpendBundleConditions]]: ...
 
 def run_block_generator2(
-    program: ReadableBuffer, args: List[ReadableBuffer], max_cost: int, flags: int
+    program: ReadableBuffer, args: List[ReadableBuffer], max_cost: int, flags: int, constants: ConsensusConstants
 ) -> Tuple[Optional[int], Optional[SpendBundleConditions]]: ...
 
 def run_puzzle(
-    puzzle: bytes, solution: bytes, parent_id: bytes32, amount: int, max_cost: int, flags: int
+    puzzle: bytes, solution: bytes, parent_id: bytes32, amount: int, max_cost: int, flags: int, constants: ConsensusConstants
 ) -> SpendBundleConditions: ...
 
 def deserialize_proof(
@@ -4134,6 +4134,12 @@ class ConsensusConstants:
     NUMBER_OF_TIMESTAMPS: uint8
     GENESIS_CHALLENGE: bytes32
     AGG_SIG_ME_ADDITIONAL_DATA: bytes32
+    AGG_SIG_PARENT_ADDITIONAL_DATA: bytes32
+    AGG_SIG_PUZZLE_ADDITIONAL_DATA: bytes32
+    AGG_SIG_AMOUNT_ADDITIONAL_DATA: bytes32
+    AGG_SIG_PUZZLE_AMOUNT_ADDITIONAL_DATA: bytes32
+    AGG_SIG_PARENT_AMOUNT_ADDITIONAL_DATA: bytes32
+    AGG_SIG_PARENT_PUZZLE_ADDITIONAL_DATA: bytes32
     GENESIS_PRE_FARM_POOL_PUZZLE_HASH: bytes32
     GENESIS_PRE_FARM_FARMER_PUZZLE_HASH: bytes32
     MAX_VDF_WITNESS_SIZE: uint8
@@ -4179,6 +4185,12 @@ class ConsensusConstants:
         NUMBER_OF_TIMESTAMPS: uint8,
         GENESIS_CHALLENGE: bytes,
         AGG_SIG_ME_ADDITIONAL_DATA: bytes,
+        AGG_SIG_PARENT_ADDITIONAL_DATA: bytes,
+        AGG_SIG_PUZZLE_ADDITIONAL_DATA: bytes,
+        AGG_SIG_AMOUNT_ADDITIONAL_DATA: bytes,
+        AGG_SIG_PUZZLE_AMOUNT_ADDITIONAL_DATA: bytes,
+        AGG_SIG_PARENT_AMOUNT_ADDITIONAL_DATA: bytes,
+        AGG_SIG_PARENT_PUZZLE_ADDITIONAL_DATA: bytes,
         GENESIS_PRE_FARM_POOL_PUZZLE_HASH: bytes,
         GENESIS_PRE_FARM_FARMER_PUZZLE_HASH: bytes,
         MAX_VDF_WITNESS_SIZE: uint8,
@@ -4241,6 +4253,12 @@ class ConsensusConstants:
         NUMBER_OF_TIMESTAMPS: Union[ uint8, _Unspec] = _Unspec(),
         GENESIS_CHALLENGE: Union[ bytes32, _Unspec] = _Unspec(),
         AGG_SIG_ME_ADDITIONAL_DATA: Union[ bytes32, _Unspec] = _Unspec(),
+        AGG_SIG_PARENT_ADDITIONAL_DATA: Union[ bytes32, _Unspec] = _Unspec(),
+        AGG_SIG_PUZZLE_ADDITIONAL_DATA: Union[ bytes32, _Unspec] = _Unspec(),
+        AGG_SIG_AMOUNT_ADDITIONAL_DATA: Union[ bytes32, _Unspec] = _Unspec(),
+        AGG_SIG_PUZZLE_AMOUNT_ADDITIONAL_DATA: Union[ bytes32, _Unspec] = _Unspec(),
+        AGG_SIG_PARENT_AMOUNT_ADDITIONAL_DATA: Union[ bytes32, _Unspec] = _Unspec(),
+        AGG_SIG_PARENT_PUZZLE_ADDITIONAL_DATA: Union[ bytes32, _Unspec] = _Unspec(),
         GENESIS_PRE_FARM_POOL_PUZZLE_HASH: Union[ bytes32, _Unspec] = _Unspec(),
         GENESIS_PRE_FARM_FARMER_PUZZLE_HASH: Union[ bytes32, _Unspec] = _Unspec(),
         MAX_VDF_WITNESS_SIZE: Union[ uint8, _Unspec] = _Unspec(),

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -183,10 +183,11 @@ fn run_puzzle(
     amount: u64,
     max_cost: Cost,
     flags: u32,
+    constants: &ConsensusConstants,
 ) -> PyResult<OwnedSpendBundleConditions> {
     let mut a = make_allocator(LIMIT_HEAP);
     let conds = native_run_puzzle::<MempoolVisitor>(
-        &mut a, puzzle, solution, parent_id, amount, max_cost, flags,
+        &mut a, puzzle, solution, parent_id, amount, max_cost, flags, constants,
     )?;
     Ok(OwnedSpendBundleConditions::from(&a, conds)?)
 }

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -1,4 +1,5 @@
 use chia_consensus::allocator::make_allocator;
+use chia_consensus::consensus_constants::ConsensusConstants;
 use chia_consensus::gen::conditions::{EmptyVisitor, MempoolVisitor};
 use chia_consensus::gen::flags::ANALYZE_SPENDS;
 use chia_consensus::gen::owned_conditions::OwnedSpendBundleConditions;
@@ -19,6 +20,7 @@ pub fn run_block_generator(
     block_refs: &Bound<'_, PyList>,
     max_cost: Cost,
     flags: u32,
+    constants: &ConsensusConstants,
 ) -> PyResult<(Option<u32>, Option<OwnedSpendBundleConditions>)> {
     let mut allocator = make_allocator(flags);
 
@@ -49,7 +51,7 @@ pub fn run_block_generator(
     };
 
     Ok(
-        match run_block(&mut allocator, program, &refs, max_cost, flags) {
+        match run_block(&mut allocator, program, &refs, max_cost, flags, constants) {
             Ok(spend_bundle_conds) => {
                 let conds = OwnedSpendBundleConditions::from(&allocator, spend_bundle_conds);
                 match conds {
@@ -73,6 +75,7 @@ pub fn run_block_generator2(
     block_refs: &Bound<'_, PyList>,
     max_cost: Cost,
     flags: u32,
+    constants: &ConsensusConstants,
 ) -> PyResult<(Option<u32>, Option<OwnedSpendBundleConditions>)> {
     let mut allocator = make_allocator(flags);
 
@@ -103,7 +106,7 @@ pub fn run_block_generator2(
     };
 
     Ok(
-        match run_block(&mut allocator, program, &refs, max_cost, flags) {
+        match run_block(&mut allocator, program, &refs, max_cost, flags, constants) {
             Ok(spend_bundle_conds) => {
                 let conds = OwnedSpendBundleConditions::from(&allocator, spend_bundle_conds);
                 match conds {


### PR DESCRIPTION
as part of the condition parsing.

The message of `AGG_SIG_UNSAFE` conditions are not allowed to end with any of the suffixes used by `AGG_SIG_*` conditions (those suffixes are derived from `ADDITIONAL_DATA`, i.e. a unique identifier for the network).

This is currently validated in `pkm_pairs()` in `chia-blockchain`. This PR moves this validation into the condition parsing, to reject invalid conditions earlier. This requires `ConsensusConstants` to be passed in to run_block_generator and run_puzzle.

In `chia-blockchain`, the suffixes for the `AGG_SIG_*` conditions are computed on-the-fly. This patch also move the agg_sig_*_additional_data into ConsensusConstants instead.