### PR TITLE
[CHIA-786] Update tools to work with the hard-fork

### DIFF
--- a/crates/chia-tools/graph.gnuplot
+++ b/crates/chia-tools/graph.gnuplot
@@ -1,63 +1,66 @@
 set term png size 1200,600
 
-set output "blockchain-stack-usage.png"
-set xlabel "block height"
-set ylabel "elements"
-set title "block stack usage"
-set key top right
-plot "chain-resource-usage.dat" using 1:2 with dots title "value stack depth", \
-"chain-resource-usage.dat" using 1:3 with dots title "environment stack depth", \
-"chain-resource-usage.dat" using 1:4 with dots title "operations stack depth"
+#set output "blockchain-stack-usage.png"
+#set xlabel "block height"
+#set ylabel "elements"
+#set title "block stack usage"
+#set key top right
+#plot "chain-resource-usage.dat" using 1:2 with dots title "value stack depth", \
+#"chain-resource-usage.dat" using 1:3 with dots title "environment stack depth", \
+#"chain-resource-usage.dat" using 1:4 with dots title "operations stack depth"
 
 set output "blockchain-heap-usage.png"
 set title "block heap usage"
 set ylabel "MB"
 
-plot "chain-resource-usage.dat" using 1:($5)*8/1000000 with dots title "Atom size", \
-"chain-resource-usage.dat" using 1:($6)*8/1000000 with dots title "Pair size", \
-"chain-resource-usage.dat" using 1:($7)/1000000 with dots title "Heap size"
+plot "chain-resource-usage.dat" using 1:($2)*8/1000000 with dots title "Atom size", \
+"chain-resource-usage.dat" using 1:($3)*4/1000000 with dots title "Small Atom size", \
+"chain-resource-usage.dat" using 1:($4)*8/1000000 with dots title "Pair size", \
+"chain-resource-usage.dat" using 1:($5)/1000000 with dots title "Heap size"
 
 set output "block-execution-time.png"
 set title "block validation time"
 set ylabel "microseconds"
 
-plot "chain-resource-usage.dat" using 1:13 with dots title "block generator"
+plot "chain-resource-usage.dat" using 1:7 with dots title "block generator"
 
-set output "block-loading-time.png"
-plot "chain-resource-usage.dat" using 1:11 with dots title "block decompress + parse", \
-"chain-resource-usage.dat" using 1:12 with dots title "block reference lookup", \
-"chain-resource-usage.dat" using 1:14 with dots title "conditions`
+#set output "block-loading-time.png"
+#plot "chain-resource-usage.dat" using 1:11 with dots title "block decompress + parse", \
+#"chain-resource-usage.dat" using 1:12 with dots title "block reference lookup", \
+#"chain-resource-usage.dat" using 1:14 with dots title "conditions`
 
 set output "block-wall-clock-delta.png"
 set title "transaction block timestamp delta"
 set xlabel "s"
-plot "chain-resource-usage.dat" using 1:16 with dots title "block timestamp delta", \
+plot "chain-resource-usage.dat" using 1:9 with dots title "block timestamp delta", \
 
 set output "block-cost-vs-time.png"
-set title "block CLVM execution time versus CLVM cost"
-set xlabel "CLVM cost (millions)"
-set ylabel "CLVM execution time (s)"
+set title "block execution time versus cost"
+set xlabel "cost (millions)"
+set ylabel "execution time (s)"
+set yrange [0:*]
 set key off
-plot "chain-resource-usage.dat" using ($9/1000000):($13/1000000) with dots title "blocks", \
+plot "chain-resource-usage.dat" using ($6/1000000):($7/1000000) with dots title "blocks", \
 
-set output "blockchain-stack-usage-cdf.png"
-set xlabel "elements"
+#set output "blockchain-stack-usage-cdf.png"
+#set xlabel "elements"
 set ylabel "fraction of blocks"
-set title "block stack usage"
-set xrange [0:5000]
+#set title "block stack usage"
+#set xrange [0:5000]
 set key bottom right
-plot "chain-resource-usage-cdf.dat" using 2:1 with lines title "value stack depth", \
-"chain-resource-usage-cdf.dat" using 3:1 with lines title "environment stack depth", \
-"chain-resource-usage-cdf.dat" using 4:1 with lines title "operations stack depth"
+#plot "chain-resource-usage-cdf.dat" using 2:1 with lines title "value stack depth", \
+#"chain-resource-usage-cdf.dat" using 3:1 with lines title "environment stack depth", \
+#"chain-resource-usage-cdf.dat" using 4:1 with lines title "operations stack depth"
 
 set output "blockchain-heap-usage-cdf.png"
 set title "block heap usage"
 set xlabel "MB"
 set xrange [0:30]
 
-plot "chain-resource-usage-cdf.dat" using ($5)*8/1000000:1 with lines title "Atom size", \
-"chain-resource-usage-cdf.dat" using ($6)*8/1000000:1 with lines title "Pair size", \
-"chain-resource-usage-cdf.dat" using ($7)/1000000:1 with lines title "Heap size"
+plot "chain-resource-usage-cdf.dat" using ($2)*8/1000000:1 with lines title "Atom size", \
+"chain-resource-usage-cdf.dat" using ($3)*4/1000000:1 with lines title "Small Atom size", \
+"chain-resource-usage-cdf.dat" using ($4)*8/1000000:1 with lines title "Pair size", \
+"chain-resource-usage-cdf.dat" using ($5)/1000000:1 with lines title "Heap size"
 
 set output "blockchain-object-usage-cdf.png"
 
@@ -65,35 +68,36 @@ set title "block object usage"
 set xlabel "count (million)"
 set xrange [0:*]
 
-plot "chain-resource-usage-cdf.dat" using ($5)/1000000:1 with lines title "Allocated atoms", \
-"chain-resource-usage-cdf.dat" using ($6)/1000000:1 with lines title "Allocated pairs"
+plot "chain-resource-usage-cdf.dat" using ($2)/1000000:1 with lines title "Allocated atoms", \
+"chain-resource-usage-cdf.dat" using ($3)/1000000:1 with lines title "Allocated small atoms", \
+"chain-resource-usage-cdf.dat" using ($4)/1000000:1 with lines title "Allocated pairs"
 
 set output "blockchain-object-usage-cdf2.png"
-set xrange [0:3]
+set xrange [0:1]
 replot
 
 set output "block-execution-time-cdf.png"
 set title "block validation time"
 set xlabel "microseconds"
-set xrange [0:300000]
+set xrange [0:150000]
 
-plot "chain-resource-usage-cdf.dat" using 13:1 with lines title "block generator", \
+plot "chain-resource-usage-cdf.dat" using 7:1 with lines title "block generator", \
 
-set output "block-loading-time-cdf.png"
-set xrange [0:2000]
+#set output "block-loading-time-cdf.png"
+#set xrange [0:2000]
 
-plot "chain-resource-usage-cdf.dat" using 11:1 with lines title "block decompress + parse", \
-"chain-resource-usage-cdf.dat" using 12:1 with lines title "block reference lookup", \
-"chain-resource-usage-cdf.dat" using 14:1 with lines title "conditions"
+#plot "chain-resource-usage-cdf.dat" using 11:1 with lines title "block decompress + parse", \
+#"chain-resource-usage-cdf.dat" using 12:1 with lines title "block reference lookup", \
+#"chain-resource-usage-cdf.dat" using 14:1 with lines title "conditions"
 
 set output "block-wall-clock-delta-cdf.png"
 set title "transaction block timestamp delta"
 set xrange [0:200]
 set xlabel "s"
 
-plot "chain-resource-usage-cdf.dat" using 16:1 with lines title "block time delta (wall-clock)"
+plot "chain-resource-usage-cdf.dat" using 9:1 with lines title "block time delta (wall-clock)"
 
 set output "block-wall-clock-delta-cdf-zoom.png"
-set xrange [0:20]
+set xrange [0:60]
 
 replot

--- a/crates/chia-tools/parse-analyze-chain.py
+++ b/crates/chia-tools/parse-analyze-chain.py
@@ -2,19 +2,12 @@ from typing import Dict, List
 
 all_counters: Dict[str, List[int]] = {}
 
-keys = ["val_stack:",
-     "env_stack:",
-     "op_stack:",
-     "atoms:",
+keys = ["atoms:",
+     "small_atoms:",
      "pairs:",
      "heap:",
      "block_cost:",
-     "clvm_cost:",
-     "cond_cost:",
-     "parse_time:",
-     "ref_lookup_time:",
      "execute_time:",
-     "conditions_time:",
      "timestamp:",
      "time_delta:",
 ]
@@ -38,7 +31,7 @@ with open("chain-resource-usage.log", "r") as f:
         num_samples += 1
 
 with open("chain-resource-usage.dat", "w+") as out:
-    out.write("# ")
+    out.write("# height: ")
     for k in keys:
         out.write(f"{k} ")
     out.write(f"\n")
@@ -53,7 +46,7 @@ for k in keys:
     all_counters[k] = sorted(all_counters[k])
 
 with open("chain-resource-usage-cdf.dat", "w+") as out:
-    out.write("# ")
+    out.write("# height: ")
     for k in keys:
         out.write(f"{k} ")
     out.write(f"\n")

--- a/crates/chia-tools/src/bin/analyze-chain.rs
+++ b/crates/chia-tools/src/bin/analyze-chain.rs
@@ -1,21 +1,14 @@
 use clap::Parser;
 
-use chia_protocol::FullBlock;
-use chia_traits::Streamable;
 use std::io::Write;
 use std::time::SystemTime;
 
-use rusqlite::Connection;
-
 use chia_consensus::consensus_constants::TEST_CONSTANTS;
-use chia_consensus::gen::conditions::{parse_spends, MempoolVisitor};
-use chia_consensus::gen::flags::MEMPOOL_MODE;
-use chia_consensus::generator_rom::{COST_PER_BYTE, GENERATOR_ROM};
-use clvmr::reduction::Reduction;
-use clvmr::run_program_with_counters;
-use clvmr::serde::node_from_bytes;
+use chia_consensus::gen::conditions::EmptyVisitor;
+use chia_consensus::gen::flags::{ALLOW_BACKREFS, MEMPOOL_MODE};
+use chia_consensus::gen::run_block_generator::{run_block_generator, run_block_generator2};
+use chia_tools::iterate_tx_blocks;
 use clvmr::Allocator;
-use clvmr::ChiaDialect;
 
 /// Analyze the blocks in a chia blockchain database
 #[derive(Parser, Debug)]
@@ -41,177 +34,84 @@ struct Args {
 fn main() {
     let args = Args::parse();
 
-    let connection = Connection::open(args.file).expect("failed to open database file");
-
-    let mut statement = connection
-        .prepare(
-            "SELECT height, block \
-        FROM full_blocks \
-        WHERE height >= ? AND height <= ? AND in_main_chain=1 \
-        ORDER BY height",
-        )
-        .expect("failed to prepare SQL statement enumerating blocks");
-
-    let mut block_ref_lookup = connection
-        .prepare("SELECT block FROM full_blocks WHERE height=? and in_main_chain=1")
-        .expect("failed to prepare SQL statement looking up ref-blocks");
+    let flags = if args.mempool_mode { MEMPOOL_MODE } else { 0 } | ALLOW_BACKREFS;
 
     let mut output =
         std::fs::File::create("chain-resource-usage.log").expect("failed to open output file");
 
-    // We only create a single allocator, load it with the generator ROM and
-    // then we keep reusing it
+    // We only create a single allocator and keep reusing it
     let mut a = Allocator::new_limited(500_000_000);
-    let generator_rom =
-        node_from_bytes(&mut a, &GENERATOR_ROM).expect("failed to parse generator ROM");
     let allocator_checkpoint = a.checkpoint();
-
     let mut prev_timestamp = 0;
+    iterate_tx_blocks(
+        &args.file,
+        args.start,
+        Some(args.end),
+        |height, block, block_refs| {
+            // after the hard fork, we run blocks without paying for the
+            // CLVM generator ROM
+            let block_runner = if height >= 5_496_000 {
+                run_block_generator2::<_, EmptyVisitor>
+            } else {
+                run_block_generator::<_, EmptyVisitor>
+            };
 
-    let mut rows = statement
-        .query([args.start, args.end])
-        .expect("failed to query blocks");
-    while let Ok(Some(row)) = rows.next() {
-        let height: u32 = row.get::<_, u32>(0).expect("missing height");
-        let block_buffer: Vec<u8> = row.get(1).expect("invalid block blob");
-
-        let start_parse = SystemTime::now();
-        let block_buffer =
-            zstd::stream::decode_all(&mut std::io::Cursor::<Vec<u8>>::new(block_buffer))
-                .expect("failed to decompress block");
-        let block =
-            FullBlock::from_bytes_unchecked(&block_buffer).expect("failed to parse FullBlock");
-
-        let Some(ti) = block.transactions_info else {
-            continue;
-        };
-        let Some(ftb) = block.foliage_transaction_block else {
-            continue;
-        };
-
-        if prev_timestamp == 0 {
-            prev_timestamp = ftb.timestamp;
-        }
-        let time_delta = ftb.timestamp - prev_timestamp;
-        prev_timestamp = ftb.timestamp;
-
-        let Some(program) = block.transactions_generator else {
-            continue;
-        };
-
-        a.restore_checkpoint(&allocator_checkpoint);
-
-        let generator =
-            node_from_bytes(&mut a, program.as_ref()).expect("failed to parse block generator");
-
-        let parse_timing = start_parse.elapsed().expect("failed to get system time");
-
-        let mut args = a.nil();
-
-        let start_ref_lookup = SystemTime::now();
-        // iterate in reverse order since we're building a linked list from
-        // the tail
-        for height in block.transactions_generator_ref_list.iter().rev() {
-            let mut rows = block_ref_lookup
-                .query(rusqlite::params![height])
-                .expect("failed to look up ref-block");
-
-            let row = rows
-                .next()
-                .expect("failed to fetch block-ref row")
-                .expect("get None block-ref row");
-            let ref_block = row
-                .get::<_, Vec<u8>>(0)
-                .expect("failed to lookup block reference");
-
-            let ref_block =
-                zstd::stream::decode_all(&mut std::io::Cursor::<Vec<u8>>::new(ref_block))
-                    .expect("failed to decompress block");
-
-            let ref_block =
-                FullBlock::from_bytes_unchecked(&ref_block).expect("failed to parse ref-block");
-            let ref_gen = ref_block
+            let generator = block
                 .transactions_generator
-                .expect("block ref has no generator");
+                .as_ref()
+                .expect("transactions_generator");
 
-            let ref_gen = a
-                .new_atom(ref_gen.as_ref())
-                .expect("failed to allocate atom for ref_block");
-            args = a.new_pair(ref_gen, args).expect("failed to allocate pair");
-        }
-        let ref_lookup_timing = start_ref_lookup
-            .elapsed()
-            .expect("failed to get system time");
+            let ti = block.transactions_info.as_ref().expect("transactions_info");
 
-        let byte_cost = program.len() as u64 * COST_PER_BYTE;
+            let ftb = block
+                .foliage_transaction_block
+                .expect("foliage_transaction_block");
 
-        args = a.new_pair(args, a.nil()).expect("failed to allocate pair");
-        let args = a.new_pair(args, a.nil()).expect("failed to allocate pair");
-        let args = a
-            .new_pair(generator, args)
-            .expect("failed to allocate pair");
+            if prev_timestamp == 0 {
+                prev_timestamp = ftb.timestamp;
+            }
+            let time_delta = ftb.timestamp - prev_timestamp;
+            prev_timestamp = ftb.timestamp;
 
-        let start_execute = SystemTime::now();
-        let dialect = ChiaDialect::new(0);
-        let (counters, result) =
-            run_program_with_counters(&mut a, &dialect, generator_rom, args, ti.cost - byte_cost);
-        let execute_timing = start_execute.elapsed().expect("failed to get system time");
+            a.restore_checkpoint(&allocator_checkpoint);
 
-        let Reduction(clvm_cost, generator_output) = result.expect("block generator failed");
-
-        let start_conditions = SystemTime::now();
-        // we pass in what's left of max_cost here, to fail early in case the
-        // cost of a condition brings us over the cost limit
-        // TODO: Use real constants
-        let Ok(conds) = parse_spends::<MempoolVisitor>(
-            &a,
-            generator_output,
-            ti.cost - clvm_cost,
-            MEMPOOL_MODE,
-            &TEST_CONSTANTS,
-        ) else {
-            panic!("failed to parse conditions in block {height}");
-        };
-        let conditions_timing = start_conditions
-            .elapsed()
-            .expect("failed to get system time");
-
-        assert!(clvm_cost + byte_cost + conds.cost == ti.cost);
-        output
-            .write_fmt(format_args!(
-                "{} val_stack: {} \
-            env_stack: {} \
-            op_stack: {} \
-            atoms: {} \
-            pairs: {} \
-            heap: {} \
-            block_cost: {} \
-            clvm_cost: {} \
-            cond_cost: {} \
-            parse_time: {} \
-            ref_lookup_time: {} \
-            execute_time: {} \
-            conditions_time: {} \
-            timestamp: {} \
-            time_delta: {} \
-            \n",
-                height,
-                counters.val_stack_usage,
-                counters.env_stack_usage,
-                counters.op_stack_usage,
-                counters.atom_count,
-                counters.pair_count,
-                counters.heap_size,
+            let start_run_block = SystemTime::now();
+            let conditions = block_runner(
+                &mut a,
+                generator,
+                &block_refs,
                 ti.cost,
-                clvm_cost,
-                conds.cost,
-                parse_timing.as_micros(),
-                ref_lookup_timing.as_micros(),
-                execute_timing.as_micros(),
-                conditions_timing.as_micros(),
-                ftb.timestamp,
-                time_delta,
-            ))
-            .expect("failed to write to output file");
-    }
+                flags,
+                &TEST_CONSTANTS,
+            )
+            .expect("failed to run block generator");
+
+            let execute_timing = start_run_block
+                .elapsed()
+                .expect("failed to get system time");
+
+            assert_eq!(conditions.cost, ti.cost);
+            output
+                .write_fmt(format_args!(
+                    "{height} \
+                atoms: {} \
+                small_atoms: {} \
+                pairs: {} \
+                heap: {} \
+                block_cost: {} \
+                execute_time: {} \
+                timestamp: {} \
+                time_delta: {time_delta} \
+                \n",
+                    a.atom_count(),
+                    a.small_atom_count(),
+                    a.pair_count(),
+                    a.heap_size(),
+                    ti.cost,
+                    execute_timing.as_micros(),
+                    ftb.timestamp,
+                ))
+                .expect("failed to write to output file");
+        },
+    );
 }


### PR DESCRIPTION
The main change is to make `analyze-chain` use `run_block_generator()` and to also make `test-block-generators` correctly switch to `run_block_generator2()` at the hard fork block height.

Since `analyze-chain` is changed to use `run_block_generator()` instead of `run_program_with_counters()` it can no longer collect operator- and stack size counters. The output is changed and the log parser scripts are updated to account for this.

Example output from `analyze-chain`:

![block-wall-clock-delta-cdf](https://github.com/Chia-Network/chia_rs/assets/661450/941fdc4a-39df-42db-b6b7-e0a690b2e2fa)
![block-execution-time-cdf](https://github.com/Chia-Network/chia_rs/assets/661450/8b7b0ceb-c558-4b22-9289-5acefb8a8c12)
