### PR TITLE
Fix pymethods by moving outside of pybindings modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ future_incompatible = { level = "deny", priority = -1 }
 nonstandard_style = { level = "deny", priority = -1 }
 unsafe_code = "deny"
 non_ascii_idents = "deny"
-unused_imports = "deny"
+unused_imports = "warn"
 unused_import_braces = "deny"
 unreachable_code = "deny"
 unreachable_patterns = "deny"

--- a/crates/chia-bls/src/gtelement.rs
+++ b/crates/chia-bls/src/gtelement.rs
@@ -102,33 +102,34 @@ impl Streamable for GTElement {
 }
 
 #[cfg(feature = "py-bindings")]
+#[pyo3::pymethods]
+impl GTElement {
+    #[classattr]
+    #[pyo3(name = "SIZE")]
+    pub const PY_SIZE: usize = Self::SIZE;
+
+    pub fn __str__(&self) -> String {
+        hex::encode(self.to_bytes())
+    }
+
+    #[must_use]
+    pub fn __mul__(&self, rhs: &Self) -> Self {
+        let mut ret = self.clone();
+        ret *= rhs;
+        ret
+    }
+
+    pub fn __imul__(&mut self, rhs: &Self) {
+        *self *= rhs;
+    }
+}
+
+#[cfg(feature = "py-bindings")]
 mod pybindings {
     use super::*;
 
     use chia_traits::{FromJsonDict, ToJsonDict};
     use pyo3::{exceptions::PyValueError, prelude::*};
-
-    #[pymethods]
-    impl GTElement {
-        #[classattr]
-        #[pyo3(name = "SIZE")]
-        const PY_SIZE: usize = Self::SIZE;
-
-        fn __str__(&self) -> String {
-            hex::encode(self.to_bytes())
-        }
-
-        #[must_use]
-        pub fn __mul__(&self, rhs: &Self) -> Self {
-            let mut ret = self.clone();
-            ret *= rhs;
-            ret
-        }
-
-        pub fn __imul__(&mut self, rhs: &Self) {
-            *self *= rhs;
-        }
-    }
 
     impl ToJsonDict for GTElement {
         fn to_json_dict(&self, py: Python<'_>) -> PyResult<PyObject> {

--- a/crates/chia-bls/src/public_key.rs
+++ b/crates/chia-bls/src/public_key.rs
@@ -296,6 +296,7 @@ pub fn hash_to_g1_with_dst(msg: &[u8], dst: &[u8]) -> PublicKey {
     PublicKey(p1)
 }
 
+#[cfg(feature = "py-bindings")]
 #[pyo3::pymethods]
 impl PublicKey {
     #[classattr]

--- a/crates/chia-bls/src/secret_key.rs
+++ b/crates/chia-bls/src/secret_key.rs
@@ -236,47 +236,49 @@ impl DerivableKey for SecretKey {
     }
 }
 
+#[pyo3::pymethods]
+impl SecretKey {
+    #[classattr]
+    pub const PRIVATE_KEY_SIZE: usize = 32;
+
+    pub fn sign_g2(&self, msg: &[u8]) -> crate::Signature {
+        crate::sign(self, msg)
+    }
+
+    pub fn get_g1(&self) -> PublicKey {
+        self.public_key()
+    }
+
+    #[pyo3(name = "public_key")]
+    pub fn py_public_key(&self) -> PublicKey {
+        self.public_key()
+    }
+
+    pub fn __str__(&self) -> String {
+        hex::encode(self.to_bytes())
+    }
+
+    #[pyo3(name = "derive_hardened")]
+    #[must_use]
+    pub fn py_derive_hardened(&self, idx: u32) -> Self {
+        self.derive_hardened(idx)
+    }
+
+    #[pyo3(name = "derive_unhardened")]
+    #[must_use]
+    pub fn py_derive_unhardened(&self, idx: u32) -> Self {
+        self.derive_unhardened(idx)
+    }
+}
+
 #[cfg(feature = "py-bindings")]
 mod pybindings {
     use super::*;
 
-    use crate::{parse_hex::parse_hex_string, PublicKey, Signature};
+    use crate::parse_hex::parse_hex_string;
 
     use chia_traits::{FromJsonDict, ToJsonDict};
     use pyo3::prelude::*;
-
-    #[pymethods]
-    impl SecretKey {
-        #[classattr]
-        const PRIVATE_KEY_SIZE: usize = 32;
-
-        fn sign_g2(&self, msg: &[u8]) -> Signature {
-            crate::sign(self, msg)
-        }
-
-        fn get_g1(&self) -> PublicKey {
-            self.public_key()
-        }
-
-        #[pyo3(name = "public_key")]
-        fn py_public_key(&self) -> PublicKey {
-            self.public_key()
-        }
-
-        fn __str__(&self) -> String {
-            hex::encode(self.to_bytes())
-        }
-
-        #[pyo3(name = "derive_hardened")]
-        fn py_derive_hardened(&self, idx: u32) -> Self {
-            self.derive_hardened(idx)
-        }
-
-        #[pyo3(name = "derive_unhardened")]
-        fn py_derive_unhardened(&self, idx: u32) -> Self {
-            self.derive_unhardened(idx)
-        }
-    }
 
     impl ToJsonDict for SecretKey {
         fn to_json_dict(&self, py: Python<'_>) -> PyResult<PyObject> {

--- a/crates/chia-bls/src/secret_key.rs
+++ b/crates/chia-bls/src/secret_key.rs
@@ -236,6 +236,7 @@ impl DerivableKey for SecretKey {
     }
 }
 
+#[cfg(feature = "py-bindings")]
 #[pyo3::pymethods]
 impl SecretKey {
     #[classattr]

--- a/crates/chia-bls/src/signature.rs
+++ b/crates/chia-bls/src/signature.rs
@@ -10,7 +10,7 @@ use std::mem::MaybeUninit;
 use std::ops::{Add, AddAssign, Neg, SubAssign};
 
 // we use the augmented scheme
-pub const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_";
+pub(crate) const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_";
 
 #[cfg_attr(
     feature = "py-bindings",
@@ -475,6 +475,41 @@ pub fn sign<Msg: AsRef<[u8]>>(sk: &SecretKey, msg: Msg) -> Signature {
     sign_raw(sk, aug_msg)
 }
 
+#[pyo3::pymethods]
+impl Signature {
+    #[classattr]
+    pub const SIZE: usize = 96;
+
+    #[new]
+    pub fn init() -> Self {
+        Self::default()
+    }
+
+    #[pyo3(name = "pair")]
+    pub fn py_pair(&self, other: &PublicKey) -> GTElement {
+        self.pair(other)
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "generator")]
+    pub fn py_generator() -> Self {
+        Self::generator()
+    }
+
+    pub fn __str__(&self) -> String {
+        hex::encode(self.to_bytes())
+    }
+
+    #[must_use]
+    pub fn __add__(&self, rhs: &Self) -> Self {
+        self + rhs
+    }
+
+    pub fn __iadd__(&mut self, rhs: &Self) {
+        *self += rhs;
+    }
+}
+
 #[cfg(feature = "py-bindings")]
 mod pybindings {
     use super::*;
@@ -483,41 +518,6 @@ mod pybindings {
 
     use chia_traits::{FromJsonDict, ToJsonDict};
     use pyo3::prelude::*;
-
-    #[pymethods]
-    impl Signature {
-        #[classattr]
-        const SIZE: usize = 96;
-
-        #[new]
-        pub fn init() -> Self {
-            Self::default()
-        }
-
-        #[pyo3(name = "pair")]
-        pub fn py_pair(&self, other: &PublicKey) -> GTElement {
-            self.pair(other)
-        }
-
-        #[staticmethod]
-        #[pyo3(name = "generator")]
-        pub fn py_generator() -> Self {
-            Self::generator()
-        }
-
-        fn __str__(&self) -> String {
-            hex::encode(self.to_bytes())
-        }
-
-        #[must_use]
-        pub fn __add__(&self, rhs: &Self) -> Self {
-            self + rhs
-        }
-
-        pub fn __iadd__(&mut self, rhs: &Self) {
-            *self += rhs;
-        }
-    }
 
     impl ToJsonDict for Signature {
         fn to_json_dict(&self, py: Python<'_>) -> PyResult<PyObject> {

--- a/crates/chia-bls/src/signature.rs
+++ b/crates/chia-bls/src/signature.rs
@@ -475,6 +475,7 @@ pub fn sign<Msg: AsRef<[u8]>>(sk: &SecretKey, msg: Msg) -> Signature {
     sign_raw(sk, aug_msg)
 }
 
+#[cfg(feature = "py-bindings")]
 #[pyo3::pymethods]
 impl Signature {
     #[classattr]


### PR DESCRIPTION
There is a bug in `pyo3` (or at least, it seems like a bug), that prevents methods defined in `pymethods` from being visible to Python if they are defined within a different module (with a `#[cfg(feature = "py-bindings")]`, notably).