### PR TITLE
Add python source to `Cargo.toml`

### DIFF
--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -17,6 +17,9 @@ name = "chia_rs"
 crate-type = ["cdylib"]
 path = "src/lib.rs"
 
+[package.metadata.maturin]
+python-source = "python"
+
 [dependencies]
 clvmr = { workspace = true }
 hex = { workspace = true }

--- a/wheel/pyproject.toml
+++ b/wheel/pyproject.toml
@@ -6,3 +6,4 @@ build-backend = "maturin"
 bindings = "pyo3"
 features = ["pyo3/extension-module"]
 python-source = "python"
+include = ["python/chia_rs/chia_rs.pyi"]

--- a/wheel/pyproject.toml
+++ b/wheel/pyproject.toml
@@ -6,4 +6,3 @@ build-backend = "maturin"
 bindings = "pyo3"
 features = ["pyo3/extension-module"]
 python-source = "python"
-include = ["python/chia_rs/chia_rs.pyi"]


### PR DESCRIPTION
I made this because it allows me to specify a specific commit to install `chia_rs` from with pip.  Without this entry, the stub file doesn't come along and mypy doesn't function properly.  The `chia-blockchain` CI has some difficulties with this but I think that's because it is manually building it when installing from the commit rather than installing from a published version.  I'm not entirely sure how to check that though so some input on how reasonable this seems would be appreciated.