### PR TITLE
CHIA-622 switch to use clvmr hashing only + clvm_rs 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
  "chia-traits 0.10.0",
  "clvm-traits",
  "clvm-utils",
+ "clvmr",
 ]
 
 [[package]]
@@ -316,6 +317,7 @@ dependencies = [
  "blst",
  "chia-traits 0.10.0",
  "chia_py_streamable_macro",
+ "clvmr",
  "criterion",
  "hex",
  "hkdf",
@@ -370,7 +372,6 @@ dependencies = [
  "pyo3",
  "rand",
  "rstest",
- "sha2",
  "text-diff",
  "thiserror",
 ]
@@ -404,7 +405,6 @@ dependencies = [
  "hex",
  "pyo3",
  "rstest",
- "sha2",
 ]
 
 [[package]]
@@ -418,7 +418,6 @@ dependencies = [
  "clvmr",
  "hex",
  "libfuzzer-sys",
- "sha2",
 ]
 
 [[package]]
@@ -434,7 +433,6 @@ dependencies = [
  "hex",
  "hex-literal",
  "num-bigint",
- "sha2",
 ]
 
 [[package]]
@@ -497,8 +495,8 @@ name = "chia-traits"
 version = "0.10.0"
 dependencies = [
  "chia_streamable_macro 0.10.0",
+ "clvmr",
  "pyo3",
- "sha2",
  "thiserror",
 ]
 
@@ -527,7 +525,6 @@ dependencies = [
  "clvmr",
  "hex",
  "pyo3",
- "sha2",
 ]
 
 [[package]]
@@ -546,6 +543,7 @@ dependencies = [
 name = "chia_streamable_macro"
 version = "0.10.0"
 dependencies = [
+ "clvmr",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -672,9 +670,7 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b05784a842671ccedbefb0e3dabab7d0eb3411395f5182a4c68722a5284591"
+version = "0.8.0"
 dependencies = [
  "chia-bls 0.4.0",
  "hex-literal",
@@ -683,6 +679,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "openssl",
  "p256",
  "sha2",
 ]
@@ -953,6 +950,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1527,6 +1539,54 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "openssl"
+version = "0.10.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.70",
+]
+
+[[package]]
+name = "openssl-src"
+version = "300.3.1+3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "p256"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ chia-traits = { workspace = true, optional = true }
 chia-puzzles = { workspace = true, optional = true }
 clvm-traits = { workspace = true, optional = true }
 clvm-utils = { workspace = true, optional = true }
+clvmr = { workspace = true}
 
 [features]
 default = [
@@ -83,6 +84,8 @@ puzzles = ["dep:chia-puzzles"]
 clvm-traits = ["dep:clvm-traits"]
 clvm-utils = ["dep:clvm-utils"]
 
+openssl = ["clvmr/openssl"] # enable openssl for clvmr on unix
+
 [profile.release]
 lto = "thin"
 
@@ -101,13 +104,12 @@ clvm-utils = { path = "./crates/clvm-utils", version = "0.10.0" }
 clvm-derive = { path = "./crates/clvm-derive", version = "0.10.0" }
 chia-fuzz = { path = "./crates/chia-consensus/fuzz", version = "0.10.0" }
 blst = { version = "0.3.12", features = ["portable"] }
-clvmr = "0.7.0"
+clvmr = "0.8.0"
 syn = "2.0.70"
 quote = "1.0.32"
 proc-macro2 = "1.0.84"
 proc-macro-crate = "1.3.1"
 anyhow = "1.0.86"
-sha2 = "0.10.8"
 hkdf = "0.12.0"
 hex = "0.4.3"
 thiserror = "1.0.61"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ chia-traits = { workspace = true, optional = true }
 chia-puzzles = { workspace = true, optional = true }
 clvm-traits = { workspace = true, optional = true }
 clvm-utils = { workspace = true, optional = true }
-clvmr = { workspace = true}
+clvmr = { workspace = true }
 
 [features]
 default = [
@@ -84,7 +84,7 @@ puzzles = ["dep:chia-puzzles"]
 clvm-traits = ["dep:clvm-traits"]
 clvm-utils = ["dep:clvm-utils"]
 
-openssl = ["clvmr/openssl"] # enable openssl for clvmr on unix
+openssl = ["clvmr/openssl"]
 
 [profile.release]
 lto = "thin"
@@ -110,6 +110,7 @@ quote = "1.0.32"
 proc-macro2 = "1.0.84"
 proc-macro-crate = "1.3.1"
 anyhow = "1.0.86"
+sha2 = "0.10.8"
 hkdf = "0.12.0"
 hex = "0.4.3"
 thiserror = "1.0.61"

--- a/crates/chia-bls/Cargo.toml
+++ b/crates/chia-bls/Cargo.toml
@@ -19,7 +19,8 @@ arbitrary = ["dep:arbitrary"]
 chia-traits = { workspace = true }
 chia_py_streamable_macro = { workspace = true, optional = true }
 anyhow = { workspace = true }
-sha2 = { workspace = true }
+sha2 = {version = "0.10.8"}
+clvmr = { workspace = true }
 hkdf = { workspace = true }
 blst = { workspace = true }
 hex = { workspace = true }

--- a/crates/chia-bls/Cargo.toml
+++ b/crates/chia-bls/Cargo.toml
@@ -19,7 +19,7 @@ arbitrary = ["dep:arbitrary"]
 chia-traits = { workspace = true }
 chia_py_streamable_macro = { workspace = true, optional = true }
 anyhow = { workspace = true }
-sha2 = {version = "0.10.8"}
+sha2 = { workspace = true }
 clvmr = { workspace = true }
 hkdf = { workspace = true }
 blst = { workspace = true }

--- a/crates/chia-bls/src/bls_cache.rs
+++ b/crates/chia-bls/src/bls_cache.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 use std::num::NonZeroUsize;
 
 use lru::LruCache;
-use sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 
 use crate::{aggregate_verify_gt, hash_to_g2};
 use crate::{GTElement, PublicKey, Signature};
@@ -55,7 +55,7 @@ impl BlsCache {
             let mut hasher = Sha256::new();
             hasher.update(pk.borrow().to_bytes());
             hasher.update(msg.as_ref());
-            let hash: [u8; 32] = hasher.finalize().into();
+            let hash: [u8; 32] = hasher.finalize();
 
             // If the pairing is in the cache, we don't need to recalculate it.
             if let Some(pairing) = self.cache.get(&hash).cloned() {
@@ -69,7 +69,7 @@ impl BlsCache {
 
             let mut hasher = Sha256::new();
             hasher.update(&aug_msg);
-            let hash: [u8; 32] = hasher.finalize().into();
+            let hash: [u8; 32] = hasher.finalize();
 
             let pairing = aug_hash.pair(pk.borrow());
             self.cache.put(hash, pairing.clone());
@@ -272,7 +272,7 @@ pub mod tests {
 
         let mut hasher = Sha256::new();
         hasher.update(aug_msg);
-        let hash: [u8; 32] = hasher.finalize().into();
+        let hash: [u8; 32] = hasher.finalize();
 
         // The first key should have been removed, since it's the oldest that's been accessed.
         assert!(!bls_cache.cache.contains(&hash));

--- a/crates/chia-bls/src/bls_cache.rs
+++ b/crates/chia-bls/src/bls_cache.rs
@@ -1,8 +1,8 @@
 use std::borrow::Borrow;
 use std::num::NonZeroUsize;
 
-use lru::LruCache;
 use clvmr::sha2::Sha256;
+use lru::LruCache;
 
 use crate::{aggregate_verify_gt, hash_to_g2};
 use crate::{GTElement, PublicKey, Signature};

--- a/crates/chia-bls/src/gtelement.rs
+++ b/crates/chia-bls/src/gtelement.rs
@@ -1,7 +1,7 @@
 use blst::*;
 use chia_traits::chia_error::Result;
 use chia_traits::{read_bytes, Streamable};
-use sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::io::Cursor;

--- a/crates/chia-bls/src/public_key.rs
+++ b/crates/chia-bls/src/public_key.rs
@@ -3,7 +3,7 @@ use crate::{DerivableKey, Error, Result};
 
 use blst::*;
 use chia_traits::{read_bytes, Streamable};
-use sha2::{digest::FixedOutput, Digest, Sha256};
+use clvmr::sha2::Sha256;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::io::Cursor;
@@ -143,7 +143,7 @@ impl PublicKey {
     pub fn get_fingerprint(&self) -> u32 {
         let mut hasher = Sha256::new();
         hasher.update(self.to_bytes());
-        let hash: [u8; 32] = hasher.finalize_fixed().into();
+        let hash: [u8; 32] = hasher.finalize();
         u32::from_be_bytes(hash[0..4].try_into().unwrap())
     }
 }
@@ -252,7 +252,7 @@ impl DerivableKey for PublicKey {
         let mut hasher = Sha256::new();
         hasher.update(self.to_bytes());
         hasher.update(idx.to_be_bytes());
-        let digest: [u8; 32] = hasher.finalize_fixed().into();
+        let digest: [u8; 32] = hasher.finalize();
 
         let p1 = unsafe {
             let mut nonce = MaybeUninit::<blst_scalar>::uninit();

--- a/crates/chia-bls/src/secret_key.rs
+++ b/crates/chia-bls/src/secret_key.rs
@@ -2,7 +2,7 @@ use crate::{DerivableKey, Error, PublicKey, Result};
 use blst::*;
 use chia_traits::{read_bytes, Streamable};
 use hkdf::HkdfExtract;
-use sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::io::Cursor;
@@ -35,7 +35,7 @@ fn flip_bits(input: [u8; 32]) -> [u8; 32] {
 }
 
 fn ikm_to_lamport_sk(ikm: &[u8; 32], salt: [u8; 4]) -> [u8; 255 * 32] {
-    let mut extracter = HkdfExtract::<Sha256>::new(Some(&salt));
+    let mut extracter = HkdfExtract::<sha2::Sha256>::new(Some(&salt));
     extracter.input_ikm(ikm);
     let (_, h) = extracter.finalize();
 
@@ -63,13 +63,13 @@ fn to_lamport_pk(ikm: [u8; 32], idx: u32) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(lamport0);
     hasher.update(lamport1);
-    hasher.finalize().into()
+    hasher.finalize()
 }
 
 fn sha256(bytes: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
-    hasher.finalize().into()
+    hasher.finalize()
 }
 
 pub fn is_all_zero(buf: &[u8]) -> bool {

--- a/crates/chia-bls/src/secret_key.rs
+++ b/crates/chia-bls/src/secret_key.rs
@@ -1,8 +1,8 @@
 use crate::{DerivableKey, Error, PublicKey, Result};
 use blst::*;
 use chia_traits::{read_bytes, Streamable};
-use hkdf::HkdfExtract;
 use clvmr::sha2::Sha256;
+use hkdf::HkdfExtract;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::io::Cursor;

--- a/crates/chia-bls/src/signature.rs
+++ b/crates/chia-bls/src/signature.rs
@@ -1,7 +1,7 @@
 use crate::{Error, GTElement, PublicKey, Result, SecretKey};
 use blst::*;
 use chia_traits::{read_bytes, Streamable};
-use sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 use std::borrow::Borrow;
 use std::fmt;
 use std::hash::{Hash, Hasher};

--- a/crates/chia-consensus/Cargo.toml
+++ b/crates/chia-consensus/Cargo.toml
@@ -18,7 +18,6 @@ py-bindings = ["dep:pyo3", "dep:chia_py_streamable_macro"]
 clvmr = { workspace = true }
 hex = { workspace = true }
 pyo3 = { workspace = true, optional = true }
-sha2 = { workspace = true }
 chia_streamable_macro = { workspace = true }
 chia_py_streamable_macro = { workspace = true, optional = true }
 clvm-utils = { workspace = true }

--- a/crates/chia-consensus/fuzz/fuzz_targets/merkle-set.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/merkle-set.rs
@@ -1,6 +1,6 @@
 #![no_main]
 use chia_consensus::merkle_tree::{validate_merkle_proof, MerkleSet};
-use clvmr::sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -19,7 +19,7 @@ fuzz_target!(|data: &[u8]| {
     // proofs-of-exclusion
     let mut hasher = Sha256::new();
     hasher.update(data);
-    leafs.push(hasher.finalize().into());
+    leafs.push(hasher.finalize());
 
     for (idx, item) in leafs.iter().enumerate() {
         let expect_included = idx < num_leafs;

--- a/crates/chia-consensus/src/gen/coin_id.rs
+++ b/crates/chia-consensus/src/gen/coin_id.rs
@@ -1,6 +1,6 @@
 use chia_protocol::Bytes32;
 use clvmr::allocator::{Allocator, NodePtr};
-use clvmr::sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 
 pub fn compute_coin_id(
     a: &Allocator,
@@ -12,7 +12,7 @@ pub fn compute_coin_id(
     hasher.update(a.atom(parent_id));
     hasher.update(a.atom(puzzle_hash));
     hasher.update(amount);
-    let coin_id: [u8; 32] = hasher.finalize().into();
+    let coin_id: [u8; 32] = hasher.finalize();
     coin_id.into()
 }
 

--- a/crates/chia-consensus/src/gen/conditions.rs
+++ b/crates/chia-consensus/src/gen/conditions.rs
@@ -25,7 +25,7 @@ use chia_bls::PublicKey;
 use chia_protocol::Bytes32;
 use clvmr::allocator::{Allocator, NodePtr, SExp};
 use clvmr::cost::Cost;
-use clvmr::sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 use std::cmp::{max, min};
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
@@ -1369,7 +1369,7 @@ pub fn validate_conditions(
             let mut hasher = Sha256::new();
             hasher.update(*coin_id);
             hasher.update(a.atom(announce));
-            let announcement_id: [u8; 32] = hasher.finalize().into();
+            let announcement_id: [u8; 32] = hasher.finalize();
             announcements.insert(announcement_id.into());
         }
 
@@ -1412,7 +1412,7 @@ pub fn validate_conditions(
             let mut hasher = Sha256::new();
             hasher.update(a.atom(puzzle_hash));
             hasher.update(a.atom(announce));
-            let announcement_id: [u8; 32] = hasher.finalize().into();
+            let announcement_id: [u8; 32] = hasher.finalize();
             announcements.insert(announcement_id.into());
         }
 
@@ -1556,7 +1556,7 @@ fn test_coin_id(parent_id: &[u8; 32], puzzle_hash: &[u8; 32], amount: u64) -> By
     hasher.update(puzzle_hash);
     let buf = u64_to_bytes(amount);
     hasher.update(&buf);
-    let coin_id: [u8; 32] = hasher.finalize().into();
+    let coin_id: [u8; 32] = hasher.finalize();
     coin_id.into()
 }
 

--- a/crates/chia-consensus/src/gen/get_puzzle_and_solution.rs
+++ b/crates/chia-consensus/src/gen/get_puzzle_and_solution.rs
@@ -71,13 +71,13 @@ fn u64_to_bytes(n: u64) -> Vec<u8> {
 }
 
 #[cfg(test)]
-use clvmr::sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 
 #[cfg(test)]
 fn make_dummy_id(seed: u64) -> Bytes32 {
     let mut sha256 = Sha256::new();
     sha256.update(seed.to_be_bytes());
-    let id: [u8; 32] = sha256.finalize().into();
+    let id: [u8; 32] = sha256.finalize();
     id.into()
 }
 

--- a/crates/chia-consensus/src/merkle_set.rs
+++ b/crates/chia-consensus/src/merkle_set.rs
@@ -1,4 +1,4 @@
-use clvmr::sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 use hex_literal::hex;
 
 fn get_bit(val: &[u8; 32], bit: u8) -> u8 {
@@ -39,7 +39,7 @@ pub(crate) fn hash(
     hasher.update([encode_type(ltype), encode_type(rtype)]);
     hasher.update(left);
     hasher.update(right);
-    hasher.finalize().into()
+    hasher.finalize()
 }
 
 pub(crate) const BLANK: [u8; 32] =
@@ -167,7 +167,7 @@ pub fn compute_merkle_set_root(leafs: &mut [[u8; 32]]) -> [u8; 32] {
             let mut hasher = Sha256::new();
             hasher.update([NodeType::Term as u8]);
             hasher.update(hash);
-            hasher.finalize().into()
+            hasher.finalize()
         }
         (hash, NodeType::Mid | NodeType::MidDbl) => hash,
         (_, NodeType::Empty) => panic!("unexpected"),
@@ -182,7 +182,7 @@ pub mod test {
         let mut hasher = Sha256::new();
         hasher.update(buf1);
         hasher.update(buf2);
-        hasher.finalize().into()
+        hasher.finalize()
     }
 
     const PREFIX: [u8; 30] = hex!("000000000000000000000000000000000000000000000000000000000000");
@@ -193,7 +193,7 @@ pub mod test {
         hasher.update(buf1);
         hasher.update(buf2);
         hasher.update(buf3);
-        hasher.finalize().into()
+        hasher.finalize()
     }
 
     #[test]

--- a/crates/chia-consensus/src/merkle_tree.rs
+++ b/crates/chia-consensus/src/merkle_tree.rs
@@ -7,7 +7,7 @@ use hex_literal::hex;
 use chia_protocol::Bytes32;
 #[cfg(feature = "py-bindings")]
 use chia_traits::ChiaToPython;
-use clvmr::sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 #[cfg(feature = "py-bindings")]
 use pyo3::exceptions::PyValueError;
 #[cfg(feature = "py-bindings")]
@@ -388,7 +388,7 @@ fn hash_leaf(leaf: &[u8; 32]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update([NodeType::Term as u8]);
     hasher.update(leaf);
-    hasher.finalize().into()
+    hasher.finalize()
 }
 
 impl MerkleSet {

--- a/crates/chia-protocol/Cargo.toml
+++ b/crates/chia-protocol/Cargo.toml
@@ -17,7 +17,6 @@ arbitrary = ["dep:arbitrary", "chia-bls/arbitrary"]
 
 [dependencies]
 pyo3 = { workspace = true, features = ["multiple-pymethods", "num-bigint"], optional = true }
-sha2 = { workspace = true }
 hex = { workspace = true }
 chia_streamable_macro = { workspace = true }
 chia_py_streamable_macro = { workspace = true, optional = true }

--- a/crates/chia-protocol/fuzz/Cargo.toml
+++ b/crates/chia-protocol/fuzz/Cargo.toml
@@ -18,7 +18,6 @@ chia-traits = { workspace = true }
 clvm-traits = { workspace = true }
 chia-protocol = { workspace = true, features = ["arbitrary"] }
 arbitrary = { workspace = true }
-sha2 = { workspace = true }
 hex = { workspace = true }
 
 [[bin]]

--- a/crates/chia-protocol/fuzz/fuzz_targets/streamable.rs
+++ b/crates/chia-protocol/fuzz/fuzz_targets/streamable.rs
@@ -3,7 +3,7 @@ use arbitrary::{Arbitrary, Unstructured};
 use chia_protocol::*;
 use chia_traits::Streamable;
 use libfuzzer_sys::fuzz_target;
-use sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 
 pub fn test_streamable<T: Streamable + std::fmt::Debug + PartialEq>(obj: &T) {
     let bytes = obj.to_bytes().unwrap();
@@ -21,7 +21,7 @@ pub fn test_streamable<T: Streamable + std::fmt::Debug + PartialEq>(obj: &T) {
 
     let mut ctx = Sha256::new();
     ctx.update(&bytes);
-    let expect_hash: [u8; 32] = ctx.finalize().into();
+    let expect_hash: [u8; 32] = ctx.finalize();
     assert_eq!(obj.hash(), expect_hash);
 
     // make sure input too large is an error

--- a/crates/chia-protocol/fuzz/fuzz_targets/streamable.rs
+++ b/crates/chia-protocol/fuzz/fuzz_targets/streamable.rs
@@ -2,8 +2,8 @@
 use arbitrary::{Arbitrary, Unstructured};
 use chia_protocol::*;
 use chia_traits::Streamable;
-use libfuzzer_sys::fuzz_target;
 use clvmr::sha2::Sha256;
+use libfuzzer_sys::fuzz_target;
 
 pub fn test_streamable<T: Streamable + std::fmt::Debug + PartialEq>(obj: &T) {
     let bytes = obj.to_bytes().unwrap();

--- a/crates/chia-protocol/src/bytes.rs
+++ b/crates/chia-protocol/src/bytes.rs
@@ -1,7 +1,7 @@
 use chia_traits::{chia_error, read_bytes, Streamable};
 use clvm_traits::{ClvmDecoder, ClvmEncoder, FromClvm, FromClvmError, ToClvm, ToClvmError};
 use clvm_utils::TreeHash;
-use sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 use std::array::TryFromSliceError;
 use std::fmt;
 use std::io::Cursor;

--- a/crates/chia-protocol/src/coin.rs
+++ b/crates/chia-protocol/src/coin.rs
@@ -4,7 +4,7 @@ use clvm_traits::{
     clvm_list, destructure_list, match_list, ClvmDecoder, ClvmEncoder, FromClvm, FromClvmError,
     ToClvm, ToClvmError,
 };
-use sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 
 #[cfg(feature = "py-bindings")]
 use pyo3::prelude::*;

--- a/crates/chia-protocol/src/program.rs
+++ b/crates/chia-protocol/src/program.rs
@@ -10,8 +10,8 @@ use clvmr::serde::{
     node_from_bytes, node_from_bytes_backrefs, node_to_bytes, serialized_length_from_bytes,
     serialized_length_from_bytes_trusted,
 };
-use clvmr::{Allocator, ChiaDialect};
 use clvmr::sha2::Sha256;
+use clvmr::{Allocator, ChiaDialect};
 use std::io::Cursor;
 use std::ops::Deref;
 

--- a/crates/chia-protocol/src/program.rs
+++ b/crates/chia-protocol/src/program.rs
@@ -11,7 +11,7 @@ use clvmr::serde::{
     serialized_length_from_bytes_trusted,
 };
 use clvmr::{Allocator, ChiaDialect};
-use sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 use std::io::Cursor;
 use std::ops::Deref;
 

--- a/crates/chia-puzzles/Cargo.toml
+++ b/crates/chia-puzzles/Cargo.toml
@@ -16,7 +16,6 @@ arbitrary = ["dep:arbitrary", "chia-protocol/arbitrary"]
 
 [dependencies]
 clvmr = { workspace = true }
-sha2 = { workspace = true }
 num-bigint = { workspace = true }
 hex-literal = { workspace = true }
 clvm-utils = { workspace = true }

--- a/crates/chia-puzzles/src/derive_synthetic.rs
+++ b/crates/chia-puzzles/src/derive_synthetic.rs
@@ -1,8 +1,8 @@
+use crate::standard::DEFAULT_HIDDEN_PUZZLE_HASH;
 use chia_bls::{PublicKey, SecretKey};
+use clvmr::sha2::Sha256;
 use hex_literal::hex;
 use num_bigint::BigInt;
-use clvmr::sha2::Sha256;
-use crate::standard::DEFAULT_HIDDEN_PUZZLE_HASH;
 
 const GROUP_ORDER_BYTES: [u8; 32] =
     hex!("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001");

--- a/crates/chia-puzzles/src/derive_synthetic.rs
+++ b/crates/chia-puzzles/src/derive_synthetic.rs
@@ -1,8 +1,7 @@
 use chia_bls::{PublicKey, SecretKey};
 use hex_literal::hex;
 use num_bigint::BigInt;
-use sha2::{digest::FixedOutput, Digest, Sha256};
-
+use clvmr::sha2::Sha256;
 use crate::standard::DEFAULT_HIDDEN_PUZZLE_HASH;
 
 const GROUP_ORDER_BYTES: [u8; 32] =
@@ -52,7 +51,7 @@ fn synthetic_offset(public_key: &PublicKey, hidden_puzzle_hash: &[u8; 32]) -> Se
     let mut hasher = Sha256::new();
     hasher.update(public_key.to_bytes());
     hasher.update(hidden_puzzle_hash);
-    let bytes: [u8; 32] = hasher.finalize_fixed().into();
+    let bytes: [u8; 32] = hasher.finalize();
     SecretKey::from_bytes(&mod_by_group_order(bytes)).unwrap()
 }
 

--- a/crates/chia-puzzles/src/derive_synthetic.rs
+++ b/crates/chia-puzzles/src/derive_synthetic.rs
@@ -1,8 +1,9 @@
-use crate::standard::DEFAULT_HIDDEN_PUZZLE_HASH;
 use chia_bls::{PublicKey, SecretKey};
 use clvmr::sha2::Sha256;
 use hex_literal::hex;
 use num_bigint::BigInt;
+
+use crate::standard::DEFAULT_HIDDEN_PUZZLE_HASH;
 
 const GROUP_ORDER_BYTES: [u8; 32] =
     hex!("73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001");

--- a/crates/chia-traits/Cargo.toml
+++ b/crates/chia-traits/Cargo.toml
@@ -15,5 +15,5 @@ py-bindings = ["dep:pyo3"]
 [dependencies]
 pyo3 = { workspace = true, features = ["multiple-pymethods"], optional = true }
 chia_streamable_macro = { workspace = true }
-sha2 = { workspace = true }
+clvmr = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/chia-traits/src/streamable.rs
+++ b/crates/chia-traits/src/streamable.rs
@@ -1,5 +1,5 @@
 use crate::chia_error::{Error, Result};
-use sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 use std::io::Cursor;
 use std::mem;
 
@@ -69,7 +69,7 @@ pub trait Streamable {
     fn hash(&self) -> [u8; 32] {
         let mut ctx = Sha256::new();
         self.update_digest(&mut ctx);
-        ctx.finalize().into()
+        ctx.finalize()
     }
 }
 

--- a/crates/chia_py_streamable_macro/src/lib.rs
+++ b/crates/chia_py_streamable_macro/src/lib.rs
@@ -217,9 +217,9 @@ pub fn py_streamable_macro(input: proc_macro::TokenStream) -> proc_macro::TokenS
             }
 
             pub fn get_hash<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {
-                let mut ctx = <sha2::Sha256 as sha2::Digest>::new();
+                let mut ctx = clvmr::sha2::Sha256::new();
                 #crate_name::Streamable::update_digest(self, &mut ctx);
-                Ok(pyo3::types::PyBytes::new_bound(py, sha2::Digest::finalize(ctx).as_slice()))
+                Ok(pyo3::types::PyBytes::new_bound(py, ctx.finalize().as_slice()))
             }
             #[pyo3(name = "to_bytes")]
             pub fn py_to_bytes<'p>(&self, py: pyo3::Python<'p>) -> pyo3::PyResult<pyo3::Bound<'p, pyo3::types::PyBytes>> {

--- a/crates/chia_streamable_macro/Cargo.toml
+++ b/crates/chia_streamable_macro/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 proc-macro = true
 
 [dependencies]
+clvmr = { workspace = true }
 syn = { workspace = true }
 quote = { workspace = true }
 proc-macro-crate = { workspace = true }

--- a/crates/chia_streamable_macro/src/lib.rs
+++ b/crates/chia_streamable_macro/src/lib.rs
@@ -158,7 +158,7 @@ pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
             }
             let ret = quote! {
                 impl #crate_name::Streamable for #ident {
-                    fn update_digest(&self, digest: &mut sha2::Sha256) {
+                    fn update_digest(&self, digest: &mut clvmr::sha2::Sha256) {
                         <u8 as #crate_name::Streamable>::update_digest(&(*self as u8), digest);
                     }
                     fn stream(&self, out: &mut Vec<u8>) -> #crate_name::chia_error::Result<()> {
@@ -198,7 +198,7 @@ pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
     if !fnames.is_empty() {
         let ret = quote! {
             impl #crate_name::Streamable for #ident {
-                fn update_digest(&self, digest: &mut sha2::Sha256) {
+                fn update_digest(&self, digest: &mut clvmr::sha2::Sha256) {
                     #(self.#fnames.update_digest(digest);)*
                 }
                 fn stream(&self, out: &mut Vec<u8>) -> #crate_name::chia_error::Result<()> {
@@ -214,7 +214,7 @@ pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
     } else if !findices.is_empty() {
         let ret = quote! {
             impl #crate_name::Streamable for #ident {
-                fn update_digest(&self, digest: &mut sha2::Sha256) {
+                fn update_digest(&self, digest: &mut clvmr::sha2::Sha256) {
                     #(self.#findices.update_digest(digest);)*
                 }
                 fn stream(&self, out: &mut Vec<u8>) -> #crate_name::chia_error::Result<()> {
@@ -231,7 +231,7 @@ pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
         // this is an empty type (Unit)
         let ret = quote! {
             impl #crate_name::Streamable for #ident {
-                fn update_digest(&self, _digest: &mut sha2::Sha256) {}
+                fn update_digest(&self, _digest: &mut clvmr::sha2::Sha256) {}
                 fn stream(&self, _out: &mut Vec<u8>) -> #crate_name::chia_error::Result<()> {
                     Ok(())
                 }

--- a/crates/clvm-utils/src/tree_hash.rs
+++ b/crates/clvm-utils/src/tree_hash.rs
@@ -1,6 +1,6 @@
 use clvmr::allocator::{Allocator, NodePtr, SExp};
 use clvmr::serde::node_from_bytes_backrefs_record;
-use clvmr::sha2::{Digest, Sha256};
+use clvmr::sha2::Sha256;
 use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::{fmt, io};
@@ -70,7 +70,7 @@ pub fn tree_hash_atom(bytes: &[u8]) -> TreeHash {
     let mut sha256 = Sha256::new();
     sha256.update([1]);
     sha256.update(bytes);
-    TreeHash::new(sha256.finalize().into())
+    TreeHash::new(sha256.finalize())
 }
 
 pub fn tree_hash_pair(first: TreeHash, rest: TreeHash) -> TreeHash {
@@ -78,7 +78,7 @@ pub fn tree_hash_pair(first: TreeHash, rest: TreeHash) -> TreeHash {
     sha256.update([2]);
     sha256.update(first);
     sha256.update(rest);
-    TreeHash::new(sha256.finalize().into())
+    TreeHash::new(sha256.finalize())
 }
 
 pub fn tree_hash(a: &Allocator, node: NodePtr) -> TreeHash {

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -23,7 +23,7 @@ python-source = "python"
 [dependencies]
 clvmr = { workspace = true }
 hex = { workspace = true }
-sha2 = { workspace = true }
+
 pyo3 = { workspace = true, features = ["multiple-pymethods"] }
 chia-consensus = { workspace = true, features = ["py-bindings"] }
 chia-bls = { workspace = true, features = ["py-bindings"]  }


### PR DESCRIPTION
one edge case for loading entropy in key gen however, so sha2 is still used

- [ ] clvm_rs release 0.8.0