### PR TITLE
Fix benchmark behavior

### DIFF
--- a/crates/chia-bls/benches/cache.rs
+++ b/crates/chia-bls/benches/cache.rs
@@ -23,45 +23,50 @@ fn cache_benchmark(c: &mut Criterion) {
         pks.push(pk);
     }
 
+    let bls_cache = BlsCache::default();
     c.bench_function("bls_cache.aggregate_verify, 0% cache hits", |b| {
         b.iter(|| {
-            let bls_cache = BlsCache::default();
+            let bls_cache = bls_cache.clone();
             assert!(bls_cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });
     });
 
     // populate 10% of keys
+    let bls_cache = BlsCache::default();
+    bls_cache.aggregate_verify(pks[0..100].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 10% cache hits", |b| {
         b.iter(|| {
-            let bls_cache = BlsCache::default();
-            bls_cache.aggregate_verify(pks[0..100].iter().zip([&msg].iter().cycle()), &agg_sig);
+            let bls_cache = bls_cache.clone();
             assert!(bls_cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });
     });
 
     // populate another 10% of keys
+    let bls_cache = BlsCache::default();
+    bls_cache.aggregate_verify(pks[0..200].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 20% cache hits", |b| {
         b.iter(|| {
-            let bls_cache = BlsCache::default();
-            bls_cache.aggregate_verify(pks[0..200].iter().zip([&msg].iter().cycle()), &agg_sig);
+            let bls_cache = bls_cache.clone();
             assert!(bls_cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });
     });
 
     // populate another 30% of keys
+    let bls_cache = BlsCache::default();
+    bls_cache.aggregate_verify(pks[0..500].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 50% cache hits", |b| {
         b.iter(|| {
-            let bls_cache = BlsCache::default();
-            bls_cache.aggregate_verify(pks[0..500].iter().zip([&msg].iter().cycle()), &agg_sig);
+            let bls_cache = bls_cache.clone();
             assert!(bls_cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });
     });
 
     // populate all other keys
+    let bls_cache = BlsCache::default();
+    bls_cache.aggregate_verify(pks[0..1000].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 100% cache hits", |b| {
         b.iter(|| {
-            let bls_cache = BlsCache::default();
-            bls_cache.aggregate_verify(pks[0..1000].iter().zip([&msg].iter().cycle()), &agg_sig);
+            let bls_cache = bls_cache.clone();
             assert!(bls_cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });
     });

--- a/crates/chia-bls/benches/cache.rs
+++ b/crates/chia-bls/benches/cache.rs
@@ -23,45 +23,45 @@ fn cache_benchmark(c: &mut Criterion) {
         pks.push(pk);
     }
 
-    let bls_cache = BlsCache::default();
     c.bench_function("bls_cache.aggregate_verify, 0% cache hits", |b| {
         b.iter(|| {
+            let bls_cache = BlsCache::default();
             assert!(bls_cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });
     });
 
     // populate 10% of keys
-    let bls_cache = BlsCache::default();
-    bls_cache.aggregate_verify(pks[0..100].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 10% cache hits", |b| {
         b.iter(|| {
+            let bls_cache = BlsCache::default();
+            bls_cache.aggregate_verify(pks[0..100].iter().zip([&msg].iter().cycle()), &agg_sig);
             assert!(bls_cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });
     });
 
     // populate another 10% of keys
-    let bls_cache = BlsCache::default();
-    bls_cache.aggregate_verify(pks[0..200].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 20% cache hits", |b| {
         b.iter(|| {
+            let bls_cache = BlsCache::default();
+            bls_cache.aggregate_verify(pks[0..200].iter().zip([&msg].iter().cycle()), &agg_sig);
             assert!(bls_cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });
     });
 
     // populate another 30% of keys
-    let bls_cache = BlsCache::default();
-    bls_cache.aggregate_verify(pks[0..500].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 50% cache hits", |b| {
         b.iter(|| {
+            let bls_cache = BlsCache::default();
+            bls_cache.aggregate_verify(pks[0..500].iter().zip([&msg].iter().cycle()), &agg_sig);
             assert!(bls_cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });
     });
 
     // populate all other keys
-    let bls_cache = BlsCache::default();
-    bls_cache.aggregate_verify(pks[0..1000].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 100% cache hits", |b| {
         b.iter(|| {
+            let bls_cache = BlsCache::default();
+            bls_cache.aggregate_verify(pks[0..1000].iter().zip([&msg].iter().cycle()), &agg_sig);
             assert!(bls_cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });
     });

--- a/crates/chia-bls/benches/cache.rs
+++ b/crates/chia-bls/benches/cache.rs
@@ -24,7 +24,6 @@ fn cache_benchmark(c: &mut Criterion) {
     }
 
     let bls_cache = BlsCache::default();
-
     c.bench_function("bls_cache.aggregate_verify, 0% cache hits", |b| {
         b.iter(|| {
             assert!(bls_cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
@@ -32,6 +31,7 @@ fn cache_benchmark(c: &mut Criterion) {
     });
 
     // populate 10% of keys
+    let bls_cache = BlsCache::default();
     bls_cache.aggregate_verify(pks[0..100].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 10% cache hits", |b| {
         b.iter(|| {
@@ -40,7 +40,8 @@ fn cache_benchmark(c: &mut Criterion) {
     });
 
     // populate another 10% of keys
-    bls_cache.aggregate_verify(pks[100..200].iter().zip([&msg].iter().cycle()), &agg_sig);
+    let bls_cache = BlsCache::default();
+    bls_cache.aggregate_verify(pks[0..200].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 20% cache hits", |b| {
         b.iter(|| {
             assert!(bls_cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
@@ -48,7 +49,8 @@ fn cache_benchmark(c: &mut Criterion) {
     });
 
     // populate another 30% of keys
-    bls_cache.aggregate_verify(pks[200..500].iter().zip([&msg].iter().cycle()), &agg_sig);
+    let bls_cache = BlsCache::default();
+    bls_cache.aggregate_verify(pks[0..500].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 50% cache hits", |b| {
         b.iter(|| {
             assert!(bls_cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
@@ -56,7 +58,8 @@ fn cache_benchmark(c: &mut Criterion) {
     });
 
     // populate all other keys
-    bls_cache.aggregate_verify(pks[500..1000].iter().zip([&msg].iter().cycle()), &agg_sig);
+    let bls_cache = BlsCache::default();
+    bls_cache.aggregate_verify(pks[0..1000].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 100% cache hits", |b| {
         b.iter(|| {
             assert!(bls_cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));

--- a/crates/chia-bls/src/bls_cache.rs
+++ b/crates/chia-bls/src/bls_cache.rs
@@ -22,6 +22,14 @@ pub struct BlsCache {
     cache: Mutex<LruCache<[u8; 32], GTElement>>,
 }
 
+impl Clone for BlsCache {
+    fn clone(&self) -> Self {
+        Self {
+            cache: Mutex::new(self.cache.lock().clone()),
+        }
+    }
+}
+
 impl Default for BlsCache {
     fn default() -> Self {
         Self::new(NonZeroUsize::new(50000).unwrap())


### PR DESCRIPTION
Results compared to prior to interior mutability:
```
Gnuplot not found, using plotters backend
Benchmarking bls_cache.aggregate_verify, 0% cache hits: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 51.1s, or reduce sample count to 10.
bls_cache.aggregate_verify, 0% cache hits
                        time:   [512.40 ms 516.72 ms 522.79 ms]
                        change: [-0.1042% +0.7965% +2.0013%] (p = 0.16 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

Benchmarking bls_cache.aggregate_verify, 10% cache hits: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 47.0s, or reduce sample count to 10.
bls_cache.aggregate_verify, 10% cache hits
                        time:   [464.36 ms 465.94 ms 467.72 ms]
                        change: [-8.6168% -8.2999% -7.9271%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe

Benchmarking bls_cache.aggregate_verify, 20% cache hits: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 40.8s, or reduce sample count to 10.
bls_cache.aggregate_verify, 20% cache hits
                        time:   [407.63 ms 408.87 ms 410.40 ms]
                        change: [-19.863% -19.596% -19.288%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

Benchmarking bls_cache.aggregate_verify, 50% cache hits: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 25.6s, or reduce sample count to 10.
bls_cache.aggregate_verify, 50% cache hits
                        time:   [258.91 ms 259.95 ms 261.08 ms]
                        change: [-49.998% -49.686% -49.347%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

bls_cache.aggregate_verify, 100% cache hits
                        time:   [2.1386 ms 2.1594 ms 2.1925 ms]
                        change: [+3.8251% +5.2293% +7.0844%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

Benchmarking bls_cache.aggregate_verify, no cache: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 26.6s, or reduce sample count to 10.
bls_cache.aggregate_verify, no cache
                        time:   [266.31 ms 267.23 ms 268.25 ms]
                        change: [-1.3208% -0.5508% +0.1486%] (p = 0.14 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
  ```