### PR TITLE
we have two copies of the u64_to_bytes() function (used in tests)

### DIFF
--- a/crates/chia-consensus/src/gen/conditions.rs
+++ b/crates/chia-consensus/src/gen/conditions.rs
@@ -1455,7 +1455,7 @@ pub fn validate_conditions(
 }
 
 #[cfg(test)]
-fn u64_to_bytes(n: u64) -> Vec<u8> {
+pub(crate) fn u64_to_bytes(n: u64) -> Vec<u8> {
     let mut buf = Vec::<u8>::new();
     buf.extend_from_slice(&n.to_be_bytes());
     if (buf[0] & 0x80) != 0 {

--- a/crates/chia-consensus/src/gen/get_puzzle_and_solution.rs
+++ b/crates/chia-consensus/src/gen/get_puzzle_and_solution.rs
@@ -59,20 +59,8 @@ pub fn get_puzzle_and_solution_for_coin(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::gen::conditions::u64_to_bytes;
     use clvmr::sha2::Sha256;
-
-    fn u64_to_bytes(n: u64) -> Vec<u8> {
-        let mut buf = Vec::<u8>::new();
-        buf.extend_from_slice(&n.to_be_bytes());
-        if (buf[0] & 0x80) != 0 {
-            buf.insert(0, 0);
-        } else {
-            while buf.len() > 1 && buf[0] == 0 && (buf[1] & 0x80) == 0 {
-                buf.remove(0);
-            }
-        }
-        buf
-    }
 
     fn make_dummy_id(seed: u64) -> Bytes32 {
         let mut sha256 = Sha256::new();


### PR DESCRIPTION
This patch deletes one of them.