### PR TITLE
fix the test coverage collected by pytest

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -390,7 +390,8 @@ jobs:
           pip install ./clvm_tools
           pip install colorama maturin pytest pytest-xdist chia-blockchain==2.1.2 clvm==0.9.8
           maturin develop --release -m wheel/Cargo.toml
-          pytest tests
+          # run pytest in a single process to avoid a race writing the coverage report
+          pytest -n 0 tests
           grcov . --binary-path target -s . --branch --ignore-not-existing --ignore='*/.cargo/*' --ignore='tests/*' --ignore='venv/*' -o rust_cov.info
           python -c 'with open("rust_cov.info") as f: lines = [l for l in f if not (l.startswith("DA:") and int(l.split(",")[1].strip()) >= 2**63)]; open("lcov.info", "w").writelines(lines)'
       - name: Upload to Coveralls


### PR DESCRIPTION
My suspicion is that running pytest in parallel causes one process to overwrite the other's coverage report