### PR TITLE
don't pass in the root directory to prettier (unconditionally) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ venv/
 node_modules/
 .mypy_cache/
 .pytest_cache/
+crates/chia-bls/fuzz/corpus
+crates/chia-consensus/fuzz/corpus
+crates/chia-protocol/fuzz/corpus
+crates/chia-traits/fuzz/corpus
+crates/chia-utils/fuzz/corpus

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: prettier
         name: Prettier
-        entry: npx prettier --write .
+        entry: npx prettier --write
         language: node
         files: \.(js|jsx|ts|tsx|json|css|scss|md|yml|yaml)$
         types: [file]


### PR DESCRIPTION
it makes `prettier` scan the whole repository.
Instead, rely on `pre-commit` to pass in the relevant files.
Also extend `.gitignore` to include the fuzz corpus