### PR TITLE
add empty `[mypy]` section to avoid a warning

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,5 @@
+[mypy]
+
 [mypy-clvm.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
This should probably be a lot more strict, but let's take that on separately.

https://github.com/Chia-Network/chia_rs/actions/runs/10581623686/job/29319386862?pr=673#step:10:16
```
mypy.ini: No [mypy] section in config file
```