### PR TITLE
Optimize `get_conditions_from_spendbundle()` by calculating the generator's size without creating the generator

### DIFF
--- a/crates/chia-consensus/fuzz/Cargo.toml
+++ b/crates/chia-consensus/fuzz/Cargo.toml
@@ -115,3 +115,10 @@ path = "fuzz_targets/merkle-set.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "solution-generator"
+path = "fuzz_targets/solution-generator.rs"
+test = false
+doc = false
+bench = false

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -22,7 +22,7 @@ fuzz_target!(|data: &[u8]| {
             spend.puzzle_reveal.to_vec(),
             spend.solution.to_vec(),
         ));
-        // Check if puzzle or solution are atoms which can represented in a smaller form
+        // Check for atoms which can represented in a smaller form
         let node = node_from_bytes_backrefs(&mut a, spend.puzzle_reveal.as_ref()).expect("node");
         let puz = node_to_bytes(&a, node).expect("bytes");
         discrepancy += spend.puzzle_reveal.as_ref().len() as i64 - puz.len() as i64;

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -3,7 +3,7 @@ use chia_consensus::gen::solution_generator::{calculate_generator_length, soluti
 use chia_protocol::{Coin, CoinSpend};
 use chia_traits::Streamable;
 use clvmr::{
-    serde::{node_from_bytes, node_to_bytes},
+    serde::{node_from_bytes_backrefs, node_to_bytes},
     Allocator,
 };
 use libfuzzer_sys::fuzz_target;
@@ -13,7 +13,7 @@ fuzz_target!(|data: &[u8]| {
     let mut spends = Vec::<CoinSpend>::new();
     let mut generator_input = Vec::<(Coin, Vec<u8>, Vec<u8>)>::new();
     let mut data = Cursor::new(data);
-    let mut discrepancy: usize = 0;
+    let mut discrepancy: i64 = 0;
     let mut a = Allocator::new();
     while let Ok(spend) = CoinSpend::parse::<false>(&mut data) {
         spends.push(spend.clone());
@@ -23,30 +23,23 @@ fuzz_target!(|data: &[u8]| {
             spend.solution.to_vec(),
         ));
         // Check if puzzle or solution are atoms which can represented in a smaller form
-        let node = node_from_bytes(&mut a, spend.puzzle_reveal.as_ref()).expect("node");
-        if node.is_atom() {
-            let puz = node_to_bytes(&a, node).expect("bytes");
-            discrepancy += spend.puzzle_reveal.as_ref().len() - puz.len();
-        }
-        let node = node_from_bytes(&mut a, spend.solution.as_ref()).expect("node");
-        if node.is_atom() {
-            let sol = node_to_bytes(&a, node).expect("bytes");
-            discrepancy += spend.solution.as_ref().len() - sol.len();
-        }
+        let node = node_from_bytes_backrefs(&mut a, spend.puzzle_reveal.as_ref()).expect("node");
+        let puz = node_to_bytes(&a, node).expect("bytes");
+        discrepancy += spend.puzzle_reveal.as_ref().len() as i64 - puz.len() as i64;
+        let node = node_from_bytes_backrefs(&mut a, spend.solution.as_ref()).expect("node");
+        let sol = node_to_bytes(&a, node).expect("bytes");
+        discrepancy += spend.solution.as_ref().len() as i64 - sol.len() as i64;
     }
     if spends.is_empty() {
         return;
     }
-    let Ok(result) = solution_generator(generator_input) else {
-        return;
-    };
-
-    if result.len() != calculate_generator_length(spends.clone()) - discrepancy {
+    let result = solution_generator(generator_input).expect("solution_generator");
+    if result.len() as i64 != calculate_generator_length(spends.clone()) as i64 - discrepancy {
         panic!("Debug spends: {:?}", spends);
     }
 
     assert_eq!(
-        result.len(),
-        calculate_generator_length(spends) - discrepancy
+        result.len() as i64,
+        calculate_generator_length(spends) as i64 - discrepancy
     );
 });

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -1,0 +1,23 @@
+#![no_main]
+use chia_protocol::{Coin, CoinSpend};
+use chia_traits::Streamable;
+use libfuzzer_sys::fuzz_target;
+use std::io::Cursor;
+use chia_consensus::gen::solution_generator::{calculate_generator_length, solution_generator};
+
+fuzz_target!(|data: &[u8]| {
+    let mut spends = Vec::<CoinSpend>::new();
+    let mut generator_input = Vec::<(Coin, Vec<u8>, Vec<u8>)>::new();
+    for _i in 1..1000 {
+        let Ok(spend) = CoinSpend::parse::<false>(&mut Cursor::new(data)) else {
+            return;
+        };
+        spends.push(spend.clone());
+        generator_input.push((spend.coin, spend.puzzle_reveal.to_vec(), spend.solution.to_vec()));
+    }
+
+    let result = solution_generator(generator_input).expect("solution_generator");
+
+    assert_eq!(result.len(), calculate_generator_length(spends));
+
+});

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -20,7 +20,7 @@ fuzz_target!(|data: &[u8]| {
     if spends.is_empty() {
         return;
     }
-    let result = solution_generator(generator_input).expect("solution_generator");
+    let Ok(result) = solution_generator(generator_input) else {return ;};
 
     assert_eq!(result.len(), calculate_generator_length(spends));
 });

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -8,10 +8,8 @@ use std::io::Cursor;
 fuzz_target!(|data: &[u8]| {
     let mut spends = Vec::<CoinSpend>::new();
     let mut generator_input = Vec::<(Coin, Vec<u8>, Vec<u8>)>::new();
-    for _i in 1..2000 {
-        let Ok(spend) = CoinSpend::parse::<false>(&mut Cursor::new(data)) else {
-            break;
-        };
+    let mut data = Cursor::new(data);
+    while let Ok(spend) = CoinSpend::parse::<true>(&mut data) {
         spends.push(spend.clone());
         generator_input.push((
             spend.coin,
@@ -19,7 +17,9 @@ fuzz_target!(|data: &[u8]| {
             spend.solution.to_vec(),
         ));
     }
-
+    if spends.is_empty() {
+        return;
+    }
     let result = solution_generator(generator_input).expect("solution_generator");
 
     assert_eq!(result.len(), calculate_generator_length(spends));

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -10,7 +10,7 @@ fuzz_target!(|data: &[u8]| {
     let mut spends = Vec::<CoinSpend>::new();
     let mut generator_input = Vec::<(Coin, Vec<u8>, Vec<u8>)>::new();
     let mut data = Cursor::new(data);
-    while let Ok(spend) = CoinSpend::parse::<true>(&mut data) {
+    while let Ok(spend) = CoinSpend::parse::<false>(&mut data) {
         spends.push(spend.clone());
         generator_input.push((
             spend.coin,
@@ -25,8 +25,5 @@ fuzz_target!(|data: &[u8]| {
         return;
     };
 
-    if result.len() !=  calculate_generator_length(spends.clone()){
-        panic!("DEBUG: {:?}", spends);
-    }
     assert_eq!(result.len(), calculate_generator_length(spends));
 });

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -3,6 +3,7 @@ use chia_consensus::gen::solution_generator::{calculate_generator_length, soluti
 use chia_protocol::{Coin, CoinSpend};
 use chia_traits::Streamable;
 use libfuzzer_sys::fuzz_target;
+use core::panic;
 use std::io::Cursor;
 
 fuzz_target!(|data: &[u8]| {
@@ -24,5 +25,8 @@ fuzz_target!(|data: &[u8]| {
         return;
     };
 
+    if result.len() !=  calculate_generator_length(spends.clone()){
+        panic!("DEBUG: {:?}", spends);
+    }
     assert_eq!(result.len(), calculate_generator_length(spends));
 });

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -3,7 +3,7 @@ use chia_consensus::gen::solution_generator::{calculate_generator_length, soluti
 use chia_protocol::{Coin, CoinSpend};
 use chia_traits::Streamable;
 use clvmr::{
-    serde::{node_from_bytes_backrefs, node_to_bytes},
+    serde::{node_from_bytes, node_to_bytes},
     Allocator,
 };
 use libfuzzer_sys::fuzz_target;
@@ -23,12 +23,12 @@ fuzz_target!(|data: &[u8]| {
             spend.solution.to_vec(),
         ));
         // Check if puzzle or solution are atoms which can represented in a smaller form
-        let node = node_from_bytes_backrefs(&mut a, spend.puzzle_reveal.as_ref()).expect("atom");
+        let Ok(node) = node_from_bytes(&mut a, spend.puzzle_reveal.as_ref()) else {return;};
         if node.is_atom() {
             let puz = node_to_bytes(&a, node).expect("bytes");
             discrepancy += spend.puzzle_reveal.as_ref().len() - puz.len();
         }
-        let node = node_from_bytes_backrefs(&mut a, spend.solution.as_ref()).expect("atom");
+        let Ok(node) = node_from_bytes(&mut a, spend.solution.as_ref()) else {return;};
         if node.is_atom() {
             let sol = node_to_bytes(&a, node).expect("bytes");
             discrepancy += spend.solution.as_ref().len() - sol.len();

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -2,14 +2,19 @@
 use chia_consensus::gen::solution_generator::{calculate_generator_length, solution_generator};
 use chia_protocol::{Coin, CoinSpend};
 use chia_traits::Streamable;
+use clvmr::{
+    serde::{node_from_bytes_backrefs, node_to_bytes},
+    Allocator,
+};
 use libfuzzer_sys::fuzz_target;
-use core::panic;
 use std::io::Cursor;
 
 fuzz_target!(|data: &[u8]| {
     let mut spends = Vec::<CoinSpend>::new();
     let mut generator_input = Vec::<(Coin, Vec<u8>, Vec<u8>)>::new();
     let mut data = Cursor::new(data);
+    let mut discrepancy: usize = 0;
+    let mut a = Allocator::new();
     while let Ok(spend) = CoinSpend::parse::<false>(&mut data) {
         spends.push(spend.clone());
         generator_input.push((
@@ -17,6 +22,17 @@ fuzz_target!(|data: &[u8]| {
             spend.puzzle_reveal.to_vec(),
             spend.solution.to_vec(),
         ));
+        // Check if puzzle or solution are atoms which can represented in a smaller form
+        let node = node_from_bytes_backrefs(&mut a, spend.puzzle_reveal.as_ref()).expect("atom");
+        if node.is_atom() {
+            let puz = node_to_bytes(&a, node).expect("bytes");
+            discrepancy += spend.puzzle_reveal.as_ref().len() - puz.len();
+        }
+        let node = node_from_bytes_backrefs(&mut a, spend.solution.as_ref()).expect("atom");
+        if node.is_atom() {
+            let sol = node_to_bytes(&a, node).expect("bytes");
+            discrepancy += spend.solution.as_ref().len() - sol.len();
+        }
     }
     if spends.is_empty() {
         return;
@@ -25,9 +41,8 @@ fuzz_target!(|data: &[u8]| {
         return;
     };
 
-    if result.len() !=  calculate_generator_length(spends.clone()){
-        panic!("DEBUG: {:?}", spends);
-    }
-
-    assert_eq!(result.len(), calculate_generator_length(spends));
+    assert_eq!(
+        result.len(),
+        calculate_generator_length(spends) - discrepancy
+    );
 });

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -22,7 +22,7 @@ fuzz_target!(|data: &[u8]| {
             spend.puzzle_reveal.to_vec(),
             spend.solution.to_vec(),
         ));
-        // Check for atoms which can represented in a smaller form
+        // Check for atoms which can be represented in a smaller form
         let node = node_from_bytes_backrefs(&mut a, spend.puzzle_reveal.as_ref()).expect("node");
         let puz = node_to_bytes(&a, node).expect("bytes");
         discrepancy += spend.puzzle_reveal.as_ref().len() as i64 - puz.len() as i64;

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -23,16 +23,12 @@ fuzz_target!(|data: &[u8]| {
             spend.solution.to_vec(),
         ));
         // Check if puzzle or solution are atoms which can represented in a smaller form
-        let Ok(node) = node_from_bytes(&mut a, spend.puzzle_reveal.as_ref()) else {
-            return;
-        };
+        let node = node_from_bytes(&mut a, spend.puzzle_reveal.as_ref()).expect("node");
         if node.is_atom() {
             let puz = node_to_bytes(&a, node).expect("bytes");
             discrepancy += spend.puzzle_reveal.as_ref().len() - puz.len();
         }
-        let Ok(node) = node_from_bytes(&mut a, spend.solution.as_ref()) else {
-            return;
-        };
+        let node = node_from_bytes(&mut a, spend.solution.as_ref()).expect("node");
         if node.is_atom() {
             let sol = node_to_bytes(&a, node).expect("bytes");
             discrepancy += spend.solution.as_ref().len() - sol.len();
@@ -45,7 +41,7 @@ fuzz_target!(|data: &[u8]| {
         return;
     };
 
-    if result.len() != calculate_generator_length(spends) - discrepancy {
+    if result.len() != calculate_generator_length(spends.clone()) - discrepancy {
         panic!("Debug spends: {:?}", spends);
     }
 

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -1,9 +1,9 @@
 #![no_main]
+use chia_consensus::gen::solution_generator::{calculate_generator_length, solution_generator};
 use chia_protocol::{Coin, CoinSpend};
 use chia_traits::Streamable;
 use libfuzzer_sys::fuzz_target;
 use std::io::Cursor;
-use chia_consensus::gen::solution_generator::{calculate_generator_length, solution_generator};
 
 fuzz_target!(|data: &[u8]| {
     let mut spends = Vec::<CoinSpend>::new();
@@ -13,11 +13,14 @@ fuzz_target!(|data: &[u8]| {
             return;
         };
         spends.push(spend.clone());
-        generator_input.push((spend.coin, spend.puzzle_reveal.to_vec(), spend.solution.to_vec()));
+        generator_input.push((
+            spend.coin,
+            spend.puzzle_reveal.to_vec(),
+            spend.solution.to_vec(),
+        ));
     }
 
     let result = solution_generator(generator_input).expect("solution_generator");
 
     assert_eq!(result.len(), calculate_generator_length(spends));
-
 });

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -8,9 +8,9 @@ use std::io::Cursor;
 fuzz_target!(|data: &[u8]| {
     let mut spends = Vec::<CoinSpend>::new();
     let mut generator_input = Vec::<(Coin, Vec<u8>, Vec<u8>)>::new();
-    for _i in 1..1000 {
+    for _i in 1..2000 {
         let Ok(spend) = CoinSpend::parse::<false>(&mut Cursor::new(data)) else {
-            return;
+            break;
         };
         spends.push(spend.clone());
         generator_input.push((

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -45,6 +45,10 @@ fuzz_target!(|data: &[u8]| {
         return;
     };
 
+    if result.len() != calculate_generator_length(spends) - discrepancy {
+        panic!("Debug spends: {:?}", spends);
+    }
+
     assert_eq!(
         result.len(),
         calculate_generator_length(spends) - discrepancy

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -45,10 +45,6 @@ fuzz_target!(|data: &[u8]| {
         return;
     };
 
-    if result.len() != calculate_generator_length(spends.clone()) - discrepancy {
-        panic!("Debug, spends are: {:?}", spends);
-    }
-
     assert_eq!(
         result.len(),
         calculate_generator_length(spends) - discrepancy

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -25,5 +25,9 @@ fuzz_target!(|data: &[u8]| {
         return;
     };
 
+    if result.len() !=  calculate_generator_length(spends.clone()){
+        panic!("DEBUG: {:?}", spends);
+    }
+
     assert_eq!(result.len(), calculate_generator_length(spends));
 });

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -20,7 +20,9 @@ fuzz_target!(|data: &[u8]| {
     if spends.is_empty() {
         return;
     }
-    let Ok(result) = solution_generator(generator_input) else {return ;};
+    let Ok(result) = solution_generator(generator_input) else {
+        return;
+    };
 
     assert_eq!(result.len(), calculate_generator_length(spends));
 });

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -34,9 +34,6 @@ fuzz_target!(|data: &[u8]| {
         return;
     }
     let result = solution_generator(generator_input).expect("solution_generator");
-    if result.len() as i64 != calculate_generator_length(spends.clone()) as i64 - discrepancy {
-        panic!("Debug spends: {:?}", spends);
-    }
 
     assert_eq!(
         result.len() as i64,

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -23,12 +23,16 @@ fuzz_target!(|data: &[u8]| {
             spend.solution.to_vec(),
         ));
         // Check if puzzle or solution are atoms which can represented in a smaller form
-        let Ok(node) = node_from_bytes(&mut a, spend.puzzle_reveal.as_ref()) else {return;};
+        let Ok(node) = node_from_bytes(&mut a, spend.puzzle_reveal.as_ref()) else {
+            return;
+        };
         if node.is_atom() {
             let puz = node_to_bytes(&a, node).expect("bytes");
             discrepancy += spend.puzzle_reveal.as_ref().len() - puz.len();
         }
-        let Ok(node) = node_from_bytes(&mut a, spend.solution.as_ref()) else {return;};
+        let Ok(node) = node_from_bytes(&mut a, spend.solution.as_ref()) else {
+            return;
+        };
         if node.is_atom() {
             let sol = node_to_bytes(&a, node).expect("bytes");
             discrepancy += spend.solution.as_ref().len() - sol.len();

--- a/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/solution-generator.rs
@@ -41,6 +41,10 @@ fuzz_target!(|data: &[u8]| {
         return;
     };
 
+    if result.len() != calculate_generator_length(spends.clone()) - discrepancy {
+        panic!("Debug, spends are: {:?}", spends);
+    }
+
     assert_eq!(
         result.len(),
         calculate_generator_length(spends) - discrepancy

--- a/crates/chia-consensus/src/gen/solution_generator.rs
+++ b/crates/chia-consensus/src/gen/solution_generator.rs
@@ -54,10 +54,14 @@ where
         let amount_bytes = s.0.amount.to_be_bytes();
         // chialisp represents integers as small as possible so remove leading 0s
         let leading_zeroes = amount_bytes.iter().take_while(|&&b| b == 0).count();
-        let mut amount_size = amount_bytes[leading_zeroes..].len();
-        if amount_bytes[leading_zeroes] >= 0x80 {
-            // add 0x00 for two's compliment as amount is always positive
-            amount_size += 1;
+        let mut amount_size: usize = 1; // rust converts 0 to 0x00, but in clvm it is 0x80
+        if leading_zeroes < 8 {
+            // if amount is not 0x0000000000000000
+            amount_size = amount_bytes[leading_zeroes..].len();
+            if amount_bytes[leading_zeroes] >= 0x80 {
+                // add 0x00 for two's compliment as amount is always positive
+                amount_size += 1;
+            }
         }
 
         // parent-id puzzle-reveal amount solution + bytes for list extension and atom prep bytes

--- a/crates/chia-consensus/src/gen/solution_generator.rs
+++ b/crates/chia-consensus/src/gen/solution_generator.rs
@@ -294,7 +294,7 @@ mod tests {
             );
             spends.push((coin, PUZZLE1.as_ref(), SOLUTION1.as_ref()));
             coin_spends.push(CoinSpend {
-                coin: coin,
+                coin,
                 puzzle_reveal: Program::from(PUZZLE1.as_ref()),
                 solution: Program::from(SOLUTION1.as_ref()),
             });

--- a/crates/chia-consensus/src/gen/solution_generator.rs
+++ b/crates/chia-consensus/src/gen/solution_generator.rs
@@ -1,7 +1,9 @@
 use chia_protocol::Coin;
 use chia_protocol::CoinSpend;
 use clvmr::allocator::{Allocator, NodePtr};
-use clvmr::serde::{node_from_bytes_backrefs, node_from_bytes, node_to_bytes, node_to_bytes_backrefs};
+use clvmr::serde::{
+    node_from_bytes, node_from_bytes_backrefs, node_to_bytes, node_to_bytes_backrefs,
+};
 use std::io;
 
 // the tuple has the Coin, puzzle-reveal and solution

--- a/crates/chia-consensus/src/gen/solution_generator.rs
+++ b/crates/chia-consensus/src/gen/solution_generator.rs
@@ -383,12 +383,12 @@ mod tests {
             puzzle_reveal: Program::from(puzzle),
             solution: Program::from(solution),
         });
-        let node = node_from_bytes(&mut a, puzzle.as_ref()).expect("atom");
+        let node = node_from_bytes(&mut a, puzzle).expect("atom");
         if node.is_atom() {
             let puz = node_to_bytes(&a, node).expect("bytes");
             discrepancy = puzzle.len() - puz.len();
         }
-        let node = node_from_bytes(&mut a, solution.as_ref()).expect("atom");
+        let node = node_from_bytes(&mut a, solution).expect("atom");
         if node.is_atom() {
             let sol = node_to_bytes(&a, node).expect("bytes");
             discrepancy = solution.len() - sol.len();

--- a/crates/chia-consensus/src/gen/solution_generator.rs
+++ b/crates/chia-consensus/src/gen/solution_generator.rs
@@ -54,15 +54,17 @@ where
         let amount_bytes = s.0.amount.to_be_bytes();
         // chialisp represents integers as small as possible so remove leading 0s
         let leading_zeroes = amount_bytes.iter().take_while(|&&b| b == 0).count();
-        let amount_size = amount_bytes[leading_zeroes..].len();
-
+        let mut amount_size = amount_bytes[leading_zeroes..].len();
         if amount_bytes[leading_zeroes] >= 0x80 {
-            // add 0x00 for two's compliment
-            size += 1;
+            // add 0x00 for two's compliment as amount is always positive
+            amount_size += 1;
         }
 
         // parent-id puzzle-reveal amount solution + bytes for list extension and atom prep bytes
         size += 32 + puzzle.len() + amount_size + solution.len() + 8;
+        if s.0.amount < 128 {
+            size -= 1;
+        }
     }
 
     size
@@ -226,8 +228,10 @@ mod tests {
         let generator_output = run_generator(&result);
         assert_eq!(generator_output, EXPECTED_GENERATOR_OUTPUT);
 
-        let result = solution_generator([(coin2, PUZZLE2.as_ref(), SOLUTION2.as_ref())])
-            .expect("solution_generator");
+        let spends = [(coin2, PUZZLE2.as_ref(), SOLUTION2.as_ref())];
+        let result = solution_generator(spends).expect("solution_generator");
+
+        assert_eq!(result.len(), calculate_generator_length(spends));
 
         assert_eq!(
             result,
@@ -255,11 +259,11 @@ mod tests {
     #[test]
     fn test_length_calculator() {
         let mut spends: Vec<(Coin, &[u8], &[u8])> = Vec::new();
-        for i in 1..100 {
+        for i in [1, 128, 129, 256, 257, 4_294_967_296, 4_294_967_297] {
             let coin: Coin = Coin::new(
                 hex!("ccd5bb71183532bff220ba46c268991a00000000000000000000000000036840").into(),
                 hex!("fcc78a9e396df6ceebc217d2446bc016e0b3d5922fb32e5783ec5a85d490cfb6").into(),
-                i * 100000,
+                i,
             );
             spends.push((coin, PUZZLE1.as_ref(), SOLUTION1.as_ref()));
             let result = solution_generator(spends.clone()).expect("solution_generator");

--- a/crates/chia-consensus/src/gen/solution_generator.rs
+++ b/crates/chia-consensus/src/gen/solution_generator.rs
@@ -74,8 +74,7 @@ where
         let solution = s.solution.as_ref();
         // parent-id puzzle-reveal amount solution
         // parent-id is always 32 bytes + prepend 1 byte = 33
-        // + 4 bytes for list extension
-        // + 2 bytes for the other atom prepended bytes
+        // + 6 bytes for list extension
         // coin amount is already prepended correctly in clvm_bytes_len()
         size += 39 + puzzle.len() + clvm_bytes_len(s.coin.amount) + solution.len();
     }

--- a/crates/chia-consensus/src/gen/solution_generator.rs
+++ b/crates/chia-consensus/src/gen/solution_generator.rs
@@ -365,6 +365,7 @@ mod tests {
 
     #[rstest]
     #[case(hex!("f800000000").as_ref(), SOLUTION1.as_ref())]
+    #[case(hex!("fffffe0000ff41ff013a").as_ref(), SOLUTION1.as_ref())]
     #[case(PUZZLE1.as_ref(), hex!("00").as_ref())]
     fn test_length_calculator_edge_case(#[case] puzzle: &[u8], #[case] solution: &[u8]) {
         let mut spends: Vec<(Coin, &[u8], &[u8])> = Vec::new();

--- a/crates/chia-consensus/src/gen/solution_generator.rs
+++ b/crates/chia-consensus/src/gen/solution_generator.rs
@@ -325,6 +325,39 @@ mod tests {
     }
 
     #[test]
+    fn test_length_calculator_edge_case() {
+        let mut spends: Vec<(Coin, &[u8], &[u8])> = Vec::new();
+        let mut coin_spends = Vec::<CoinSpend>::new();
+        let mut a = Allocator::new();
+        let mut discrepancy: usize = 0;
+
+        let coin: Coin = Coin::new(
+            hex!("ccd5bb71183532bff220ba46c268991a00000000000000000000000000036840").into(),
+            hex!("fcc78a9e396df6ceebc217d2446bc016e0b3d5922fb32e5783ec5a85d490cfb6").into(),
+            100,
+        );
+        spends.push((coin, hex!("f800000000").as_ref(), SOLUTION1.as_ref()));
+        coin_spends.push(CoinSpend {
+            coin,
+            puzzle_reveal: Program::from(hex!("f800000000").as_ref()),
+            solution: Program::from(SOLUTION1.as_ref()),
+        });
+        let node = node_from_bytes_backrefs(&mut a, hex!("f800000000").as_ref()).expect("atom");
+        if node.is_atom() {
+            let puz = node_to_bytes(&a, node).expect("bytes");
+            assert_eq!(puz.len(), 1);
+            discrepancy = hex!("f800000000").as_ref().len() - puz.len();
+        }
+        assert_eq!(discrepancy, 4);
+        let result = solution_generator(spends.clone()).expect("solution_generator");
+
+        assert_eq!(
+            result.len(),
+            calculate_generator_length(&coin_spends) - discrepancy
+        );
+    }
+
+    #[test]
     fn test_solution_generator_backre() {
         let coin1: Coin = Coin::new(
             hex!("ccd5bb71183532bff220ba46c268991a00000000000000000000000000036840").into(),

--- a/crates/chia-consensus/src/gen/solution_generator.rs
+++ b/crates/chia-consensus/src/gen/solution_generator.rs
@@ -40,26 +40,25 @@ where
     Ok(quote)
 }
 
-// do not use generally
-fn len_for_generator(val: u64) -> usize {
+fn clvm_bytes_len(val: u64) -> usize {
     if val < 0x80 {
-        0 // this encompasses a chialisp optimisation that happens for small ints
+        1
     } else if val < 0x8000 {
-        2
-    } else if val < 0x0080_0000 {
         3
-    } else if val < 0x8000_0000 {
+    } else if val < 0x0080_0000 {
         4
-    } else if val < 0x0080_0000_0000 {
+    } else if val < 0x8000_0000 {
         5
-    } else if val < 0x8000_0000_0000 {
+    } else if val < 0x0080_0000_0000 {
         6
-    } else if val < 0x0080_0000_0000_0000 {
+    } else if val < 0x8000_0000_0000 {
         7
-    } else if val < 0x8000_0000_0000_0000 {
+    } else if val < 0x0080_0000_0000_0000 {
         8
-    } else {
+    } else if val < 0x8000_0000_0000_0000 {
         9
+    } else {
+        10
     }
 }
 
@@ -73,8 +72,12 @@ where
     for s in spends.as_ref() {
         let puzzle = s.puzzle_reveal.as_ref();
         let solution = s.solution.as_ref();
-        // parent-id puzzle-reveal amount solution + bytes for list extension and atom prep bytes
-        size += 32 + puzzle.len() + len_for_generator(s.coin.amount) + solution.len() + 8;
+        // parent-id puzzle-reveal amount solution
+        // parent-id is always 32 bytes + prepend 1 byte = 33
+        // + 4 bytes for list extension
+        // + 2 bytes for the other atom prepended bytes
+        // coin amount is already prepended correctly in clvm_bytes_len()
+        size += 39 + puzzle.len() + clvm_bytes_len(s.coin.amount) + solution.len();
     }
 
     size

--- a/crates/chia-consensus/src/gen/solution_generator.rs
+++ b/crates/chia-consensus/src/gen/solution_generator.rs
@@ -1,9 +1,7 @@
 use chia_protocol::Coin;
 use chia_protocol::CoinSpend;
 use clvmr::allocator::{Allocator, NodePtr};
-use clvmr::serde::{
-    node_from_bytes, node_from_bytes_backrefs, node_to_bytes, node_to_bytes_backrefs,
-};
+use clvmr::serde::{node_from_bytes_backrefs, node_to_bytes, node_to_bytes_backrefs};
 use std::io;
 
 // the tuple has the Coin, puzzle-reveal and solution
@@ -27,42 +25,6 @@ where
         let item = a.new_pair(amount, item)?;
         // puzzle reveal
         let puzzle = node_from_bytes_backrefs(a, s.1.as_ref())?;
-        let item = a.new_pair(puzzle, item)?;
-        // parent-id
-        let parent_id = a.new_atom(&s.0.parent_coin_info)?;
-        let item = a.new_pair(parent_id, item)?;
-
-        spend_list = a.new_pair(item, spend_list)?;
-    }
-
-    // the list of spends is the first (and only) item in an outer list
-    spend_list = a.new_pair(spend_list, a.nil())?;
-
-    let quote = a.new_pair(a.one(), spend_list)?;
-    Ok(quote)
-}
-
-// the tuple has the Coin, puzzle-reveal and solution
-fn build_generator_no_backrefs<BufRef, I>(a: &mut Allocator, spends: I) -> io::Result<NodePtr>
-where
-    BufRef: AsRef<[u8]>,
-    I: IntoIterator<Item = (Coin, BufRef, BufRef)>,
-{
-    // the generator we produce here is just a quoted list. Nothing fancy.
-    // Its format is as follows:
-    // (q . ( ( ( parent-id puzzle-reveal amount solution ) ... ) ) )
-
-    let mut spend_list = a.nil();
-    for s in spends {
-        let item = a.nil();
-        // solution
-        let solution = node_from_bytes(a, s.2.as_ref())?;
-        let item = a.new_pair(solution, item)?;
-        // amount
-        let amount = a.new_number(s.0.amount.into())?;
-        let item = a.new_pair(amount, item)?;
-        // puzzle reveal
-        let puzzle = node_from_bytes(a, s.1.as_ref())?;
         let item = a.new_pair(puzzle, item)?;
         // parent-id
         let parent_id = a.new_atom(&s.0.parent_coin_info)?;
@@ -127,7 +89,7 @@ where
     I: IntoIterator<Item = (Coin, BufRef, BufRef)>,
 {
     let mut a = Allocator::new();
-    let generator = build_generator_no_backrefs(&mut a, spends)?;
+    let generator = build_generator(&mut a, spends)?;
     node_to_bytes(&a, generator)
 }
 
@@ -145,6 +107,7 @@ where
 mod tests {
     use super::*;
     use chia_protocol::Program;
+    use chia_traits::Streamable;
     use clvmr::{run_program, ChiaDialect};
     use hex_literal::hex;
     use rstest::rstest;
@@ -371,7 +334,7 @@ mod tests {
         let mut spends: Vec<(Coin, &[u8], &[u8])> = Vec::new();
         let mut coin_spends = Vec::<CoinSpend>::new();
         let mut a = Allocator::new();
-        let mut discrepancy: usize = 0;
+        let mut discrepancy: i64 = 0;
 
         let coin: Coin = Coin::new(
             hex!("ccd5bb71183532bff220ba46c268991a00000000000000000000000000036840").into(),
@@ -381,24 +344,20 @@ mod tests {
         spends.push((coin, puzzle, solution));
         coin_spends.push(CoinSpend {
             coin,
-            puzzle_reveal: Program::from(puzzle),
-            solution: Program::from(solution),
+            puzzle_reveal: Program::from_bytes(puzzle).expect("puzzle_reveal"),
+            solution: Program::from_bytes(solution).expect("solution"),
         });
-        let node = node_from_bytes(&mut a, puzzle).expect("atom");
-        if node.is_atom() {
-            let puz = node_to_bytes(&a, node).expect("bytes");
-            discrepancy = puzzle.len() - puz.len();
-        }
-        let node = node_from_bytes(&mut a, solution).expect("atom");
-        if node.is_atom() {
-            let sol = node_to_bytes(&a, node).expect("bytes");
-            discrepancy = solution.len() - sol.len();
-        }
+        let node = node_from_bytes_backrefs(&mut a, puzzle).expect("puzzle");
+        let puz = node_to_bytes(&a, node).expect("bytes");
+        discrepancy += puzzle.len() as i64 - puz.len() as i64;
+        let node = node_from_bytes_backrefs(&mut a, solution).expect("solution");
+        let sol = node_to_bytes(&a, node).expect("bytes");
+        discrepancy += solution.len() as i64 - sol.len() as i64;
         let result = solution_generator(spends.clone()).expect("solution_generator");
 
         assert_eq!(
-            result.len(),
-            calculate_generator_length(&coin_spends) - discrepancy
+            result.len() as i64,
+            calculate_generator_length(&coin_spends) as i64 - discrepancy
         );
     }
 

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -4,7 +4,7 @@ use crate::gen::conditions::{
 };
 use crate::gen::flags::MEMPOOL_MODE;
 use crate::gen::run_block_generator::subtract_cost;
-use crate::gen::solution_generator::{calculate_generator_length, solution_generator};
+use crate::gen::solution_generator::calculate_generator_length;
 use crate::gen::validation_error::ValidationErr;
 use crate::spendbundle_validation::get_flags_for_height_and_constants;
 use chia_protocol::SpendBundle;
@@ -87,6 +87,7 @@ mod tests {
     use crate::allocator::make_allocator;
     use crate::gen::conditions::{ELIGIBLE_FOR_DEDUP, ELIGIBLE_FOR_FF};
     use crate::gen::run_block_generator::run_block_generator2;
+    use crate::gen::solution_generator::solution_generator;
     use chia_bls::Signature;
     use chia_protocol::CoinSpend;
     use chia_traits::Streamable;

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -32,17 +32,10 @@ pub fn get_conditions_from_spendbundle(
     let dialect = ChiaDialect::new(flags);
     let mut ret = SpendBundleConditions::default();
     let mut state = ParseState::default();
-
-    let spends_info = spend_bundle.coin_spends.iter().map(|coin_spend| {
-        (
-            coin_spend.coin,
-            &coin_spend.puzzle_reveal,
-            &coin_spend.solution,
-        )
-    });
     // We don't pay the size cost (nor execution cost) of being wrapped by a
     // quote (in solution_generator).
-    let generator_length_without_quote = calculate_generator_length(spends_info) - QUOTE_BYTES;
+    let generator_length_without_quote =
+        calculate_generator_length(&spend_bundle.coin_spends) - QUOTE_BYTES;
 
     let byte_cost = generator_length_without_quote as u64 * constants.cost_per_byte;
     subtract_cost(a, &mut cost_left, byte_cost)?;

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -4,7 +4,7 @@ use crate::gen::conditions::{
 };
 use crate::gen::flags::MEMPOOL_MODE;
 use crate::gen::run_block_generator::subtract_cost;
-use crate::gen::solution_generator::solution_generator;
+use crate::gen::solution_generator::{calculate_generator_length, solution_generator};
 use crate::gen::validation_error::ValidationErr;
 use crate::spendbundle_validation::get_flags_for_height_and_constants;
 use chia_protocol::SpendBundle;
@@ -42,7 +42,8 @@ pub fn get_conditions_from_spendbundle(
     });
     // We don't pay the size cost (nor execution cost) of being wrapped by a
     // quote (in solution_generator).
-    let generator_length_without_quote = solution_generator(spends_info)?.len() - QUOTE_BYTES;
+    let generator_length_without_quote = calculate_generator_length(spends_info) - QUOTE_BYTES;
+
     let byte_cost = generator_length_without_quote as u64 * constants.cost_per_byte;
     subtract_cost(a, &mut cost_left, byte_cost)?;
 


### PR DESCRIPTION
Adds a new function called `calculate_generator_length()` which deterministically calculates the generators byte length given the spends. This function can act as a drop in replacement when we only care about the size of the generator, as the input is the same.