### PR TITLE
[CHIA-1087] remove the `ANALYZE_SPENDS` flag

### DIFF
--- a/crates/chia-consensus/benches/run-generator.rs
+++ b/crates/chia-consensus/benches/run-generator.rs
@@ -51,7 +51,7 @@ fn run(c: &mut Criterion) {
                     let mut a = Allocator::new();
                     let start = Instant::now();
 
-                    let conds = run_block_generator::<_, MempoolVisitor, _>(
+                    let conds = run_block_generator(
                         &mut a,
                         gen,
                         &block_refs,
@@ -69,7 +69,7 @@ fn run(c: &mut Criterion) {
                     let mut a = Allocator::new();
                     let start = Instant::now();
 
-                    let conds = run_block_generator2::<_, MempoolVisitor, _>(
+                    let conds = run_block_generator2(
                         &mut a,
                         gen,
                         &block_refs,

--- a/crates/chia-consensus/fuzz/fuzz_targets/run-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/run-generator.rs
@@ -1,7 +1,6 @@
 #![no_main]
 use chia_consensus::allocator::make_allocator;
 use chia_consensus::consensus_constants::TEST_CONSTANTS;
-use chia_consensus::gen::conditions::MempoolVisitor;
 use chia_consensus::gen::flags::ALLOW_BACKREFS;
 use chia_consensus::gen::run_block_generator::{run_block_generator, run_block_generator2};
 use chia_consensus::gen::validation_error::{ErrorCode, ValidationErr};
@@ -10,7 +9,7 @@ use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     let mut a1 = make_allocator(LIMIT_HEAP);
-    let r1 = run_block_generator::<&[u8], MempoolVisitor, _>(
+    let r1 = run_block_generator::<&[u8], _>(
         &mut a1,
         data,
         [],
@@ -21,7 +20,7 @@ fuzz_target!(|data: &[u8]| {
     drop(a1);
 
     let mut a2 = make_allocator(LIMIT_HEAP);
-    let r2 = run_block_generator2::<&[u8], MempoolVisitor, _>(
+    let r2 = run_block_generator2::<&[u8], _>(
         &mut a2,
         data,
         [],

--- a/crates/chia-consensus/src/gen/flags.rs
+++ b/crates/chia-consensus/src/gen/flags.rs
@@ -13,9 +13,4 @@ pub const STRICT_ARGS_COUNT: u32 = 0x80000;
 // contain back-references
 pub const ALLOW_BACKREFS: u32 = 0x0200_0000;
 
-// When set, the "flags" field of the Spend objects will be set depending on
-// what features are detected of the spends
-pub const ANALYZE_SPENDS: u32 = 0x0400_0000;
-
-pub const MEMPOOL_MODE: u32 =
-    CLVM_MEMPOOL_MODE | NO_UNKNOWN_CONDS | STRICT_ARGS_COUNT | ANALYZE_SPENDS;
+pub const MEMPOOL_MODE: u32 = CLVM_MEMPOOL_MODE | NO_UNKNOWN_CONDS | STRICT_ARGS_COUNT;

--- a/crates/chia-consensus/src/gen/get_puzzle_and_solution.rs
+++ b/crates/chia-consensus/src/gen/get_puzzle_and_solution.rs
@@ -61,7 +61,7 @@ pub fn get_puzzle_and_solution_for_coin(
 mod test {
     use super::*;
     use crate::consensus_constants::TEST_CONSTANTS;
-    use crate::gen::conditions::{u64_to_bytes, MempoolVisitor};
+    use crate::gen::conditions::u64_to_bytes;
     use crate::gen::flags::{ALLOW_BACKREFS, MEMPOOL_MODE};
     use crate::gen::run_block_generator::{run_block_generator2, setup_generator_args};
     use chia_protocol::Bytes32;
@@ -234,7 +234,7 @@ mod test {
 
         let mut a = Allocator::new();
         let blocks: &[&[u8]] = &[];
-        let conds = run_block_generator2::<_, MempoolVisitor, _>(
+        let conds = run_block_generator2(
             &mut a,
             &generator,
             blocks,

--- a/crates/chia-consensus/src/gen/run_block_generator.rs
+++ b/crates/chia-consensus/src/gen/run_block_generator.rs
@@ -1,9 +1,9 @@
 use crate::consensus_constants::ConsensusConstants;
 use crate::gen::conditions::{
-    parse_spends, process_single_spend, validate_conditions, ParseState, SpendBundleConditions,
+    parse_spends, process_single_spend, validate_conditions, EmptyVisitor, ParseState,
+    SpendBundleConditions,
 };
 use crate::gen::flags::ALLOW_BACKREFS;
-use crate::gen::spend_visitor::SpendVisitor;
 use crate::gen::validation_error::{first, ErrorCode, ValidationErr};
 use crate::generator_rom::{CLVM_DESERIALIZER, GENERATOR_ROM};
 use clvm_utils::{tree_hash_cached, TreeHash};
@@ -67,7 +67,7 @@ where
 // the only reason we need to pass in the allocator is because the returned
 // SpendBundleConditions contains NodePtr fields. If that's changed, we could
 // create the allocator inside this functions as well.
-pub fn run_block_generator<GenBuf: AsRef<[u8]>, V: SpendVisitor, I: IntoIterator<Item = GenBuf>>(
+pub fn run_block_generator<GenBuf: AsRef<[u8]>, I: IntoIterator<Item = GenBuf>>(
     a: &mut Allocator,
     program: &[u8],
     block_refs: I,
@@ -112,7 +112,8 @@ where
 
     // we pass in what's left of max_cost here, to fail early in case the
     // cost of a condition brings us over the cost limit
-    let mut result = parse_spends::<V>(a, generator_output, cost_left, flags, constants)?;
+    let mut result =
+        parse_spends::<EmptyVisitor>(a, generator_output, cost_left, flags, constants)?;
     result.cost += max_cost - cost_left;
     Ok(result)
 }
@@ -146,7 +147,7 @@ pub fn extract_n<const N: usize>(
 // you only pay cost for the generator, the puzzles and the conditions).
 // it also does not apply the stack depth or object allocation limits the same,
 // as each puzzle run in its own environment.
-pub fn run_block_generator2<GenBuf: AsRef<[u8]>, V: SpendVisitor, I: IntoIterator<Item = GenBuf>>(
+pub fn run_block_generator2<GenBuf: AsRef<[u8]>, I: IntoIterator<Item = GenBuf>>(
     a: &mut Allocator,
     program: &[u8],
     block_refs: I,
@@ -198,7 +199,7 @@ where
         let buf = tree_hash_cached(a, puzzle, &backrefs, &mut cache);
         let puzzle_hash = a.new_atom(&buf)?;
 
-        process_single_spend::<V>(
+        process_single_spend::<EmptyVisitor>(
             a,
             &mut ret,
             &mut state,

--- a/crates/chia-consensus/src/gen/test_generators.rs
+++ b/crates/chia-consensus/src/gen/test_generators.rs
@@ -1,4 +1,4 @@
-use super::conditions::{MempoolVisitor, NewCoin, SpendBundleConditions, SpendConditions};
+use super::conditions::{NewCoin, SpendBundleConditions, SpendConditions};
 use super::run_block_generator::{run_block_generator, run_block_generator2};
 use crate::allocator::make_allocator;
 use crate::consensus_constants::TEST_CONSTANTS;
@@ -231,7 +231,7 @@ fn run_generator(#[case] name: &str) {
     for (flags, expected) in zip(&[DEFAULT_FLAGS, DEFAULT_FLAGS | MEMPOOL_MODE], expected) {
         println!("flags: {flags:x}");
         let mut a = make_allocator(*flags);
-        let conds = run_block_generator::<_, MempoolVisitor, _>(
+        let conds = run_block_generator(
             &mut a,
             &generator,
             &block_refs,
@@ -246,7 +246,7 @@ fn run_generator(#[case] name: &str) {
         };
 
         let mut a = make_allocator(*flags);
-        let conds = run_block_generator2::<_, MempoolVisitor, _>(
+        let conds = run_block_generator2(
             &mut a,
             &generator,
             &block_refs,

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -133,7 +133,7 @@ mod tests {
         });
         let program = solution_generator(program_spends).expect("solution_generator failed");
         let blocks: &[&[u8]] = &[];
-        let block_conds = run_block_generator2::<_, MempoolVisitor, _>(
+        let block_conds = run_block_generator2(
             &mut a,
             program.as_slice(),
             blocks,
@@ -312,7 +312,7 @@ mod tests {
         // of just the spend bundle will be lower
         let (block_cost, block_output) = {
             let mut a = make_allocator(DEFAULT_FLAGS);
-            let block_conds = run_block_generator::<_, MempoolVisitor, _>(
+            let block_conds = run_block_generator(
                 &mut a,
                 &generator_buffer,
                 &block_refs,

--- a/crates/chia-tools/src/bin/analyze-chain.rs
+++ b/crates/chia-tools/src/bin/analyze-chain.rs
@@ -4,7 +4,6 @@ use std::io::Write;
 use std::time::SystemTime;
 
 use chia_consensus::consensus_constants::TEST_CONSTANTS;
-use chia_consensus::gen::conditions::EmptyVisitor;
 use chia_consensus::gen::flags::{ALLOW_BACKREFS, MEMPOOL_MODE};
 use chia_consensus::gen::run_block_generator::{run_block_generator, run_block_generator2};
 use chia_tools::iterate_tx_blocks;
@@ -51,9 +50,9 @@ fn main() {
             // after the hard fork, we run blocks without paying for the
             // CLVM generator ROM
             let block_runner = if height >= 5_496_000 {
-                run_block_generator2::<_, EmptyVisitor, _>
+                run_block_generator2
             } else {
-                run_block_generator::<_, EmptyVisitor, _>
+                run_block_generator
             };
 
             let generator = block

--- a/crates/chia-tools/src/bin/test-block-generators.rs
+++ b/crates/chia-tools/src/bin/test-block-generators.rs
@@ -2,9 +2,7 @@ use clap::Parser;
 
 use chia_bls::PublicKey;
 use chia_consensus::consensus_constants::TEST_CONSTANTS;
-use chia_consensus::gen::conditions::{
-    EmptyVisitor, NewCoin, SpendBundleConditions, SpendConditions,
-};
+use chia_consensus::gen::conditions::{NewCoin, SpendBundleConditions, SpendConditions};
 use chia_consensus::gen::flags::{ALLOW_BACKREFS, MEMPOOL_MODE};
 use chia_consensus::gen::run_block_generator::{run_block_generator, run_block_generator2};
 use chia_tools::iterate_tx_blocks;
@@ -161,9 +159,9 @@ fn main() {
                 // after the hard fork, we run blocks without paying for the
                 // CLVM generator ROM
                 let block_runner = if height >= 5_496_000 {
-                    run_block_generator2::<_, EmptyVisitor, _>
+                    run_block_generator2
                 } else {
-                    run_block_generator::<_, EmptyVisitor, _>
+                    run_block_generator
                 };
 
                 let mut conditions =
@@ -183,7 +181,7 @@ fn main() {
                 }
 
                 if args.validate {
-                    let mut baseline = run_block_generator::<_, EmptyVisitor, _>(
+                    let mut baseline = run_block_generator(
                         &mut a,
                         generator.as_ref(),
                         &block_refs,

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -3,7 +3,7 @@ use chia_consensus::allocator::make_allocator;
 use chia_consensus::consensus_constants::ConsensusConstants;
 use chia_consensus::gen::conditions::MempoolVisitor;
 use chia_consensus::gen::flags::{
-    ALLOW_BACKREFS, ANALYZE_SPENDS, MEMPOOL_MODE, NO_UNKNOWN_CONDS, STRICT_ARGS_COUNT,
+    ALLOW_BACKREFS, MEMPOOL_MODE, NO_UNKNOWN_CONDS, STRICT_ARGS_COUNT,
 };
 use chia_consensus::gen::owned_conditions::{OwnedSpendBundleConditions, OwnedSpendConditions};
 use chia_consensus::gen::run_block_generator::setup_generator_args;
@@ -502,7 +502,6 @@ pub fn chia_rs(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("STRICT_ARGS_COUNT", STRICT_ARGS_COUNT)?;
     m.add("MEMPOOL_MODE", MEMPOOL_MODE)?;
     m.add("ALLOW_BACKREFS", ALLOW_BACKREFS)?;
-    m.add("ANALYZE_SPENDS", ANALYZE_SPENDS)?;
 
     // Chia classes
     m.add_class::<Coin>()?;

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -1,7 +1,5 @@
 use chia_consensus::allocator::make_allocator;
 use chia_consensus::consensus_constants::ConsensusConstants;
-use chia_consensus::gen::conditions::{EmptyVisitor, MempoolVisitor};
-use chia_consensus::gen::flags::ANALYZE_SPENDS;
 use chia_consensus::gen::owned_conditions::OwnedSpendBundleConditions;
 use chia_consensus::gen::run_block_generator::run_block_generator as native_run_block_generator;
 use chia_consensus::gen::run_block_generator::run_block_generator2 as native_run_block_generator2;
@@ -39,14 +37,10 @@ pub fn run_block_generator<'a>(
         })
         .collect::<Vec<&'a [u8]>>();
     let program = py_to_slice::<'a>(program);
-    let run_block = if (flags & ANALYZE_SPENDS) == 0 {
-        native_run_block_generator::<_, EmptyVisitor, _>
-    } else {
-        native_run_block_generator::<_, MempoolVisitor, _>
-    };
 
     py.allow_threads(|| {
-        match run_block(&mut allocator, program, refs, max_cost, flags, constants) {
+        match native_run_block_generator(&mut allocator, program, refs, max_cost, flags, constants)
+        {
             Ok(spend_bundle_conds) => (
                 None,
                 Some(OwnedSpendBundleConditions::from(
@@ -84,14 +78,10 @@ pub fn run_block_generator2<'a>(
         .collect::<Vec<&'a [u8]>>();
 
     let program = py_to_slice::<'a>(program);
-    let run_block = if (flags & ANALYZE_SPENDS) == 0 {
-        native_run_block_generator2::<_, EmptyVisitor, _>
-    } else {
-        native_run_block_generator2::<_, MempoolVisitor, _>
-    };
 
     py.allow_threads(|| {
-        match run_block(&mut allocator, program, refs, max_cost, flags, constants) {
+        match native_run_block_generator2(&mut allocator, program, refs, max_cost, flags, constants)
+        {
             Ok(spend_bundle_conds) => (
                 None,
                 Some(OwnedSpendBundleConditions::from(


### PR DESCRIPTION
now that the mempool TX validation path has been separated from the block validation, we can remove the `ANALYZE_SPENDS` flag. It's implied for `validate_clvm_and_signature()`.
This, further, lets us remove the `SpendVisitor` generic parameter to `run_block_generator()` and `run_block_generator2()`.

With this PR https://github.com/Chia-Network/chia-blockchain/pull/18557 we have separated the mempool TX validation path from the block validation path. This is why we can now further simplify the block validation path.