### PR TITLE
move mypy config into config

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: python mypy
         run: |
-          mypy --ignore-missing-imports tests
+          mypy tests
 
       - name: python mypy stubtest
         shell: bash

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,7 @@
 [mypy]
 
+[mypy-clvm.*]
+ignore_missing_imports = True
+
 [mypy-colorama.*]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,8 @@
 [mypy]
 
+[mypy-blspy.*]
+ignore_missing_imports = True
+
 [mypy-clvm.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
while latest clvm is indeed hinted, we aren't using latest clvm since we use old blockchain.  so, kinda reverting https://github.com/Chia-Network/chia_rs/pull/684.  the brokenness was masked by the universal `--ignore-missing-imports` on the cli in the ci runs.