### PR TITLE
pass `ParseState` by reference into `validate_conditions()`

### DIFF
--- a/crates/chia-consensus/src/gen/flags.rs
+++ b/crates/chia-consensus/src/gen/flags.rs
@@ -1,13 +1,16 @@
 use clvmr::MEMPOOL_MODE as CLVM_MEMPOOL_MODE;
 
-// flags controlling to condition parsing
+// flags controlling the condition parsing
+// These flags are combined in the same fields as clvm_rs flags, controlling the
+// CLVM execution. To avoid clashes, CLVM flags are in the lower two bytes and
+// condition parsing and validation flags are in the top two bytes.
 
 // unknown condition codes are disallowed
-pub const NO_UNKNOWN_CONDS: u32 = 0x20000;
+pub const NO_UNKNOWN_CONDS: u32 = 0x2_0000;
 
 // With this flag, conditions will require the exact number of arguments
 // currently supported for those conditions. This is meant for mempool-mode
-pub const STRICT_ARGS_COUNT: u32 = 0x80000;
+pub const STRICT_ARGS_COUNT: u32 = 0x8_0000;
 
 // when this flag is set, the block generator serialization is allowed to
 // contain back-references

--- a/crates/chia-consensus/src/gen/get_puzzle_and_solution.rs
+++ b/crates/chia-consensus/src/gen/get_puzzle_and_solution.rs
@@ -61,8 +61,8 @@ pub fn get_puzzle_and_solution_for_coin(
 mod test {
     use super::*;
     use crate::consensus_constants::TEST_CONSTANTS;
-    use crate::gen::conditions::u64_to_bytes;
     use crate::gen::flags::{ALLOW_BACKREFS, MEMPOOL_MODE};
+    use crate::gen::make_aggsig_final_message::u64_to_bytes;
     use crate::gen::run_block_generator::{run_block_generator2, setup_generator_args};
     use chia_protocol::Bytes32;
     use clvm_traits::FromClvm;

--- a/crates/chia-consensus/src/gen/make_aggsig_final_message.rs
+++ b/crates/chia-consensus/src/gen/make_aggsig_final_message.rs
@@ -4,7 +4,6 @@ use crate::gen::opcodes::{
     AGG_SIG_PARENT_PUZZLE, AGG_SIG_PUZZLE, AGG_SIG_PUZZLE_AMOUNT,
 };
 use crate::gen::owned_conditions::OwnedSpendConditions;
-use chia_protocol::Bytes;
 use chia_protocol::Coin;
 
 pub fn make_aggsig_final_message(
@@ -51,13 +50,13 @@ pub fn make_aggsig_final_message(
     }
 }
 
-fn u64_to_bytes(val: u64) -> Bytes {
+pub fn u64_to_bytes(val: u64) -> Vec<u8> {
     let amount_bytes: [u8; 8] = val.to_be_bytes();
     if val >= 0x8000_0000_0000_0000_u64 {
         let mut ret = Vec::<u8>::new();
         ret.push(0_u8);
         ret.extend(amount_bytes);
-        Bytes::new(ret)
+        ret
     } else {
         let start = match val {
             n if n >= 0x0080_0000_0000_0000_u64 => 0,
@@ -70,7 +69,7 @@ fn u64_to_bytes(val: u64) -> Bytes {
             n if n > 0 => 7,
             _ => 8,
         };
-        Bytes::new(amount_bytes[start..].to_vec())
+        amount_bytes[start..].to_vec()
     }
 }
 

--- a/crates/chia-consensus/src/gen/run_block_generator.rs
+++ b/crates/chia-consensus/src/gen/run_block_generator.rs
@@ -216,7 +216,7 @@ where
         return Err(ValidationErr(all_spends, ErrorCode::GeneratorRuntimeError));
     }
 
-    validate_conditions(a, &ret, state, a.nil(), flags)?;
+    validate_conditions(a, &ret, &state, a.nil(), flags)?;
 
     ret.cost = max_cost - cost_left;
     Ok(ret)

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -66,7 +66,7 @@ pub fn get_conditions_from_spendbundle(
         )?;
     }
 
-    validate_conditions(a, &ret, state, a.nil(), flags)?;
+    validate_conditions(a, &ret, &state, a.nil(), flags)?;
     assert!(max_cost >= cost_left);
     ret.cost = max_cost - cost_left;
     Ok(ret)

--- a/crates/chia-consensus/src/spendbundle_validation.rs
+++ b/crates/chia-consensus/src/spendbundle_validation.rs
@@ -122,7 +122,7 @@ pub fn get_flags_for_height_and_constants(height: u32, constants: &ConsensusCons
 mod tests {
     use super::*;
     use crate::consensus_constants::TEST_CONSTANTS;
-    use crate::gen::conditions::u64_to_bytes;
+    use crate::gen::make_aggsig_final_message::u64_to_bytes;
     use chia_bls::{sign, G2Element, SecretKey, Signature};
     use chia_protocol::{Bytes, Bytes32};
     use chia_protocol::{Coin, CoinSpend, Program};


### PR DESCRIPTION
There's nothing in `validate_conditions()` that need to take ownership of anything in `ParseState`.

Also, remove redundant `u64_to_bytes()` function and improve documentation of condition flags,