### PR TITLE
Change BLSCache to use the augmented message for its lookup

### DIFF
--- a/crates/chia-bls/src/bls_cache.rs
+++ b/crates/chia-bls/src/bls_cache.rs
@@ -53,7 +53,9 @@ impl BlsCache {
             // Hash pubkey + message
             let mut hasher = Sha256::new();
             hasher.update(pk.borrow().to_bytes());
-            hasher.update(msg.as_ref());
+            let mut aug_msg = pk.borrow().to_bytes().to_vec();
+            aug_msg.extend_from_slice(msg.as_ref());
+            hasher.update(&aug_msg);
             let hash: [u8; 32] = hasher.finalize();
 
             // If the pairing is in the cache, we don't need to recalculate it.
@@ -62,8 +64,6 @@ impl BlsCache {
             }
 
             // Otherwise, we need to calculate the pairing and add it to the cache.
-            let mut aug_msg = pk.borrow().to_bytes().to_vec();
-            aug_msg.extend_from_slice(msg.as_ref());
             let aug_hash = hash_to_g2(&aug_msg);
 
             let mut hasher = Sha256::new();

--- a/crates/chia-bls/src/bls_cache.rs
+++ b/crates/chia-bls/src/bls_cache.rs
@@ -52,7 +52,6 @@ impl BlsCache {
         let iter = pks_msgs.into_iter().map(|(pk, msg)| -> GTElement {
             // Hash pubkey + message
             let mut hasher = Sha256::new();
-            hasher.update(pk.borrow().to_bytes());
             let mut aug_msg = pk.borrow().to_bytes().to_vec();
             aug_msg.extend_from_slice(msg.as_ref());
             hasher.update(&aug_msg);
@@ -65,10 +64,6 @@ impl BlsCache {
 
             // Otherwise, we need to calculate the pairing and add it to the cache.
             let aug_hash = hash_to_g2(&aug_msg);
-
-            let mut hasher = Sha256::new();
-            hasher.update(&aug_msg);
-            let hash: [u8; 32] = hasher.finalize();
 
             let pairing = aug_hash.pair(pk.borrow());
             self.cache.put(hash, pairing.clone());

--- a/crates/chia-consensus/src/spendbundle_validation.rs
+++ b/crates/chia-consensus/src/spendbundle_validation.rs
@@ -38,7 +38,6 @@ pub fn validate_clvm_and_signature(
     let mut pairs = Vec::new();
 
     let mut aug_msg = Vec::<u8>::new();
-    let mut final_msg = Vec::<u8>::new();
 
     for spend in &conditions.spends {
         let condition_items_pairs = [
@@ -54,14 +53,12 @@ pub fn validate_clvm_and_signature(
         for (condition, items) in condition_items_pairs {
             for (pk, msg) in items {
                 aug_msg.clear();
-                final_msg.clear();
-                final_msg.extend_from_slice(msg.as_slice());
                 aug_msg.extend_from_slice(&pk.to_bytes());
-                make_aggsig_final_message(condition, &mut final_msg, spend, constants);
-                aug_msg.extend(&final_msg);
+                aug_msg.extend_from_slice(msg.as_slice());
+                make_aggsig_final_message(condition, &mut aug_msg, spend, constants);
                 let aug_hash = hash_to_g2(&aug_msg);
                 let pairing = aug_hash.pair(pk);
-                pairs.push((hash_pk_and_msg(&pk.to_bytes(), &final_msg), pairing));
+                pairs.push((hash_pk_and_msg(&pk.to_bytes(), &aug_msg), pairing));
             }
         }
     }


### PR DESCRIPTION
This reduces the allocations required inside the bls_cache and inside `spendbundle_validation.rs`.