### PR TITLE
[CHIA-1563] add function to run a *trusted* block and return additions and removals.

### DIFF
--- a/crates/chia-consensus/benches/run-generator.rs
+++ b/crates/chia-consensus/benches/run-generator.rs
@@ -1,5 +1,6 @@
 use chia_bls::Signature;
 use chia_consensus::consensus_constants::TEST_CONSTANTS;
+use chia_consensus::gen::additions_and_removals::additions_and_removals;
 use chia_consensus::gen::flags::{ALLOW_BACKREFS, DONT_VALIDATE_SIGNATURE};
 use chia_consensus::gen::run_block_generator::{run_block_generator, run_block_generator2};
 use clvmr::serde::{node_from_bytes, node_to_bytes_backrefs};
@@ -82,6 +83,15 @@ fn run(c: &mut Criterion) {
                         &TEST_CONSTANTS,
                     );
                     let _ = black_box(conds);
+                    start.elapsed()
+                });
+            });
+
+            group.bench_function(format!("additions_and_removals {name}{name_suffix}"), |b| {
+                b.iter(|| {
+                    let start = Instant::now();
+                    let results = additions_and_removals(gen, &block_refs, 0, &TEST_CONSTANTS);
+                    let _ = black_box(results);
                     start.elapsed()
                 });
             });

--- a/crates/chia-consensus/fuzz/Cargo.toml
+++ b/crates/chia-consensus/fuzz/Cargo.toml
@@ -113,3 +113,10 @@ path = "fuzz_targets/solution-generator.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "additions-and-removals"
+path = "fuzz_targets/additions-and-removals.rs"
+test = false
+doc = false
+bench = false

--- a/crates/chia-consensus/fuzz/fuzz_targets/additions-and-removals.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/additions-and-removals.rs
@@ -1,0 +1,82 @@
+#![no_main]
+use chia_bls::Signature;
+use chia_consensus::allocator::make_allocator;
+use chia_consensus::consensus_constants::TEST_CONSTANTS;
+use chia_consensus::gen::additions_and_removals::additions_and_removals;
+use chia_consensus::gen::flags::{ALLOW_BACKREFS, DONT_VALIDATE_SIGNATURE};
+use chia_consensus::gen::run_block_generator::run_block_generator2;
+use chia_protocol::{Bytes, Coin};
+use libfuzzer_sys::fuzz_target;
+use std::collections::HashSet;
+
+fuzz_target!(|data: &[u8]| {
+    // additions_and_removals only work on trusted blocks, so if
+    // run_block_generator2() fails, we can call additions_and_removals() on it.
+    let results = additions_and_removals::<&[u8], _>(data, [], ALLOW_BACKREFS, &TEST_CONSTANTS);
+
+    let mut a1 = make_allocator(0);
+    let Ok(r1) = run_block_generator2::<&[u8], _>(
+        &mut a1,
+        data,
+        [],
+        110_000_000,
+        ALLOW_BACKREFS | DONT_VALIDATE_SIGNATURE,
+        &Signature::default(),
+        None,
+        &TEST_CONSTANTS,
+    ) else {
+        // just because the full block execution fails, doesn't mean
+        // additons_and_removals() failed. It assumes a valid block and may
+        // return Ok even for invalid blocks.
+        return;
+    };
+
+    // if run_block_generator() passed however, additions_and_removals() also
+    // must pass
+    let (additions, removals) = results.expect("additions_and_removals()");
+
+    let mut expect_additions = HashSet::<(Coin, Option<Bytes>)>::new();
+    let mut expect_removals = HashSet::<Coin>::new();
+
+    for spend in &r1.spends {
+        let removal = Coin {
+            parent_coin_info: a1
+                .atom(spend.parent_id)
+                .as_ref()
+                .try_into()
+                .expect("CREATE_COIN parent id"),
+            puzzle_hash: a1
+                .atom(spend.puzzle_hash)
+                .as_ref()
+                .try_into()
+                .expect("CREATE_COIN puzzle hash"),
+            amount: spend.coin_amount,
+        };
+        let coin_id = removal.coin_id();
+        expect_removals.insert(removal);
+        for add in &spend.create_coin {
+            let addition = Coin {
+                parent_coin_info: coin_id,
+                puzzle_hash: add.puzzle_hash,
+                amount: add.amount,
+            };
+            let hint = if a1.atom_len(add.hint) == 32 {
+                Some(Into::<Bytes>::into(a1.atom(add.hint).as_ref()))
+            } else {
+                None
+            };
+            expect_additions.insert((addition, hint));
+        }
+    }
+
+    assert_eq!(expect_additions.len(), additions.len());
+    assert_eq!(expect_removals.len(), removals.len());
+
+    for a in &additions {
+        assert!(expect_additions.contains(a));
+    }
+
+    for r in &removals {
+        assert!(expect_removals.contains(r));
+    }
+});

--- a/crates/chia-consensus/src/gen/additions_and_removals.rs
+++ b/crates/chia-consensus/src/gen/additions_and_removals.rs
@@ -1,0 +1,234 @@
+use crate::gen::run_block_generator::setup_generator_args;
+use crate::gen::run_block_generator::subtract_cost;
+use chia_protocol::Coin;
+
+use crate::allocator::make_allocator;
+use crate::consensus_constants::ConsensusConstants;
+use crate::gen::validation_error::{atom, first, next, rest, ErrorCode, ValidationErr};
+use chia_protocol::{Bytes, Bytes32};
+use clvm_traits::FromClvm;
+use clvm_utils::{tree_hash_cached, TreeHash};
+use clvmr::allocator::NodePtr;
+use clvmr::chia_dialect::ChiaDialect;
+use clvmr::reduction::Reduction;
+use clvmr::run_program::run_program;
+use clvmr::serde::node_from_bytes_backrefs_record;
+use std::collections::HashMap;
+
+/// Run a *trusted* block generator and return its additions and removals. This
+/// function does not validate the block, it is assumed to be valid.
+/// The returned vectors are additions (with hints) and removals.
+#[allow(clippy::type_complexity)]
+pub fn additions_and_removals<GenBuf: AsRef<[u8]>, I: IntoIterator<Item = GenBuf>>(
+    program: &[u8],
+    block_refs: I,
+    flags: u32,
+    constants: &ConsensusConstants,
+) -> Result<(Vec<(Coin, Option<Bytes>)>, Vec<Coin>), ValidationErr>
+where
+    <I as IntoIterator>::IntoIter: DoubleEndedIterator,
+{
+    let mut a = make_allocator(flags);
+    let mut additions = Vec::<(Coin, Option<Bytes>)>::new();
+    let mut removals = Vec::<Coin>::new();
+
+    let mut cost_left = constants.max_block_cost_clvm;
+
+    let (program, backrefs) = node_from_bytes_backrefs_record(&mut a, program)?;
+
+    let args = setup_generator_args(&mut a, block_refs)?;
+    let dialect = ChiaDialect::new(flags);
+
+    let Reduction(clvm_cost, mut all_spends) =
+        run_program(&mut a, &dialect, program, args, cost_left)?;
+
+    subtract_cost(&a, &mut cost_left, clvm_cost)?;
+    all_spends = first(&a, all_spends)?;
+
+    let mut cache = HashMap::<NodePtr, TreeHash>::new();
+    // at this point all_spends is a list of:
+    // (parent-coin-id puzzle-reveal amount solution . extra)
+    // where extra may be nil, or additional extension data
+
+    while let Some((spend, tail)) = a.next(all_spends) {
+        all_spends = tail;
+        // process the spend
+        let (parent_id, (puzzle, (amount, (solution, _spend_level_extra)))) =
+            <(Bytes32, (NodePtr, (u64, (NodePtr, NodePtr))))>::from_clvm(&a, spend)
+                .map_err(|_| ValidationErr(spend, ErrorCode::InvalidCondition))?;
+
+        let Reduction(clvm_cost, mut iter) =
+            run_program(&mut a, &dialect, puzzle, solution, cost_left)?;
+
+        subtract_cost(&a, &mut cost_left, clvm_cost)?;
+
+        let puzzle_hash = tree_hash_cached(&a, puzzle, &backrefs, &mut cache);
+
+        let coin = Coin {
+            parent_coin_info: parent_id,
+            puzzle_hash: puzzle_hash.into(),
+            amount,
+        };
+
+        removals.push(coin);
+        let spend_id = coin.coin_id();
+
+        while let Some((mut c, next)) = next(&a, iter)? {
+            iter = next;
+            let op = first(&a, c)?;
+            let Ok(op) = atom(&a, op, ErrorCode::InvalidConditionOpcode) else {
+                // unknown opcodes (including pairs) are simply ingnored in
+                // consensus mode
+                continue;
+            };
+            // CREATE_COIN
+            if op.as_ref() != [51_u8] {
+                continue;
+            }
+            c = rest(&a, c)?;
+
+            let (puzzle_hash, (amount, hint)) = <(Bytes32, (u64, NodePtr))>::from_clvm(&a, c)
+                .map_err(|_| ValidationErr(c, ErrorCode::InvalidCondition))?;
+
+            let coin = Coin {
+                parent_coin_info: spend_id,
+                puzzle_hash,
+                amount,
+            };
+
+            // there was another item in the list
+            // the item was a cons-box, and params is the left-hand
+            // side, the list element
+
+            let hint =
+                if let Ok(((hint, _), _)) = <((Bytes, NodePtr), NodePtr)>::from_clvm(&a, hint) {
+                    if hint.len() <= 32 {
+                        Some(hint)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+            additions.push((coin, hint));
+        }
+    }
+
+    Ok((additions, removals))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::consensus_constants::TEST_CONSTANTS;
+    use crate::gen::flags::{ALLOW_BACKREFS, DONT_VALIDATE_SIGNATURE};
+    use crate::gen::run_block_generator::run_block_generator2;
+    use chia_bls::Signature;
+    use rstest::rstest;
+    use std::collections::HashSet;
+
+    #[rstest]
+    #[case("new-agg-sigs")]
+    #[case("block-1ee588dc")]
+    #[case("block-6fe59b24")]
+    #[case("block-b45268ac")]
+    #[case("block-c2a8df0d")]
+    #[case("block-e5002df2")]
+    #[case("block-4671894")]
+    #[case("block-225758")]
+    #[case("block-834752")]
+    #[case("block-834752-compressed")]
+    #[case("block-834760")]
+    #[case("block-834761")]
+    #[case("block-834765")]
+    #[case("block-834766")]
+    #[case("block-834768")]
+    #[case("create-coin-different-amounts")]
+    #[case("create-coin-hint")]
+    #[case("create-coin-hint2")]
+    #[case("duplicate-height-absolute-div")]
+    #[case("just-puzzle-announce")]
+    #[case("many-create-coin")]
+    #[case("many-large-ints-negative")]
+    #[case("max-height")]
+    #[case("multiple-reserve-fee")]
+    #[case("unknown-condition")]
+    fn test_additions_and_removals(#[case] name: &str) {
+        use std::fs::read_to_string;
+
+        let filename = format!("../../generator-tests/{name}.txt");
+        println!("file: {filename}");
+        let test_file = read_to_string(filename).expect("test file not found");
+        let (generator, _expected) = test_file.split_once('\n').expect("invalid test file");
+        let generator = hex::decode(generator).expect("invalid hex encoded generator");
+
+        let mut block_refs = Vec::<Vec<u8>>::new();
+
+        let filename = format!("../../generator-tests/{name}.env");
+        if let Ok(env_hex) = read_to_string(&filename) {
+            println!("block-ref file: {filename}");
+            block_refs.push(hex::decode(env_hex).expect("hex decode env-file"));
+        }
+
+        // we run the block using run_block_generator2() to extract the additions
+        // and removals we *expect* to see
+        // additions_and_removals only work on trusted blocks, so if
+        // run_block_generator2() fails, we can call additions_and_removals() on it.
+        let mut a = make_allocator(0);
+        let conds = run_block_generator2(
+            &mut a,
+            &generator,
+            &block_refs,
+            11_000_000_000,
+            ALLOW_BACKREFS | DONT_VALIDATE_SIGNATURE,
+            &Signature::default(),
+            None,
+            &TEST_CONSTANTS,
+        )
+        .expect("run_block_generator2()");
+
+        let mut expect_additions = HashSet::<(Coin, Option<Bytes>)>::new();
+        let mut expect_removals = HashSet::<Coin>::new();
+
+        for spend in &conds.spends {
+            let removal = Coin {
+                parent_coin_info: a.atom(spend.parent_id).as_ref().try_into().unwrap(),
+                puzzle_hash: a.atom(spend.puzzle_hash).as_ref().try_into().unwrap(),
+                amount: spend.coin_amount,
+            };
+            let coin_id = removal.coin_id();
+            expect_removals.insert(removal);
+            for add in &spend.create_coin {
+                let addition = Coin {
+                    parent_coin_info: coin_id,
+                    puzzle_hash: add.puzzle_hash,
+                    amount: add.amount,
+                };
+                let hint = if add.hint != NodePtr::NIL && a.atom_len(add.hint) <= 32 {
+                    Some(Into::<Bytes>::into(a.atom(add.hint).as_ref()))
+                } else {
+                    None
+                };
+                println!("expect : {addition:?} hint: {hint:?}");
+                expect_additions.insert((addition, hint));
+            }
+        }
+
+        // now run the function under test
+        let (additions, removals) =
+            additions_and_removals(&generator, &block_refs, ALLOW_BACKREFS, &TEST_CONSTANTS)
+                .expect("additions_and_removals()");
+
+        assert_eq!(expect_additions.len(), additions.len());
+        assert_eq!(expect_removals.len(), removals.len());
+
+        for a in &additions {
+            println!("addition: {a:?}");
+            assert!(expect_additions.contains(a));
+        }
+
+        for r in &removals {
+            assert!(expect_removals.contains(r));
+        }
+    }
+}

--- a/crates/chia-consensus/src/gen/mod.rs
+++ b/crates/chia-consensus/src/gen/mod.rs
@@ -1,3 +1,4 @@
+pub mod additions_and_removals;
 mod coin_id;
 mod condition_sanitizers;
 pub mod conditions;

--- a/crates/chia-tools/src/bin/gen-corpus.rs
+++ b/crates/chia-tools/src/bin/gen-corpus.rs
@@ -27,6 +27,7 @@ use std::time::{Duration, Instant};
 /// Analyze the spends in a chia blockchain database
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
+#[allow(clippy::struct_excessive_bools)]
 struct Args {
     /// Path to blockchain database file to analyze
     file: String,
@@ -39,7 +40,7 @@ struct Args {
     #[arg(long, default_value_t = false)]
     spend_bundles: bool,
 
-    /// generate corpus for run_block_generator()
+    /// generate corpus for run_block_generator() and additions_and_removals()
     #[arg(long, default_value_t = false)]
     block_generators: bool,
 
@@ -96,6 +97,10 @@ fn main() {
 
                 if args.block_generators {
                     let directory = "../chia-protocol/fuzz/corpus/run-generator";
+                    let _ = std::fs::create_dir_all(directory);
+                    write(format!("{directory}/{height}.bundle"), generator).expect("write");
+
+                    let directory = "../chia-protocol/fuzz/corpus/additions-and-removals";
                     let _ = std::fs::create_dir_all(directory);
                     write(format!("{directory}/{height}.bundle"), generator).expect("write");
                     cnt.fetch_add(1, Ordering::Relaxed);

--- a/tests/test_additions_and_removals.py
+++ b/tests/test_additions_and_removals.py
@@ -1,0 +1,90 @@
+from typing import Set, Optional, Tuple
+from chia_rs import (
+    additions_and_removals,
+    ALLOW_BACKREFS,
+)
+from run_gen import DEFAULT_CONSTANTS
+from pathlib import Path
+import glob
+
+
+def test_additions_and_removals() -> None:
+
+    for g in sorted(glob.glob("generator-tests/*.txt")):
+        print(f"{Path(g).name}")
+
+        test_file = open(g, "r").read()
+        generator_hex, test_file = test_file.split("\n", 1)
+        generator = bytes.fromhex(generator_hex)
+
+        test_file = test_file.split("STRICT:", 1)[0]
+
+        # add the block program arguments
+        block_refs = []
+        args = g.replace(".txt", ".env")
+        if args and args != "":
+            try:
+                with open(args, "r") as f:
+                    block_refs = [bytes.fromhex(f.read())]
+            except OSError as e:
+                pass
+
+        try:
+            additions, removals = additions_and_removals(
+                generator, block_refs, ALLOW_BACKREFS, DEFAULT_CONSTANTS
+            )
+
+            # if this was an invalid block, it wasn't OK to pass it to
+            # additions_and_removals() to begin with
+            if "FAILED: " in test_file:
+                continue
+
+            expected_additions: Set[Tuple[str, str, str, Optional[str]]] = set()
+            expected_removals: Set[Tuple[str, str]] = set()
+            last_coin_id = ""
+            for l in test_file.splitlines():
+                if "- coin id: " in l:
+                    fields = l.split()
+                    last_coin_id = fields[3]
+                    expected_removals.add((fields[3], fields[5]))
+                elif "  CREATE_COIN: ph: " in l:
+                    fields = l.split()
+                    if len(fields) > 6:
+                        expected_additions.add(
+                            (last_coin_id, fields[2], fields[4], fields[6])
+                        )
+                    else:
+                        expected_additions.add(
+                            (last_coin_id, fields[2], fields[4], None)
+                        )
+
+            assert len(additions) == len(expected_additions)
+            assert len(removals) == len(expected_removals)
+
+            for add in additions:
+                addition: Tuple[str, str, str, Optional[str]]
+                if add[1] is not None:
+                    addition = (
+                        f"{add[0].parent_coin_info}",
+                        f"{add[0].puzzle_hash.hex()}",
+                        f"{add[0].amount}",
+                        f"{add[1].hex() if add[1] is not None else None}",
+                    )
+                else:
+                    addition = (
+                        f"{add[0].parent_coin_info}",
+                        f"{add[0].puzzle_hash.hex()}",
+                        f"{add[0].amount}",
+                        None,
+                    )
+                assert addition in expected_additions
+                expected_additions.remove(addition)
+
+            for rem in removals:
+                removal = (f"{rem.name().hex()}", f"{rem.puzzle_hash.hex()}")
+                assert removal in expected_removals
+                expected_removals.remove(removal)
+            assert expected_additions == set()
+            assert expected_removals == set()
+        except ValueError as e:
+            assert "FAILED: " in test_file

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -288,6 +288,10 @@ def run_block_generator2(
     program: ReadableBuffer, block_refs: List[ReadableBuffer], max_cost: int, flags: int, signature: G2Element, bls_cache: Optional[BLSCache], constants: ConsensusConstants
 ) -> Tuple[Optional[int], Optional[SpendBundleConditions]]: ...
 
+def additions_and_removals(
+    program: ReadableBuffer, block_refs: List[ReadableBuffer], flags: int, constants: ConsensusConstants
+) -> Tuple[List[Tuple[Coin, Optional[bytes]]], List[Coin]]: ...
+
 def confirm_included_already_hashed(
     root: bytes32,
     item: bytes32,

--- a/wheel/python/chia_rs/chia_rs.pyi
+++ b/wheel/python/chia_rs/chia_rs.pyi
@@ -30,6 +30,10 @@ def run_block_generator2(
     program: ReadableBuffer, block_refs: List[ReadableBuffer], max_cost: int, flags: int, signature: G2Element, bls_cache: Optional[BLSCache], constants: ConsensusConstants
 ) -> Tuple[Optional[int], Optional[SpendBundleConditions]]: ...
 
+def additions_and_removals(
+    program: ReadableBuffer, block_refs: List[ReadableBuffer], flags: int, constants: ConsensusConstants
+) -> Tuple[List[Tuple[Coin, Optional[bytes]]], List[Coin]]: ...
+
 def confirm_included_already_hashed(
     root: bytes32,
     item: bytes32,

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -1,4 +1,6 @@
-use crate::run_generator::{py_to_slice, run_block_generator, run_block_generator2};
+use crate::run_generator::{
+    additions_and_removals, py_to_slice, run_block_generator, run_block_generator2,
+};
 use chia_consensus::allocator::make_allocator;
 use chia_consensus::consensus_constants::ConsensusConstants;
 use chia_consensus::gen::flags::{
@@ -451,6 +453,7 @@ pub fn chia_rs(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // generator functions
     m.add_function(wrap_pyfunction!(run_block_generator, m)?)?;
     m.add_function(wrap_pyfunction!(run_block_generator2, m)?)?;
+    m.add_function(wrap_pyfunction!(additions_and_removals, m)?)?;
     m.add_function(wrap_pyfunction!(solution_generator, m)?)?;
     m.add_function(wrap_pyfunction!(solution_generator_backrefs, m)?)?;
     m.add_function(wrap_pyfunction!(supports_fast_forward, m)?)?;

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -1,16 +1,20 @@
 use chia_bls::{BlsCache, Signature};
 use chia_consensus::allocator::make_allocator;
 use chia_consensus::consensus_constants::ConsensusConstants;
+use chia_consensus::gen::additions_and_removals::additions_and_removals as native_additions_and_removals;
 use chia_consensus::gen::owned_conditions::OwnedSpendBundleConditions;
 use chia_consensus::gen::run_block_generator::run_block_generator as native_run_block_generator;
 use chia_consensus::gen::run_block_generator::run_block_generator2 as native_run_block_generator2;
 use chia_consensus::gen::validation_error::ValidationErr;
+use chia_protocol::Bytes;
+use chia_protocol::Coin;
 
 use clvmr::cost::Cost;
 
 use pyo3::buffer::PyBuffer;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
+use pyo3::PyResult;
 
 pub fn py_to_slice<'a>(buf: PyBuffer<u8>) -> &'a [u8] {
     assert!(buf.is_c_contiguous(), "buffer must be contiguous");
@@ -119,5 +123,37 @@ pub fn run_block_generator2<'a>(
                 (Some(error_code.into()), None)
             }
         }
+    })
+}
+
+#[pyfunction]
+#[allow(clippy::type_complexity)]
+pub fn additions_and_removals<'a>(
+    py: Python<'a>,
+    program: PyBuffer<u8>,
+    block_refs: &Bound<'_, PyList>,
+    flags: u32,
+    constants: &ConsensusConstants,
+) -> PyResult<(Vec<(Coin, Option<Bytes>)>, Vec<Coin>)> {
+    let refs = block_refs
+        .into_iter()
+        .map(|b| {
+            let buf = b
+                .extract::<PyBuffer<u8>>()
+                .expect("block_refs must be list of buffers");
+            py_to_slice::<'a>(buf)
+        })
+        .collect::<Vec<&'a [u8]>>();
+
+    let program = py_to_slice::<'a>(program);
+
+    py.allow_threads(|| {
+        native_additions_and_removals(program, refs, flags, constants).map_err(|e| {
+            // a validation error occurred
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "additions_and_removals() failed: {}",
+                e.1 as u16
+            ))
+        })
     })
 }


### PR DESCRIPTION
This adds a function called `additions_and_removals()`, which is similar to `run_block_generator()` and `run_block_generator2()` but with some important differences.

`additions_and_removals()`:
* assumes that the block is valid. It's only meant to be run on blocks we've already validated (and perhaps pulled out of the blockchain database).
* only return the created coins ("additions") and spent coins ("removals"). The created coins also include the optional hint.

# motivation

The two main reasons to introduce this function are:
* It's faster than `run_block_generator()`
* It completes the two use cases `chia-blockchain` has for running blocks. Letting `run_block_generator()` be more specialized to always fully validate blocks (e.g. the signature).

## running trusted blocks

In `chia-blockchain` we sometimes validate blocks completely (1). Ensuring their conditions hold, their signatures are correct, the proof of space is correct etc. This is done as part of syncing a node as well as keeping up with the chain and maintaining the mempool. When we receive a transaction for the mempool, we fully validate it before accepting it. When we receive an `UnfinishedBlock`, we fully validated it.

The other use case for running block generators is to just get additions and removals (2) to respond to an RPC or to rebuild the coin store during a reorg (or when adding an orphaned block). This, case 2, could be replaced by the cheaper call to `additions_and_removals().

The non-test call sites of `get_name_puzzle_conditions()` are:

* `CostLogger.add_cost()` - part of the spend-sim, to compute the cost of a block in the simulator. This requires the full `run_block_generator() to compute the cost. Case (1).
* `Blockchain.run_single_block()` - this is to catch up a `ForkInfo` object with all the additions and removals of a fork of the chain. We need to do this when adding orphaned blocks, or reorging. Case (2).
* `batch_pre_validate_blocks()` - this is run when validating full blocks, either because we're syncing or just received a new block extending the blockchain. Case (1).
* `_run_generator()` - this is called when validating an `UnfinishedBlock`. Case (1).
`FullNodeAPI.request_block_header()` - this is an RPC called on existing, validated, blocks in the chain. Case (2).
* `FullBlockApi.request_block_header()` - To construct a block header from a full block, we need the additions and removals, so we recompute them from a trusted block. Case (2).

### git grep output, for non-tests and non-imports:

```
git grep -B 1 -A 1 get_name_puzzle_conditions

chia/clvm/spend_sim.py-        program: BlockGenerator = simple_solution_generator(spend_bundle)
chia/clvm/spend_sim.py:        npc_result: NPCResult = get_name_puzzle_conditions(
chia/clvm/spend_sim.py-            program,
--
chia/consensus/block_creation.py-def compute_block_cost(generator: BlockGenerator, constants: ConsensusConstants, height: uint32) -> uint64:
chia/consensus/block_creation.py:    result: NPCResult = get_name_puzzle_conditions(
chia/consensus/block_creation.py-        generator, constants.MAX_BLOCK_COST_CLVM, mempool_mode=True, height=height, constants=constants
--
chia/consensus/blockchain.py-            assert block.foliage_transaction_block is not None
chia/consensus/blockchain.py:            npc = get_name_puzzle_conditions(
chia/consensus/blockchain.py-                block_generator,
--
chia/consensus/multiprocess_validation.py-                assert block_generator.program == block.transactions_generator
chia/consensus/multiprocess_validation.py:                npc_result = get_name_puzzle_conditions(
chia/consensus/multiprocess_validation.py-                    block_generator,
--
chia/consensus/multiprocess_validation.py-        assert block_generator.program == unfinished_block.transactions_generator
chia/consensus/multiprocess_validation.py:        npc_result: NPCResult = get_name_puzzle_conditions(
chia/consensus/multiprocess_validation.py-            block_generator,
--
chia/full_node/full_node_api.py-                functools.partial(
chia/full_node/full_node_api.py:                    get_name_puzzle_conditions,
chia/full_node/full_node_api.py-                    block_generator,
```

## Performance

One of the main reasons to justify this function, rather than just calling `run_block_generator()` is the time you can save. Here's the benchmark for block 4671894 on mainnet. The plot below compares `run_block_generator()` (slowest), `run_block_generator2()` (middle) and `additions_and_removals()` (fastest).

![image](https://github.com/user-attachments/assets/aa0ce30c-1ef4-4a58-9036-9b9dc98fb864)
