### PR TITLE
make BlsCache thread safe by adding an internal mutex

### DIFF
--- a/crates/chia-bls/Cargo.toml
+++ b/crates/chia-bls/Cargo.toml
@@ -35,6 +35,7 @@ rstest = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]
+bench = false
 
 [[bench]]
 name = "derive_key"

--- a/crates/chia-bls/src/bls_cache.rs
+++ b/crates/chia-bls/src/bls_cache.rs
@@ -3,6 +3,7 @@ use std::num::NonZeroUsize;
 
 use chia_sha2::Sha256;
 use lru::LruCache;
+use std::sync::Mutex;
 
 use crate::{aggregate_verify_gt, hash_to_g2};
 use crate::{GTElement, PublicKey, Signature};
@@ -17,10 +18,10 @@ use crate::{GTElement, PublicKey, Signature};
 /// aggregate_verify() primitive is faster. When long-syncing, that's
 /// preferable.
 #[cfg_attr(feature = "py-bindings", pyo3::pyclass(name = "BLSCache"))]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BlsCache {
     // sha256(pubkey + message) -> GTElement
-    cache: LruCache<[u8; 32], GTElement>,
+    cache: Mutex<LruCache<[u8; 32], GTElement>>,
 }
 
 impl Default for BlsCache {
@@ -29,19 +30,27 @@ impl Default for BlsCache {
     }
 }
 
+impl Clone for BlsCache {
+    fn clone(&self) -> Self {
+        Self {
+            cache: Mutex::new(self.cache.lock().expect("cache").clone()),
+        }
+    }
+}
+
 impl BlsCache {
     pub fn new(cache_size: NonZeroUsize) -> Self {
         Self {
-            cache: LruCache::new(cache_size),
+            cache: Mutex::new(LruCache::new(cache_size)),
         }
     }
 
     pub fn len(&self) -> usize {
-        self.cache.len()
+        self.cache.lock().expect("cache").len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.cache.is_empty()
+        self.cache.lock().expect("cache").is_empty()
     }
 
     pub fn aggregate_verify<Pk: Borrow<PublicKey>, Msg: AsRef<[u8]>>(
@@ -57,7 +66,7 @@ impl BlsCache {
             let hash: [u8; 32] = hasher.finalize();
 
             // If the pairing is in the cache, we don't need to recalculate it.
-            if let Some(pairing) = self.cache.get(&hash).cloned() {
+            if let Some(pairing) = self.cache.lock().expect("cache").get(&hash).cloned() {
                 return pairing;
             }
 
@@ -71,7 +80,7 @@ impl BlsCache {
             let hash: [u8; 32] = hasher.finalize();
 
             let pairing = aug_hash.pair(pk.borrow());
-            self.cache.put(hash, pairing.clone());
+            self.cache.lock().expect("cache").put(hash, pairing.clone());
             pairing
         });
 
@@ -136,7 +145,8 @@ impl BlsCache {
         use pyo3::prelude::*;
         use pyo3::types::PyBytes;
         let ret = PyList::empty_bound(py);
-        for (key, value) in &self.cache {
+        let c = self.cache.lock().expect("cache");
+        for (key, value) in &*c {
             ret.append((PyBytes::new_bound(py, key), value.clone().into_py(py)))?;
         }
         Ok(ret.into())
@@ -144,9 +154,10 @@ impl BlsCache {
 
     #[pyo3(name = "update")]
     pub fn py_update(&mut self, other: &Bound<'_, PySequence>) -> PyResult<()> {
+        let mut c = self.cache.lock().expect("cache");
         for item in other.borrow().iter()? {
             let (key, value): (Vec<u8>, GTElement) = item?.extract()?;
-            self.cache.put(
+            c.put(
                 key.try_into()
                     .map_err(|_| PyValueError::new_err("invalid key"))?,
                 value,
@@ -248,7 +259,7 @@ pub mod tests {
         }
 
         // The cache should be full now.
-        assert_eq!(bls_cache.cache.len(), 3);
+        assert_eq!(bls_cache.cache.lock().expect("cache").len(), 3);
 
         // Recreate first key.
         let sk = SecretKey::from_seed(&[1; 32]);
@@ -262,7 +273,7 @@ pub mod tests {
         let hash: [u8; 32] = hasher.finalize();
 
         // The first key should have been removed, since it's the oldest that's been accessed.
-        assert!(!bls_cache.cache.contains(&hash));
+        assert!(!bls_cache.cache.lock().expect("cache").contains(&hash));
     }
 
     #[test]


### PR DESCRIPTION
Make the `BlsCache` thread safe by making its cache be held by a `Mutex`.

This adds a small (0-6%) slow-down. It will allow `UnfinishedBlock`s to be validated in a thread pool, rather than the main thread, so that seems like a small price.

```
group                                          main.benchmark                         sync-cache.benchmark
-----                                          --------------                         --------------------
bls_cache.aggregate_verify, 0% cache hits      1.00    654.0±8.63ms        ? ?/sec    1.02   664.0±26.99ms        ? ?/sec
bls_cache.aggregate_verify, 10% cache hits     1.00   590.9±22.85ms        ? ?/sec    1.01    594.5±4.98ms        ? ?/sec
bls_cache.aggregate_verify, 100% cache hits    1.00      2.6±0.01ms        ? ?/sec    1.03      2.7±0.14ms        ? ?/sec
bls_cache.aggregate_verify, 20% cache hits     1.00    524.7±7.52ms        ? ?/sec    1.01   527.4±20.89ms        ? ?/sec
bls_cache.aggregate_verify, 50% cache hits     1.00     83.8±0.59ms        ? ?/sec    1.00     83.9±0.79ms        ? ?/sec
bls_cache.aggregate_verify, no cache           1.00    344.6±1.04ms        ? ?/sec    1.06   364.6±56.84ms        ? ?/sec
```
