### PR TITLE
Add needed items for sdist

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -258,6 +258,14 @@ jobs:
         run: |
           pip install maturin
           maturin sdist -m wheel/Cargo.toml
+          cd target/wheels
+          dirname=`basename chia_rs*.tar.gz .tar.gz`
+          echo $dirname
+          mkdir $dirname
+          cp -r ./src/ $dirname/src/
+          gunzip chia_rs*.tar.gz
+          tar rvf chia_rs*.tar $dirname/src
+          gzip chia_rs*.tar
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -259,6 +259,7 @@ jobs:
           pip install maturin
           maturin sdist -m wheel/Cargo.toml
           cd target/wheels
+          ls -l
           dirname=`basename chia_rs*.tar.gz .tar.gz`
           echo $dirname
           mkdir $dirname
@@ -266,6 +267,8 @@ jobs:
           gunzip chia_rs*.tar.gz
           tar rvf chia_rs*.tar $dirname/src
           gzip chia_rs*.tar
+          ls -l
+          tar tzvf chia_rs*.tar.gz
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -259,7 +259,6 @@ jobs:
           pip install maturin
           maturin sdist -m wheel/Cargo.toml
           cd target/wheels
-          ls -l
           dirname=`basename chia_rs*.tar.gz .tar.gz`
           echo $dirname
           mkdir $dirname
@@ -267,8 +266,7 @@ jobs:
           gunzip chia_rs*.tar.gz
           tar rvf chia_rs*.tar $dirname/src
           gzip chia_rs*.tar
-          ls -l
-          tar tzvf chia_rs*.tar.gz
+          rm -rf $dirname
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -262,7 +262,7 @@ jobs:
           dirname=`basename chia_rs*.tar.gz .tar.gz`
           echo $dirname
           mkdir $dirname
-          cp -r ./src/ $dirname/src/
+          cp -r ../../src/ $dirname/src/
           gunzip chia_rs*.tar.gz
           tar rvf chia_rs*.tar $dirname/src
           gzip chia_rs*.tar

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,8 +517,10 @@ name = "chia_rs"
 version = "0.14.1"
 dependencies = [
  "chia-bls 0.14.1",
+ "chia-client",
  "chia-consensus",
  "chia-protocol",
+ "chia-ssl",
  "clvm-utils",
  "clvmr",
  "hex",

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.14.1"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2021"
 license = "Apache-2.0"
-license-file = "../LICENSE"
 description = "Code useful for implementing chia consensus."
 homepage = "https://github.com/Chia-Network/chia_rs"
 repository = "https://github.com/Chia-Network/chia_rs"
@@ -29,3 +28,5 @@ chia-consensus = { workspace = true, features = ["py-bindings"] }
 chia-bls = { workspace = true, features = ["py-bindings"]  }
 chia-protocol = { workspace = true, features = ["py-bindings"]  }
 clvm-utils = { workspace = true }
+chia-ssl = { workspace = true }
+chia-client = { workspace = true }

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -20,6 +20,11 @@ path = "src/lib.rs"
 [package.metadata.maturin]
 python-source = "python"
 
+# chia-client and chia-ssl are needed for the wheel sdist to work correctly
+# ignore any errors from machete about unused dependencies
+[package.metadata.cargo-machete]
+ignored = ["chia-client", "chia-ssl"]
+
 [dependencies]
 clvmr = { workspace = true }
 hex = { workspace = true }


### PR DESCRIPTION
Add in some missing bits in wheel/Cargo.toml and some hacks around missing parts in the tar archive

Main items are:
needing to add in `chia-client` and `chia-ssl` to `wheel/Cargo.toml`
needing to remove the `../LICENSE` from `wheel/Cargo.toml` - this resulted in the tar not having the LICENSE file but also pip expecting it, so I just removed it for now.
I noticed the tar was missing the `src` directory, so I had to manually add in the src directory to the tar archive. 

This does make a` tar.gz` that does build on my riscv machine and also my mac.