### PR TITLE
add fuzz packages to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,11 @@ clvm-traits = { path = "./crates/clvm-traits", version = "0.15.0" }
 clvm-utils = { path = "./crates/clvm-utils", version = "0.15.0" }
 clvm-derive = { path = "./crates/clvm-derive", version = "0.13.0" }
 chia-fuzz = { path = "./crates/chia-consensus/fuzz", version = "0.15.0" }
+chia-bls-fuzz = { path = "./crates/chia-bls/fuzz", version = "0.15.0" }
+chia-protocol-fuzz = { path = "./crates/chia-protocol/fuzz", version = "0.15.0" }
+chia-puzzles-fuzz = { path = "./crates/chia-puzzles/fuzz", version = "0.15.0" }
+chia-traits-fuzz = { path = "./crates/chia-traits/fuzz", version = "0.15.0" }
+chia-utils-fuzz = { path = "./crates/chia-utils/fuzz", version = "0.15.0" }
 blst = { version = "0.3.12", features = ["portable"] }
 clvmr = "0.9.0"
 syn = "2.0.75"


### PR DESCRIPTION
For sooommeee reason :roll_eyes: dependabot likes to remove these from `Cargo.lock`.  As a stop gap, this PR adds them explicitly to the workspace in hopes of making dependabot useful again.  See https://github.com/Chia-Network/chia_rs/pull/762/files#diff-13ee4b2252c9e516a0547f2891aa2105c3ca71c6d7a1e682c69be97998dfc87e for example.
