### PR TITLE
CHIA-1763: Make functions use bls cache immutably

### DIFF
--- a/crates/chia-bls/benches/cache.rs
+++ b/crates/chia-bls/benches/cache.rs
@@ -23,10 +23,10 @@ fn cache_benchmark(c: &mut Criterion) {
         pks.push(pk);
     }
 
-    let mut bls_cache = BlsCache::default();
+    let bls_cache = BlsCache::default();
 
     c.bench_function("bls_cache.aggregate_verify, 0% cache hits", |b| {
-        let mut cache = bls_cache.clone();
+        let cache = bls_cache.clone();
         b.iter(|| {
             assert!(cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });
@@ -35,7 +35,7 @@ fn cache_benchmark(c: &mut Criterion) {
     // populate 10% of keys
     bls_cache.aggregate_verify(pks[0..100].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 10% cache hits", |b| {
-        let mut cache = bls_cache.clone();
+        let cache = bls_cache.clone();
         b.iter(|| {
             assert!(cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });
@@ -44,7 +44,7 @@ fn cache_benchmark(c: &mut Criterion) {
     // populate another 10% of keys
     bls_cache.aggregate_verify(pks[100..200].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 20% cache hits", |b| {
-        let mut cache = bls_cache.clone();
+        let cache = bls_cache.clone();
         b.iter(|| {
             assert!(cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });
@@ -53,7 +53,7 @@ fn cache_benchmark(c: &mut Criterion) {
     // populate another 30% of keys
     bls_cache.aggregate_verify(pks[200..500].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 50% cache hits", |b| {
-        let mut cache = bls_cache.clone();
+        let cache = bls_cache.clone();
         b.iter(|| {
             assert!(cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });
@@ -62,7 +62,7 @@ fn cache_benchmark(c: &mut Criterion) {
     // populate all other keys
     bls_cache.aggregate_verify(pks[500..1000].iter().zip([&msg].iter().cycle()), &agg_sig);
     c.bench_function("bls_cache.aggregate_verify, 100% cache hits", |b| {
-        let mut cache = bls_cache.clone();
+        let cache = bls_cache.clone();
         b.iter(|| {
             assert!(cache.aggregate_verify(pks.iter().zip([&msg].iter().cycle()), &agg_sig));
         });

--- a/crates/chia-bls/src/bls_cache.rs
+++ b/crates/chia-bls/src/bls_cache.rs
@@ -82,7 +82,7 @@ impl BlsCache {
         aggregate_verify_gt(sig, iter)
     }
 
-    pub fn update(&mut self, aug_msg: &[u8], gt: GTElement) {
+    pub fn update(&self, aug_msg: &[u8], gt: GTElement) {
         let mut hasher = Sha256::new();
         hasher.update(aug_msg.as_ref());
         let hash: [u8; 32] = hasher.finalize();

--- a/crates/chia-bls/src/bls_cache.rs
+++ b/crates/chia-bls/src/bls_cache.rs
@@ -54,7 +54,7 @@ impl BlsCache {
     }
 
     pub fn aggregate_verify<Pk: Borrow<PublicKey>, Msg: AsRef<[u8]>>(
-        &mut self,
+        &self,
         pks_msgs: impl IntoIterator<Item = (Pk, Msg)>,
         sig: &Signature,
     ) -> bool {
@@ -119,7 +119,7 @@ impl BlsCache {
 
     #[pyo3(name = "aggregate_verify")]
     pub fn py_aggregate_verify(
-        &mut self,
+        &self,
         pks: &Bound<'_, PyList>,
         msgs: &Bound<'_, PyList>,
         sig: &Signature,
@@ -155,7 +155,7 @@ impl BlsCache {
     }
 
     #[pyo3(name = "update")]
-    pub fn py_update(&mut self, other: &Bound<'_, PySequence>) -> PyResult<()> {
+    pub fn py_update(&self, other: &Bound<'_, PySequence>) -> PyResult<()> {
         let mut c = self.cache.lock().expect("cache");
         for item in other.borrow().iter()? {
             let (key, value): (Vec<u8>, GTElement) = item?.extract()?;
@@ -178,7 +178,7 @@ pub mod tests {
 
     #[test]
     fn test_aggregate_verify() {
-        let mut bls_cache = BlsCache::default();
+        let bls_cache = BlsCache::default();
 
         let sk = SecretKey::from_seed(&[0; 32]);
         let pk = sk.public_key();
@@ -201,7 +201,7 @@ pub mod tests {
 
     #[test]
     fn test_cache() {
-        let mut bls_cache = BlsCache::default();
+        let bls_cache = BlsCache::default();
 
         let sk1 = SecretKey::from_seed(&[0; 32]);
         let pk1 = sk1.public_key();
@@ -242,7 +242,7 @@ pub mod tests {
     #[test]
     fn test_cache_limit() {
         // The cache is limited to only 3 items.
-        let mut bls_cache = BlsCache::new(NonZeroUsize::new(3).unwrap());
+        let bls_cache = BlsCache::new(NonZeroUsize::new(3).unwrap());
 
         // Before we cache anything, it should be empty.
         assert!(bls_cache.is_empty());
@@ -280,7 +280,7 @@ pub mod tests {
 
     #[test]
     fn test_empty_sig() {
-        let mut bls_cache = BlsCache::default();
+        let bls_cache = BlsCache::default();
 
         let pks_msgs: [(&PublicKey, &[u8]); 0] = [];
 

--- a/crates/chia-consensus/src/gen/conditions.rs
+++ b/crates/chia-consensus/src/gen/conditions.rs
@@ -1291,7 +1291,7 @@ pub fn parse_spends<V: SpendVisitor>(
     max_cost: Cost,
     flags: u32,
     aggregate_signature: &Signature,
-    bls_cache: Option<&mut BlsCache>,
+    bls_cache: Option<&BlsCache>,
     constants: &ConsensusConstants,
 ) -> Result<SpendBundleConditions, ValidationErr> {
     let mut ret = SpendBundleConditions::default();
@@ -1503,7 +1503,7 @@ pub fn validate_signature(
     state: &ParseState,
     signature: &Signature,
     flags: u32,
-    bls_cache: Option<&mut BlsCache>,
+    bls_cache: Option<&BlsCache>,
 ) -> Result<(), ValidationErr> {
     if (flags & DONT_VALIDATE_SIGNATURE) != 0 {
         return Ok(());
@@ -1766,7 +1766,7 @@ fn cond_test_cb(
     flags: u32,
     callback: Callback,
     signature: &Signature,
-    bls_cache: Option<&mut BlsCache>,
+    bls_cache: Option<&BlsCache>,
 ) -> Result<(Allocator, SpendBundleConditions), ValidationErr> {
     let mut a = Allocator::new();
 
@@ -1817,7 +1817,7 @@ fn cond_test_flag(
 fn cond_test_sig(
     input: &str,
     signature: &Signature,
-    bls_cache: Option<&mut BlsCache>,
+    bls_cache: Option<&BlsCache>,
     flags: u32,
 ) -> Result<(Allocator, SpendBundleConditions), ValidationErr> {
     cond_test_cb(input, flags, None, signature, bls_cache)
@@ -4698,7 +4698,7 @@ fn add_signature(sig: &mut Signature, puzzle: &mut String, opcode: ConditionOpco
 }
 
 #[cfg(test)]
-fn populate_cache(opcode: ConditionOpcode, bls_cache: &mut BlsCache) {
+fn populate_cache(opcode: ConditionOpcode, bls_cache: &BlsCache) {
     use chia_bls::hash_to_g2;
     let msg = final_message(H1, H2, 123, opcode, MSG1);
     // Otherwise, we need to calculate the pairing and add it to the cache.
@@ -4720,17 +4720,17 @@ fn test_agg_sig(
 ) {
     use chia_bls::{sign, SecretKey};
     let mut signature = Signature::default();
-    let mut bls_cache = BlsCache::default();
-    let cache: Option<&mut BlsCache> = if with_cache {
-        populate_cache(43, &mut bls_cache);
-        populate_cache(44, &mut bls_cache);
-        populate_cache(45, &mut bls_cache);
-        populate_cache(46, &mut bls_cache);
-        populate_cache(47, &mut bls_cache);
-        populate_cache(48, &mut bls_cache);
-        populate_cache(49, &mut bls_cache);
-        populate_cache(50, &mut bls_cache);
-        Some(&mut bls_cache)
+    let bls_cache = BlsCache::default();
+    let cache: Option<&BlsCache> = if with_cache {
+        populate_cache(43, &bls_cache);
+        populate_cache(44, &bls_cache);
+        populate_cache(45, &bls_cache);
+        populate_cache(46, &bls_cache);
+        populate_cache(47, &bls_cache);
+        populate_cache(48, &bls_cache);
+        populate_cache(49, &bls_cache);
+        populate_cache(50, &bls_cache);
+        Some(&bls_cache)
     } else {
         None
     };

--- a/crates/chia-consensus/src/gen/run_block_generator.rs
+++ b/crates/chia-consensus/src/gen/run_block_generator.rs
@@ -76,7 +76,7 @@ pub fn run_block_generator<GenBuf: AsRef<[u8]>, I: IntoIterator<Item = GenBuf>>(
     max_cost: u64,
     flags: u32,
     signature: &Signature,
-    bls_cache: Option<&mut BlsCache>,
+    bls_cache: Option<&BlsCache>,
     constants: &ConsensusConstants,
 ) -> Result<SpendBundleConditions, ValidationErr>
 where
@@ -166,7 +166,7 @@ pub fn run_block_generator2<GenBuf: AsRef<[u8]>, I: IntoIterator<Item = GenBuf>>
     max_cost: u64,
     flags: u32,
     signature: &Signature,
-    bls_cache: Option<&mut BlsCache>,
+    bls_cache: Option<&BlsCache>,
     constants: &ConsensusConstants,
 ) -> Result<SpendBundleConditions, ValidationErr>
 where

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -31,7 +31,7 @@ pub fn run_block_generator<'a>(
     max_cost: Cost,
     flags: u32,
     signature: &Signature,
-    bls_cache: Option<&mut BlsCache>,
+    bls_cache: Option<&BlsCache>,
     constants: &ConsensusConstants,
 ) -> (Option<u32>, Option<OwnedSpendBundleConditions>) {
     let mut allocator = make_allocator(flags);
@@ -83,7 +83,7 @@ pub fn run_block_generator2<'a>(
     max_cost: Cost,
     flags: u32,
     signature: &Signature,
-    bls_cache: Option<&mut BlsCache>,
+    bls_cache: Option<&BlsCache>,
     constants: &ConsensusConstants,
 ) -> (Option<u32>, Option<OwnedSpendBundleConditions>) {
     let mut allocator = make_allocator(flags);


### PR DESCRIPTION
`BLSCache` has all its members protected by a mutex. In order to allow threads sharing the same object, it needs to be treated as immutable. This is the patter `Mutex` is meant to be used in.

It's believed to address the issue from pyo3:

```
full_node chia.full_node.full_node: ERROR    Error in _handle_one_transaction, closing: Traceback (most recent call last):
  File "/home/arvid/dev/chia-blockchain/chia/full_node/full_node.py", line 475, in _handle_one_transaction
    inc_status, err = await self.add_transaction(entry.transaction, entry.spend_name, peer, entry.test)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arvid/dev/chia-blockchain/chia/full_node/full_node.py", line 2681, in add_transaction
    cost_result = await self.mempool_manager.pre_validate_spendbundle(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arvid/dev/chia-blockchain/chia/full_node/mempool_manager.py", line 298, in pre_validate_spendbundle
    bls_cache.update(new_cache_entries)
RuntimeError: Already borrowed
```