### PR TITLE
fixed `bytes32` return values in py-bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,7 @@ dependencies = [
  "chia-consensus",
  "chia-protocol",
  "chia-ssl",
+ "chia-traits 0.15.0",
  "clvm-utils",
  "clvmr",
  "hex",

--- a/crates/chia-bls/benches/cache.rs
+++ b/crates/chia-bls/benches/cache.rs
@@ -91,7 +91,7 @@ fn cache_benchmark(c: &mut Criterion) {
     );
 
     c.bench_function("bls_cache.evict 5% of the items", |b| {
-        let mut cache = bls_cache.clone();
+        let cache = bls_cache.clone();
         let mut pks_shuffled = pks.clone();
         pks_shuffled.shuffle(&mut rng);
         b.iter(|| {
@@ -103,7 +103,7 @@ fn cache_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("bls_cache.evict 100% of the items", |b| {
-        let mut cache = bls_cache.clone();
+        let cache = bls_cache.clone();
         let mut pks_shuffled = pks.clone();
         pks_shuffled.shuffle(&mut rng);
         b.iter(|| {

--- a/crates/chia-bls/src/bls_cache.rs
+++ b/crates/chia-bls/src/bls_cache.rs
@@ -344,7 +344,7 @@ pub mod tests {
 
     #[test]
     fn test_evict() {
-        let mut bls_cache = BlsCache::new(NonZeroUsize::new(5).unwrap());
+        let bls_cache = BlsCache::new(NonZeroUsize::new(5).unwrap());
         // Create 5 pk msg pairs and add them to the cache.
         let mut pks_msgs = Vec::new();
         for i in 1..=5 {

--- a/crates/chia-protocol/src/bytes.rs
+++ b/crates/chia-protocol/src/bytes.rs
@@ -392,14 +392,14 @@ impl From<TreeHash> for Bytes32 {
 #[cfg(feature = "py-bindings")]
 impl<const N: usize> ToPyObject for BytesImpl<N> {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        PyBytes::new_bound(py, &self.0).into()
+        ChiaToPython::to_python(self, py).unwrap().into()
     }
 }
 
 #[cfg(feature = "py-bindings")]
 impl<const N: usize> IntoPy<PyObject> for BytesImpl<N> {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyBytes::new_bound(py, &self.0).into()
+        ChiaToPython::to_python(&self, py).unwrap().into()
     }
 }
 

--- a/crates/chia-protocol/src/coin.rs
+++ b/crates/chia-protocol/src/coin.rs
@@ -54,8 +54,8 @@ impl Coin {
 #[cfg(feature = "py-bindings")]
 #[pymethods]
 impl Coin {
-    fn name<'p>(&self, py: Python<'p>) -> Bound<'p, pyo3::types::PyBytes> {
-        pyo3::types::PyBytes::new_bound(py, &self.coin_id())
+    fn name(&self) -> Bytes32 {
+        self.coin_id()
     }
 }
 

--- a/tests/test_coin.py
+++ b/tests/test_coin.py
@@ -3,6 +3,7 @@ from hashlib import sha256
 import copy
 import pytest
 from chia_rs.sized_ints import uint64
+from chia_rs.sized_bytes import bytes32
 
 parent_coin = b"---foo---                       "
 puzzle_hash = b"---bar---                       "
@@ -385,3 +386,12 @@ def test_coin_fields() -> None:
     assert c1.parent_coin_info == parent_coin
     assert c1.puzzle_hash == puzzle_hash
     assert c1.amount == 1000000
+
+
+def test_coin_print() -> None:
+    c1 = Coin(parent_coin, puzzle_hash, uint64(1000000))
+    assert type(c1.name()) is bytes32
+    assert (
+        f"{c1.name()}"
+        == "e1838c5c7ebb472e310600ce9c03c09b5e4bb77dde53f3427f6e8cc67dede32d"
+    )

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -1,4 +1,5 @@
 from chia_rs import run_chia_program, Program
+from chia_rs.sized_bytes import bytes32
 
 
 def test_raise() -> None:
@@ -34,3 +35,12 @@ def test_repr() -> None:
         assert False
     except ValueError as e:
         assert f"{e}" == "('clvm raise', '83666f6f')"
+
+
+def test_print() -> None:
+    temp = Program.to([8, (1, "foo")])
+    assert type(temp.get_tree_hash()) is bytes32
+    assert (
+        f"{temp.get_tree_hash()}"
+        == "a200d6417c8fdc7c7937382c1b61e219854e1efd8f2e15d6c88e6571bc29ed1a"
+    )

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -35,3 +35,4 @@ chia-protocol = { workspace = true, features = ["py-bindings"]  }
 clvm-utils = { workspace = true }
 chia-ssl = { workspace = true }
 chia-client = { workspace = true }
+chia-traits = { workspace = true }

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -43,6 +43,7 @@ use chia_protocol::{
     SubSlotProofs, TimestampedPeerInfo, TransactionAck, TransactionsInfo, UnfinishedBlock,
     UnfinishedHeaderBlock, VDFInfo, VDFProof, WeightProof,
 };
+use chia_traits::ChiaToPython;
 use clvm_utils::tree_hash_from_bytes;
 use clvmr::{LIMIT_HEAP, NO_UNKNOWN_OPS};
 use pyo3::buffer::PyBuffer;
@@ -113,9 +114,9 @@ pub fn confirm_not_included_already_hashed(
 }
 
 #[pyfunction]
-pub fn tree_hash<'a>(py: Python<'a>, blob: PyBuffer<u8>) -> PyResult<Bound<'_, PyBytes>> {
+pub fn tree_hash<'a>(py: Python<'a>, blob: PyBuffer<u8>) -> PyResult<Bound<'a, PyAny>> {
     let slice = py_to_slice::<'a>(blob);
-    Ok(PyBytes::new_bound(py, &tree_hash_from_bytes(slice)?))
+    ChiaToPython::to_python(&Bytes32::from(&tree_hash_from_bytes(slice)?.into()), py)
 }
 
 // there is an updated version of this function that doesn't require serializing


### PR DESCRIPTION
make sure Coin.name(), tree_hash() and Program.get_tree_hash() return bytes32 objects to python. This is tested by them printing as hex