### PR TITLE
Fix memo parsing for offers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,7 @@ dependencies = [
 name = "chia-puzzles"
 version = "0.16.0"
 dependencies = [
+ "anyhow",
  "arbitrary",
  "chia-bls 0.16.0",
  "chia-protocol",

--- a/crates/chia-puzzles/Cargo.toml
+++ b/crates/chia-puzzles/Cargo.toml
@@ -27,6 +27,7 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 hex = { workspace = true }
+anyhow = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/chia-puzzles/src/puzzles/offer.rs
+++ b/crates/chia-puzzles/src/puzzles/offer.rs
@@ -25,6 +25,8 @@ pub struct NotarizedPayment {
 pub struct Payment {
     pub puzzle_hash: Bytes32,
     pub amount: u64,
+    /// The memos should usually be set to [`None`] instead of an empty list.
+    /// This is for compatibility with the way the reference wallet encodes offers.
     #[clvm(rest)]
     pub memos: Option<Memos>,
 }
@@ -43,11 +45,11 @@ impl Payment {
         }
     }
 
-    pub fn with_memos(puzzle_hash: Bytes32, amount: u64, memos: Memos) -> Self {
+    pub fn with_memos(puzzle_hash: Bytes32, amount: u64, memos: Vec<Bytes>) -> Self {
         Self {
             puzzle_hash,
             amount,
-            memos: Some(memos),
+            memos: Some(Memos(memos)),
         }
     }
 }
@@ -145,7 +147,7 @@ mod tests {
             "2a5cbc6f5076e0517bdb1e4664b3c26e64d27178b65aaa1ae97267eee629113b"
         ));
         let amount = 20_000_000_000;
-        let memos = Memos(Vec::new());
+        let memos = Vec::new();
 
         let payment = Payment::with_memos(puzzle_hash, amount, memos);
         let notarized_payment = SettlementPaymentsSolution {


### PR DESCRIPTION
Fixes a bug where empty memo lists were treated the same as not having a memo list at all, which makes the announcement message different when fulfilling requested payments.