### PR TITLE
Validate blockchain

### DIFF
--- a/crates/chia-tools/src/bin/validate-blockchain-db.rs
+++ b/crates/chia-tools/src/bin/validate-blockchain-db.rs
@@ -133,6 +133,17 @@ features that are validated:
             "SELECT coin_name, coinbase, puzzle_hash, coin_parent, amount FROM coin_record WHERE confirmed_index == ?;",
         )
         .expect("failed to prepare SQL statement finding created coins");
+    let mut select_peak = connection
+        .prepare("SELECT hash FROM current_peak WHERE key == 0;")
+        .expect("failed to prepare SQL statement finding peak");
+
+    let mut peak_row = select_peak.query([]).expect("failed to query current peak");
+    let peak_hash = peak_row
+        .next()
+        .expect("missing peak")
+        .expect("missing peak")
+        .get::<_, [u8; 32]>(0)
+        .expect("missing peak");
 
     let mut prev_hash = constants.genesis_challenge;
     let mut prev_height: i64 = args.start as i64 - 1;
@@ -336,5 +347,6 @@ features that are validated:
     pool.join();
     assert_eq!(pool.panic_count(), 0);
 
+    assert_eq!(peak_hash, prev_hash.as_slice());
     println!("\nALL DONE, success!");
 }

--- a/crates/chia-tools/src/bin/validate-blockchain-db.rs
+++ b/crates/chia-tools/src/bin/validate-blockchain-db.rs
@@ -70,7 +70,7 @@ const TESTNET11_CONSTANTS: ConsensusConstants = ConsensusConstants {
     agg_sig_parent_puzzle_additional_data: Bytes32::new(hex!(
         "54c3ed8017f77354acca4000b40424396a369740e5a504467784f392b961ab37"
     )),
-    difficulty_constant_factor: 10052721566054,
+    difficulty_constant_factor: 10_052_721_566_054,
     difficulty_starting: 30,
     epoch_blocks: 768,
     genesis_challenge: Bytes32::new(hex!(
@@ -84,12 +84,12 @@ const TESTNET11_CONSTANTS: ConsensusConstants = ConsensusConstants {
     )),
     mempool_block_buffer: 10,
     min_plot_size: 18,
-    sub_slot_iters_starting: 67108864,
+    sub_slot_iters_starting: 67_108_864,
     // forks activated from the beginning on testnet11
     hard_fork_height: 0,
-    plot_filter_128_height: 6029568,
-    plot_filter_64_height: 11075328,
-    plot_filter_32_height: 16121088,
+    plot_filter_128_height: 6_029_568,
+    plot_filter_64_height: 11_075_328,
+    plot_filter_32_height: 16_121_088,
     ..MAINNET_CONSTANTS
 };
 


### PR DESCRIPTION
extends the `validate-blockchain-db` tool with more checks. Specifically:

* the peak hash
* (optional) `height-to-hash`