### PR TITLE
Add negative tests  and pytests for `validate_clvm_and_signature()`

### DIFF
--- a/crates/chia-consensus/src/spendbundle_validation.rs
+++ b/crates/chia-consensus/src/spendbundle_validation.rs
@@ -177,6 +177,38 @@ ff01\
             236,
         )
         .expect("SpendBundle should be valid for this test");
+        
+        // test wrong message
+        let solution = hex!("ffff31ffb0997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2ff8568656c6c6f8080").to_vec();
+        // ((49 0x997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2 "hello"))
+        let spend = CoinSpend::new(test_coin, Program::new(vec![1_u8].into()), solution.into());
+        let msg = b"goodbye";  // bad message
+        let sig = sign(&sk, msg);
+        let coin_spends: Vec<CoinSpend> = vec![spend];
+        let spend_bundle = SpendBundle {
+            coin_spends,
+            aggregated_signature: sig,
+        };
+        let result =
+            validate_clvm_and_signature(&spend_bundle, TEST_CONSTANTS.max_block_cost_clvm, &TEST_CONSTANTS, 246);
+        assert!(matches!(result, Err(ErrorCode::BadAggregateSignature)));
+
+        // test sk message
+        let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efc";  // bad key
+        let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
+        let solution = hex!("ffff31ffb0997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2ff8568656c6c6f8080").to_vec();
+        // ((49 0x997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2 "hello"))
+        let spend = CoinSpend::new(test_coin, Program::new(vec![1_u8].into()), solution.into());
+        let msg = b"hello";
+        let sig = sign(&sk, msg);
+        let coin_spends: Vec<CoinSpend> = vec![spend];
+        let spend_bundle = SpendBundle {
+            coin_spends,
+            aggregated_signature: sig,
+        };
+        let result =
+            validate_clvm_and_signature(&spend_bundle, TEST_CONSTANTS.max_block_cost_clvm, &TEST_CONSTANTS, 246);
+        assert!(matches!(result, Err(ErrorCode::BadAggregateSignature)));
     }
 
     #[test]
@@ -251,6 +283,54 @@ ff01\
             1,
         )
         .expect("SpendBundle should be valid for this test");
+
+        // test wrong message
+        let solution = hex!("ffff32ffb0997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2ff8568656c6c6f8080").to_vec();
+        // ((50 0x997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2 "hello"))
+        let spend = CoinSpend::new(test_coin, Program::new(vec![1_u8].into()), solution.into());
+        let msg = b"goodbye";  // bad message
+        let mut result = msg.to_vec();
+        result.extend(
+            [
+                test_coin.coin_id().as_slice(),
+                TEST_CONSTANTS.agg_sig_me_additional_data.as_slice(),
+            ]
+            .concat(),
+        );
+        let sig = sign(&sk, result.as_slice());
+        let coin_spends: Vec<CoinSpend> = vec![spend];
+        let spend_bundle = SpendBundle {
+            coin_spends,
+            aggregated_signature: sig,
+        };
+        let result =
+            validate_clvm_and_signature(&spend_bundle, TEST_CONSTANTS.max_block_cost_clvm, &TEST_CONSTANTS, 246);
+        assert!(matches!(result, Err(ErrorCode::BadAggregateSignature)));
+
+        // test sk message
+        let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efc";  // bad key
+        let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
+        let solution = hex!("ffff32ffb0997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2ff8568656c6c6f8080").to_vec();
+        // ((50 0x997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2 "hello"))
+        let spend = CoinSpend::new(test_coin, Program::new(vec![1_u8].into()), solution.into());
+        let msg = b"hello";
+        let mut result = msg.to_vec();
+        result.extend(
+            [
+                test_coin.coin_id().as_slice(),
+                TEST_CONSTANTS.agg_sig_me_additional_data.as_slice(),
+            ]
+            .concat(),
+        );
+        let sig = sign(&sk, result.as_slice());
+        let coin_spends: Vec<CoinSpend> = vec![spend];
+        let spend_bundle = SpendBundle {
+            coin_spends,
+            aggregated_signature: sig,
+        };
+        let result =
+            validate_clvm_and_signature(&spend_bundle, TEST_CONSTANTS.max_block_cost_clvm, &TEST_CONSTANTS, 246);
+        assert!(matches!(result, Err(ErrorCode::BadAggregateSignature)));
     }
 
     #[test]
@@ -258,7 +338,6 @@ ff01\
         let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb";
         let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
         //let pk: PublicKey = sk.public_key(); //0x997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2
-        // panic!("{:?}", pk);
 
         let full_puz = Bytes32::new(tree_hash_atom(&[1_u8]).to_bytes());
         let test_coin = Coin::new(
@@ -300,6 +379,57 @@ ff01\
             TEST_CONSTANTS.hard_fork_height + 1,
         )
         .expect("SpendBundle should be valid for this test");
+
+        // test wrong message
+        let solution = hex!("ffff30ffb0997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2ff8568656c6c6f8080").to_vec();
+        // ((48 0x997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2 "hello"))
+        let spend = CoinSpend::new(test_coin, Program::new(vec![1_u8].into()), solution.into());
+        let msg = b"goodbye";  // bad message
+        let mut result = msg.to_vec();
+        result.extend(
+            [
+                test_coin.parent_coin_info.as_slice(),
+                test_coin.puzzle_hash.as_slice(),
+                TEST_CONSTANTS
+                    .agg_sig_parent_puzzle_additional_data
+                    .as_slice(),
+            ]
+            .concat(),
+        );
+        let sig = sign(&sk, result.as_slice());
+        let coin_spends: Vec<CoinSpend> = vec![spend];
+        let spend_bundle = SpendBundle {
+            coin_spends,
+            aggregated_signature: sig,
+        };
+        let result =
+            validate_clvm_and_signature(&spend_bundle, TEST_CONSTANTS.max_block_cost_clvm, &TEST_CONSTANTS, 246);
+        assert!(matches!(result, Err(ErrorCode::BadAggregateSignature)));
+
+        // test sk message
+        let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efc";  // bad key
+        let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
+        let solution = hex!("ffff30ffb0997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2ff8568656c6c6f8080").to_vec();
+        // ((48 0x997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2 "hello"))
+        let spend = CoinSpend::new(test_coin, Program::new(vec![1_u8].into()), solution.into());
+        let msg = b"hello";
+        let mut result = msg.to_vec();
+        result.extend(
+            [
+                test_coin.coin_id().as_slice(),
+                TEST_CONSTANTS.agg_sig_me_additional_data.as_slice(),
+            ]
+            .concat(),
+        );
+        let sig = sign(&sk, result.as_slice());
+        let coin_spends: Vec<CoinSpend> = vec![spend];
+        let spend_bundle = SpendBundle {
+            coin_spends,
+            aggregated_signature: sig,
+        };
+        let result =
+            validate_clvm_and_signature(&spend_bundle, TEST_CONSTANTS.max_block_cost_clvm, &TEST_CONSTANTS, 246);
+        assert!(matches!(result, Err(ErrorCode::BadAggregateSignature)));
     }
 
     #[test]
@@ -343,6 +473,61 @@ ff01\
             TEST_CONSTANTS.hard_fork_height + 1,
         )
         .expect("SpendBundle should be valid for this test");
+
+        // test wrong message
+        let solution = hex!("ffff2fffb0997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2ff8568656c6c6f8080").to_vec();
+        // ((47 0x997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2 "hello"))
+
+        let spend = CoinSpend::new(test_coin, Program::new(vec![1_u8].into()), solution.into());
+        let msg = b"goodbye";  // bad message
+        let mut result = msg.to_vec();
+        result.extend(
+            [
+                test_coin.parent_coin_info.as_slice(),
+                u64_to_bytes(test_coin.amount).as_slice(),
+                TEST_CONSTANTS
+                    .agg_sig_parent_amount_additional_data
+                    .as_slice(),
+            ]
+            .concat(),
+        );
+        let sig = sign(&sk, result.as_slice());
+        let coin_spends: Vec<CoinSpend> = vec![spend];
+        let spend_bundle = SpendBundle {
+            coin_spends,
+            aggregated_signature: sig,
+        };
+        let result =
+            validate_clvm_and_signature(&spend_bundle, TEST_CONSTANTS.max_block_cost_clvm, &TEST_CONSTANTS, 246);
+        assert!(matches!(result, Err(ErrorCode::BadAggregateSignature)));
+
+        // test sk message
+        let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efc";  // bad key
+        let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
+        let solution = hex!("ffff2fffb0997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2ff8568656c6c6f8080").to_vec();
+        // ((47 0x997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2 "hello"))
+        let spend = CoinSpend::new(test_coin, Program::new(vec![1_u8].into()), solution.into());
+        let msg = b"hello";
+        let mut result = msg.to_vec();
+        result.extend(
+            [
+                test_coin.parent_coin_info.as_slice(),
+                u64_to_bytes(test_coin.amount).as_slice(),
+                TEST_CONSTANTS
+                    .agg_sig_parent_amount_additional_data
+                    .as_slice(),
+            ]
+            .concat(),
+        );
+        let sig = sign(&sk, result.as_slice());
+        let coin_spends: Vec<CoinSpend> = vec![spend];
+        let spend_bundle = SpendBundle {
+            coin_spends,
+            aggregated_signature: sig,
+        };
+        let result =
+            validate_clvm_and_signature(&spend_bundle, TEST_CONSTANTS.max_block_cost_clvm, &TEST_CONSTANTS, 246);
+        assert!(matches!(result, Err(ErrorCode::BadAggregateSignature)));
     }
 
     #[test]
@@ -386,5 +571,60 @@ ff01\
             TEST_CONSTANTS.hard_fork_height + 1,
         )
         .expect("SpendBundle should be valid for this test");
+
+        // test wrong message
+        let solution = hex!("ffff2effb0997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2ff8568656c6c6f8080").to_vec();
+        // ((46 0x997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2 "hello"))
+
+        let spend = CoinSpend::new(test_coin, Program::new(vec![1_u8].into()), solution.into());
+        let msg = b"goodbye";  // bad message
+        let mut result = msg.to_vec();
+        result.extend(
+            [
+                test_coin.puzzle_hash.as_slice(),
+                u64_to_bytes(test_coin.amount).as_slice(),
+                TEST_CONSTANTS
+                    .agg_sig_puzzle_amount_additional_data
+                    .as_slice(),
+            ]
+            .concat(),
+        );
+        let sig = sign(&sk, result.as_slice());
+        let coin_spends: Vec<CoinSpend> = vec![spend];
+        let spend_bundle = SpendBundle {
+            coin_spends,
+            aggregated_signature: sig,
+        };
+        let result =
+            validate_clvm_and_signature(&spend_bundle, TEST_CONSTANTS.max_block_cost_clvm, &TEST_CONSTANTS, 246);
+        assert!(matches!(result, Err(ErrorCode::BadAggregateSignature)));
+
+        // test sk message
+        let sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efc";  // bad key
+        let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
+        let solution = hex!("ffff2effb0997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2ff8568656c6c6f8080").to_vec();
+        // ((46 0x997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2 "hello"))
+        let spend = CoinSpend::new(test_coin, Program::new(vec![1_u8].into()), solution.into());
+        let msg = b"hello";
+        let mut result = msg.to_vec();
+        result.extend(
+            [
+                test_coin.puzzle_hash.as_slice(),
+                u64_to_bytes(test_coin.amount).as_slice(),
+                TEST_CONSTANTS
+                    .agg_sig_puzzle_amount_additional_data
+                    .as_slice(),
+            ]
+            .concat(),
+        );
+        let sig = sign(&sk, result.as_slice());
+        let coin_spends: Vec<CoinSpend> = vec![spend];
+        let spend_bundle = SpendBundle {
+            coin_spends,
+            aggregated_signature: sig,
+        };
+        let result =
+            validate_clvm_and_signature(&spend_bundle, TEST_CONSTANTS.max_block_cost_clvm, &TEST_CONSTANTS, 246);
+        assert!(matches!(result, Err(ErrorCode::BadAggregateSignature)));
     }
 }

--- a/tests/test_validate_clvm_and_signature.py
+++ b/tests/test_validate_clvm_and_signature.py
@@ -1,0 +1,71 @@
+from chia_rs import validate_clvm_and_signature
+from chia_rs import SpendBundle, CoinSpend, Coin, Program, PrivateKey, AugSchemeMPL
+from run_gen import DEFAULT_CONSTANTS
+import pytest
+
+def test_validate_clvm_and_signature():
+    
+    # Initial secret key
+    sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efb"
+    sk = PrivateKey.from_bytes(bytes.fromhex(sk_hex))
+    
+    # Coin details
+    full_puz = Program.to(1).get_tree_hash()
+    test_coin = Coin(
+        bytes.fromhex("4444444444444444444444444444444444444444444444444444444444444444"),
+        full_puz,
+        1
+    )
+    
+    # Solution
+    solution = Program.from_bytes(bytes.fromhex("ffff32ffb0997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2ff8568656c6c6f8080"))
+    # ((50 0x997cc43ed8788f841fcf3071f6f212b89ba494b6ebaf1bda88c3f9de9d968a61f3b7284a5ee13889399ca71a026549a2 "hello"))
+
+    # Valid spend
+    spend = CoinSpend(test_coin, Program.to(1), solution)
+    msg = b"hello"
+    result = msg + test_coin.name() + DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA
+    sig = AugSchemeMPL.sign(sk, result)
+    spend_bundle = SpendBundle([spend], sig)
+    
+    # Validate CLVM and signature
+    validate_clvm_and_signature(
+        spend_bundle,
+        DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM,
+        DEFAULT_CONSTANTS,
+        1
+    )
+    
+    # Invalid message
+    msg = b"goodbye"  # Bad message
+    result = msg + test_coin.name() + DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA
+    sig = AugSchemeMPL.sign(sk, result)
+    spend_bundle = SpendBundle([spend], sig)
+    
+    with pytest.raises(TypeError) as excinfo:
+        validate_clvm_and_signature(
+            spend_bundle,
+            DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM,
+            DEFAULT_CONSTANTS,
+            246
+        )
+    error_code = excinfo.value.args[0]
+    assert error_code == 7  # 7 = BadAggregateSignature
+    
+    # Invalid key 
+    sk_hex = "52d75c4707e39595b27314547f9723e5530c01198af3fc5849d9a7af65631efc"  # Bad key
+    sk = PrivateKey.from_bytes(bytes.fromhex(sk_hex))
+    msg = b"hello"
+    result = msg + test_coin.name() + DEFAULT_CONSTANTS.AGG_SIG_ME_ADDITIONAL_DATA
+    sig = AugSchemeMPL.sign(sk, result)
+    spend_bundle = SpendBundle([spend], sig)
+    
+    with pytest.raises(TypeError) as excinfo:
+        validate_clvm_and_signature(
+            spend_bundle,
+            DEFAULT_CONSTANTS.MAX_BLOCK_COST_CLVM,
+            DEFAULT_CONSTANTS,
+            246
+        )
+    error_code = excinfo.value.args[0]
+    assert error_code == 7  # 7 = BadAggregateSignature


### PR DESCRIPTION
Extended the current rust tests to check against an incorrect message and an incorrect key, and added a python test for one of the cases