### PR TITLE
stop defaulting to hiding lock file changes in PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/*.lock  linguist-generated=false


### PR DESCRIPTION
it seems to me that the changes should generally be small with granular updates mostly via dependabot so it is reasonable to glance at the changes and make sure they are not doing a lot more than expected.