### PR TITLE
Fix clippy warning and deny them in the future

### DIFF
--- a/.github/workflows/build-crate.yml
+++ b/.github/workflows/build-crate.yml
@@ -30,7 +30,7 @@ jobs:
         run: cargo fmt --all -- --files-with-diff --check
 
       - name: Clippy
-        run: cargo clippy --workspace --all-features --all-targets
+        run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
       - name: Install cargo-machete
         run: cargo install cargo-machete

--- a/crates/chia-consensus/src/spendbundle_validation.rs
+++ b/crates/chia-consensus/src/spendbundle_validation.rs
@@ -405,7 +405,7 @@ ff01\
         #[case] sk_hex: &str,
     ) {
         let sk = SecretKey::from_bytes(&<[u8; 32]>::from_hex(sk_hex).unwrap()).unwrap();
-        let sol_bytes: Vec<u8> = hex::decode(solution).unwrap().to_vec();
+        let sol_bytes = hex::decode(solution).unwrap();
         let full_puz = Bytes32::new(tree_hash_atom(&[1_u8]).to_bytes());
         let test_coin = Coin::new(
             hex!("4444444444444444444444444444444444444444444444444444444444444444").into(),


### PR DESCRIPTION
A while back I loosened the CI a bit to allow warnings through, and differentiated some of the warnings as hard errors. I think this is great for during development so you aren't forced to fix every strict clippy warning immediately, but when you're merging a PR through I think all of the warnings should be fixed beforehand. So I re-added the check in CI to deny warnings, while leaving it alone in precommit.

Another reason for allowing them before was that new nightly Rust versions would break CI without us changing the code. Now that we both use stable, and use a rust-toolchain.toml file, this is theoretically impossible.