### PR TITLE
fixup version for maturin

### DIFF
--- a/wheel/pyproject.toml
+++ b/wheel/pyproject.toml
@@ -10,3 +10,4 @@ python-source = "python"
 [project]
 name = "chia_rs"
 dependencies = ["typing_extensions"]
+dynamic = ["version"]


### PR DESCRIPTION
https://github.com/Chia-Network/chia_rs/actions/runs/12574101581/job/35047783400?pr=836
```
⚠️  Warning: `project.version` field is required in pyproject.toml unless it is present in the `project.dynamic` list
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings
🐍 Found CPython 3.10 at /home/ubuntu/actions-runner/_work/chia_rs/chia_rs/venv/bin/python
📡 Using build options features, bindings from pyproject.toml
⚠️  Warning: `project.version` field is required in pyproject.toml unless it is present in the `project.dynamic` list
💥 maturin failed
  Caused by: Cannot build without valid version information. You need to specify either `project.version` or `project.dynamic = ["version"]` in pyproject.toml.
```

https://github.com/PyO3/maturin/blob/main/Changelog.md#180
https://github.com/PyO3/maturin/pull/2391
https://github.com/PyO3/maturin/issues/2390