### PR TITLE
**/*.lock  linguist-generated=false

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/*.lock  linguist-generated=false


### PR DESCRIPTION
https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

default to showing lock file diffs in pr view.  they are defaulted to not showing since people often like to ignore their noise.  with granular changes i think it's worth looking over them to make sure there aren't unexpected changes.  in the case of merging large branches with too many lock changes to review, go ahead and mark it viewed and github will keep it hidden until it is changed.

like https://github.com/Chia-Network/chia-blockchain/pull/18939