### PR TITLE
bump clvm_rs dependency

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -311,6 +311,10 @@ jobs:
         with:
           fetch-depth: 1
       - uses: dtolnay/rust-toolchain@stable
+      - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+        if: runner.os == 'Windows'
+      - run: vcpkg install openssl:x64-windows-static-md
+        if: runner.os == 'Windows'
       - name: Prepare for coverage
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,7 +291,7 @@ dependencies = [
  "chia-protocol",
  "chia-puzzles",
  "chia-secp",
- "chia-sha2",
+ "chia-sha2 0.17.0",
  "chia-ssl",
  "chia-traits 0.17.0",
  "clvm-traits",
@@ -289,13 +301,13 @@ dependencies = [
 
 [[package]]
 name = "chia-bls"
-version = "0.10.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725b43b268cb81f014559eed11a74d0e5b9dd55282cae272ff509796099ab0b9"
+checksum = "53dea95bd7dac1e69c59ef6839ecf30ff3fe29170c16c4aa00093be21e0d789e"
 dependencies = [
- "anyhow",
  "blst",
- "chia-traits 0.10.0",
+ "chia-sha2 0.15.0",
+ "chia-traits 0.15.0",
  "hex",
  "hkdf",
  "lru",
@@ -309,7 +321,7 @@ version = "0.17.0"
 dependencies = [
  "arbitrary",
  "blst",
- "chia-sha2",
+ "chia-sha2 0.17.0",
  "chia-traits 0.17.0",
  "chia_py_streamable_macro",
  "criterion",
@@ -352,7 +364,7 @@ dependencies = [
  "chia-bls 0.17.0",
  "chia-protocol",
  "chia-puzzles",
- "chia-sha2",
+ "chia-sha2 0.17.0",
  "chia-traits 0.17.0",
  "chia_py_streamable_macro",
  "chia_streamable_macro 0.17.0",
@@ -377,7 +389,7 @@ dependencies = [
  "chia-bls 0.17.0",
  "chia-consensus",
  "chia-protocol",
- "chia-sha2",
+ "chia-sha2 0.17.0",
  "chia-traits 0.17.0",
  "clvm-traits",
  "clvm-utils",
@@ -392,7 +404,7 @@ version = "0.17.0"
 dependencies = [
  "arbitrary",
  "chia-bls 0.17.0",
- "chia-sha2",
+ "chia-sha2 0.17.0",
  "chia-traits 0.17.0",
  "chia_py_streamable_macro",
  "chia_streamable_macro 0.17.0",
@@ -410,7 +422,7 @@ version = "0.16.0"
 dependencies = [
  "arbitrary",
  "chia-protocol",
- "chia-sha2",
+ "chia-sha2 0.17.0",
  "chia-traits 0.17.0",
  "clvm-traits",
  "clvmr",
@@ -426,7 +438,7 @@ dependencies = [
  "arbitrary",
  "chia-bls 0.17.0",
  "chia-protocol",
- "chia-sha2",
+ "chia-sha2 0.17.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -451,12 +463,22 @@ version = "0.17.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "chia-sha2",
+ "chia-sha2 0.17.0",
  "hex",
  "k256",
  "p256",
  "rand",
  "rand_chacha",
+]
+
+[[package]]
+name = "chia-sha2"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7020f53eeae8b4c24c5666165738173a167c6478e0c0a9e1c428a491a2e1383d"
+dependencies = [
+ "openssl",
+ "sha2",
 ]
 
 [[package]]
@@ -501,12 +523,12 @@ dependencies = [
 
 [[package]]
 name = "chia-traits"
-version = "0.10.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb786114e5c748fe0af3ba1e95840fa1910b28f7300c05184506045aff60bb6"
+checksum = "e57bbde886b38a9a5df185e751d90e295d14e99659bf43df7fa701d52d4da1ea"
 dependencies = [
- "chia_streamable_macro 0.10.0",
- "sha2",
+ "chia-sha2 0.15.0",
+ "chia_streamable_macro 0.15.0",
  "thiserror",
 ]
 
@@ -514,7 +536,7 @@ dependencies = [
 name = "chia-traits"
 version = "0.17.0"
 dependencies = [
- "chia-sha2",
+ "chia-sha2 0.17.0",
  "chia_streamable_macro 0.17.0",
  "pyo3",
  "thiserror",
@@ -548,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "chia_streamable_macro"
-version = "0.10.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43975e01fb4293021af4950366a6f80c45d7301d499622359c7533bd7af19592"
+checksum = "00e78b5981952d2383b08344fdc6e6f843e72cc9d502d46d1d2824c485b34694"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -679,7 +701,7 @@ dependencies = [
 name = "clvm-utils"
 version = "0.17.0"
 dependencies = [
- "chia-sha2",
+ "chia-sha2 0.17.0",
  "clvm-traits",
  "clvmr",
  "hex",
@@ -699,20 +721,21 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0a3193c4f868919b940fa188f4251ed0c24e39d425ded397945bef1b08f7d9"
+checksum = "8b38393b34f8eb8460f66be324a0b4a507d5ffbcc1a88e49682d4b81936113a4"
 dependencies = [
- "chia-bls 0.10.0",
+ "bitvec",
+ "chia-bls 0.15.0",
+ "chia-sha2 0.15.0",
  "hex-literal",
  "k256",
  "lazy_static",
  "num-bigint",
  "num-integer",
  "num-traits",
- "openssl",
  "p256",
- "sha2",
+ "rand",
  "sha3",
 ]
 
@@ -1003,6 +1026,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1602,15 +1631,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl-src"
-version = "300.3.2+3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,7 +1638,6 @@ checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1853,6 +1872,12 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2255,6 +2280,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -2670,6 +2701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ chia-puzzles-fuzz = { path = "./crates/chia-puzzles/fuzz", version = "0.16.0" }
 clvm-traits-fuzz = { path = "./crates/clvm-traits/fuzz", version = "0.16.0" }
 clvm-utils-fuzz = { path = "./crates/clvm-utils/fuzz", version = "0.16.0" }
 blst = { version = "0.3.12", features = ["portable"] }
-clvmr = "0.10.0"
+clvmr = "0.11.0"
 syn = "2.0.95"
 quote = "1.0.38"
 proc-macro2 = "1.0.92"

--- a/crates/chia-consensus/src/gen/solution_generator.rs
+++ b/crates/chia-consensus/src/gen/solution_generator.rs
@@ -418,28 +418,27 @@ mod tests {
 
                 b78080
 
-                fe81f6
+                ff0180
 
                 ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff
                 06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff
                 8080808080ffff01ff0bffff0101
 
-                fe6f
+                ff0580
 
                 80ff0180
 
-                fe3e
+                ff0180
 
                 80ffff04ffff01b08cf5533a94afae0f4613d3ea565e47abc5373415967ef582
                 4fd009c602cb629e259908ce533c21de7fd7a68eb96c52d0
 
-                fe7f
+                ff0180
 
                 80ff8601977420dc00ffff80ffff01ffff3dffa080115c1c71035a2cd60a4949
                 9fb9e5cb55be8d6e25e8680bfc0409b7acaeffd48080ff8080808080"
             )
         );
-
         let generator_output = run_generator(&result);
         assert_eq!(generator_output, EXPECTED_GENERATOR_OUTPUT);
     }


### PR DESCRIPTION
one important change to the way we serialize compressed CLVM (in `clvm_rs`) was that nodes whose serialized length is less than 4 bytes are not considered for deduplication, even though we might save 1 byte by doing so. This was a performance trade-off, as each lookup for a back-reference is quite expensive.

This is what causes the serialized output to change in one of the tests.

`cargo test` was failing to find openssl (the `openssl-sys` crate was failing). The fix is taken from https://github.com/sfackler/rust-openssl/issues/1542#issuecomment-1399358351

it adds 6 minutes to the job on windows.

It's unclear why this started failing now. But on CI we build with `--all-features`, which enables the `openssl` feature for windows. When we build the wheels, we use openssl for Linux and MacOS, but not windows. Windows uses the native rust implementation of sha2 instead.

the `openssl` dependency is coming in via `chia-sha2`, which is a thin abstraction layer on top of openssl or the rust-native sha2 implementation. It's also used by the CLVM interpreter in `clvm_rs`.