### PR TITLE
add the openssl feature to the chia_rs wheel

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,11 +57,17 @@ jobs:
           python -m pip install pytest pytest-xdist
           python -m pip install mypy
           python -m pip install black
-
-      - name: Build
-        run: |
           python -m pip install clvm_tools colorama blspy chia-blockchain==2.1.2 clvm==0.9.8
+
+      - name: Build (windows)
+        if: matrix.os.matrix == 'windows'
+        run: |
           maturin develop --release -m wheel/Cargo.toml
+
+      - name: Build (non-windows)
+        if: matrix.os.matrix != 'windows'
+        run: |
+          maturin develop --release -m wheel/Cargo.toml --features=openssl
 
       - name: python mypy
         run: |
@@ -131,7 +137,7 @@ jobs:
 
       - name: Build
         run: |
-          maturin develop --release -m wheel/Cargo.toml
+          maturin develop --release -m wheel/Cargo.toml --features=openssl
 
       - name: test generators
         run: |

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           python${{ matrix.python.major-dot-minor }} -m venv venv
           . venv/bin/activate
-          maturin build -i python --release -m wheel/Cargo.toml
+          maturin build -i python --release -m wheel/Cargo.toml --features=openssl,pyo3/extension-module
 
       - name: Build Linux with maturin on Python ${{ matrix.python }}
         if: matrix.os.matrix == 'ubuntu'
@@ -150,13 +150,14 @@ jobs:
             ${{ matrix.python.by-arch[matrix.arch.matrix].docker-url }} \
             bash -exc '\
               yum -y install openssl-devel && \
+              yum -y install perl-IPC-Cmd && \
               source $HOME/.cargo/env && \
               rustup target add ${{ matrix.python.by-arch[matrix.arch.matrix].rustup-target }} && \
               python${{ matrix.python.major-dot-minor }} -m venv /venv && \
               . /venv/bin/activate && \
               pip install --upgrade pip && \
               pip install maturin && \
-              CC=gcc maturin build --release --manylinux ${{ matrix.python.by-arch[matrix.arch.matrix].manylinux-version }} -m wheel/Cargo.toml \
+              CC=gcc maturin build --release --manylinux ${{ matrix.python.by-arch[matrix.arch.matrix].manylinux-version }} -m wheel/Cargo.toml --features=openssl,pyo3/extension-module \
             '
 
       - name: Build Windows with maturin on Python ${{ matrix.python }}

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -25,6 +25,9 @@ python-source = "python"
 [package.metadata.cargo-machete]
 ignored = ["chia-client", "chia-ssl"]
 
+[features]
+openssl = ["clvmr/openssl"]
+
 [dependencies]
 clvmr = { workspace = true }
 hex = { workspace = true }


### PR DESCRIPTION
and enable it for non-windows builds.

I encountered this issue: https://stackoverflow.com/questions/70464585/error-when-installing-openssl-3-0-1-cant-locate-ipc-cmd-pm-in-inc
The new openssl build step requires a new perl package which needed to be installed on the docker image.

It appears the `--features` switch to `maturin` does not *add* features to what it find in `pyproject.toml`, but replaces them. That's why I had to also include `pyo3/extension-module` as a feature on the command line.