### PR TITLE
datalayer exceptions for python

### DIFF
--- a/tests/test_datalayer.py
+++ b/tests/test_datalayer.py
@@ -1,7 +1,8 @@
-from chia_rs.datalayer import LeafNode, MerkleBlob
+import pytest
+
+from chia_rs.datalayer import InvalidBlobLengthError, LeafNode, MerkleBlob
 from chia_rs.sized_bytes import bytes32
 from chia_rs.sized_ints import int64, uint8
-
 
 def test_merkle_blob():
     blob = bytes.fromhex(
@@ -52,3 +53,9 @@ def test_checking_coverage() -> None:
         if isinstance(node, LeafNode)
     }
     assert keys == set(range(count))
+
+
+def test_invalid_blob_length_raised() -> None:
+    """Mostly verifying that the exceptions are available and raise."""
+    with pytest.raises(InvalidBlobLengthError):
+        MerkleBlob(blob=b"\x00")

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -78,8 +78,6 @@ use chia_bls::{
     Signature,
 };
 
-use chia_datalayer::{InternalNode, LeafNode, MerkleBlob};
-
 #[pyfunction]
 pub fn compute_merkle_set_root<'p>(
     py: Python<'p>,
@@ -648,12 +646,16 @@ pub fn chia_rs(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
 }
 
 pub fn add_datalayer_submodule(py: Python<'_>, parent: &Bound<'_, PyModule>) -> PyResult<()> {
+    use chia_datalayer::*;
+
     let datalayer = PyModule::new(py, "datalayer")?;
     parent.add_submodule(&datalayer)?;
 
     datalayer.add_class::<MerkleBlob>()?;
     datalayer.add_class::<InternalNode>()?;
     datalayer.add_class::<LeafNode>()?;
+
+    python_exceptions::add_to_module(py, &datalayer)?;
 
     // https://github.com/PyO3/pyo3/issues/1517#issuecomment-808664021
     // https://github.com/PyO3/pyo3/issues/759


### PR DESCRIPTION
integrates the definition provided to `thiserror` to expose python versions of those errors through the wheel

<details>
<summary>expanded macro</summary>

as of 011a54a5d18734f4538f4ccc5d2b4e9bc9c92be8

```rust
#[derive(Debug, Error, PartialEq, Eq)]
pub enum Error {
    #[error("failed loading metadata: {0}")]
    FailedLoadingMetadata(String),
    #[error("failed loading node: {0}")]
    FailedLoadingNode(String),
    #[error("blob length must be a multiple of block count, found extra bytes: {0}")]
    InvalidBlobLength(usize),
    #[error("key already present")]
    KeyAlreadyPresent(),
    #[error("requested insertion at root but tree not empty")]
    UnableToInsertAsRootOfNonEmptyTree(),
    #[error("unable to find a leaf")]
    UnableToFindALeaf(),
    #[error("unknown key: {0:?}")]
    UnknownKey(KvId),
    #[error("key not in key to index cache: {0:?}")]
    IntegrityKeyNotInCache(KvId),
    #[error("key to index cache for {0:?} should be {1:?} got: {2:?}")]
    IntegrityKeyToIndexCacheIndex(KvId, TreeIndex, TreeIndex),
    #[error("parent and child relationship mismatched: {0:?}")]
    IntegrityParentChildMismatch(TreeIndex),
    #[error("found {0:?} leaves but key to index cache length is: {1}")]
    IntegrityKeyToIndexCacheLength(usize, usize),
    #[error("unmatched parent -> child references found: {0}")]
    IntegrityUnmatchedChildParentRelationships(usize),
    #[error("expected total node count {0:?} found: {1:?}")]
    IntegrityTotalNodeCount(TreeIndex, usize),
    #[error("zero-length seed bytes not allowed")]
    ZeroLengthSeedNotAllowed(),
    #[error("block index out of range: {0:?}")]
    BlockIndexOutOfRange(TreeIndex),
    #[error("node not a leaf: {0:?}")]
    NodeNotALeaf(InternalNode),
    #[error("from streamable: {0:?}")]
    Streaming(chia_traits::chia_error::Error),
    #[error("index not a child: {0}")]
    IndexIsNotAChild(TreeIndex),
    #[error("cycle found")]
    CycleFound(),
    #[error("block index out of bounds: {0}")]
    BlockIndexOutOfBounds(TreeIndex),
}
#[cfg(feature = "py-bindings")]
pub mod python_exceptions {
    use pyo3::prelude::*;

    pyo3::create_exception!( chia_rs . chia_rs . datalayer , FailedLoadingMetadataError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , FailedLoadingNodeError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , InvalidBlobLengthError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , KeyAlreadyPresentError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , UnableToInsertAsRootOfNonEmptyTreeError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , UnableToFindALeafError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , UnknownKeyError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , IntegrityKeyNotInCacheError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , IntegrityKeyToIndexCacheIndexError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , IntegrityParentChildMismatchError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , IntegrityKeyToIndexCacheLengthError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , IntegrityUnmatchedChildParentRelationshipsError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , IntegrityTotalNodeCountError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , ZeroLengthSeedNotAllowedError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , BlockIndexOutOfRangeError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , NodeNotALeafError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , StreamingError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , IndexIsNotAChildError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , CycleFoundError , pyo3 :: exceptions :: PyException );   pyo3::create_exception!( chia_rs . chia_rs . datalayer , BlockIndexOutOfBoundsError , pyo3 :: exceptions :: PyException );

    pub fn add_to_module(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
        module.add(stringify!( FailedLoadingMetadataError ), py.get_type::<FailedLoadingMetadataError>())?;
        module.add(stringify!( FailedLoadingNodeError ), py.get_type::<FailedLoadingNodeError>())?;
        module.add(stringify!( InvalidBlobLengthError ), py.get_type::<InvalidBlobLengthError>())?;
        module.add(stringify!( KeyAlreadyPresentError ), py.get_type::<KeyAlreadyPresentError>())?;
        module.add(stringify!( UnableToInsertAsRootOfNonEmptyTreeError ), py.get_type::<UnableToInsertAsRootOfNonEmptyTreeError>())?;
        module.add(stringify!( UnableToFindALeafError ), py.get_type::<UnableToFindALeafError>())?;
        module.add(stringify!( UnknownKeyError ), py.get_type::<UnknownKeyError>())?;
        module.add(stringify!( IntegrityKeyNotInCacheError ), py.get_type::<IntegrityKeyNotInCacheError>())?;
        module.add(stringify!( IntegrityKeyToIndexCacheIndexError ), py.get_type::<IntegrityKeyToIndexCacheIndexError>())?;
        module.add(stringify!( IntegrityParentChildMismatchError ), py.get_type::<IntegrityParentChildMismatchError>())?;
        module.add(stringify!( IntegrityKeyToIndexCacheLengthError ), py.get_type::<IntegrityKeyToIndexCacheLengthError>())?;
        module.add(stringify!( IntegrityUnmatchedChildParentRelationshipsError ), py.get_type::<IntegrityUnmatchedChildParentRelationshipsError>())?;
        module.add(stringify!( IntegrityTotalNodeCountError ), py.get_type::<IntegrityTotalNodeCountError>())?;
        module.add(stringify!( ZeroLengthSeedNotAllowedError ), py.get_type::<ZeroLengthSeedNotAllowedError>())?;
        module.add(stringify!( BlockIndexOutOfRangeError ), py.get_type::<BlockIndexOutOfRangeError>())?;
        module.add(stringify!( NodeNotALeafError ), py.get_type::<NodeNotALeafError>())?;
        module.add(stringify!( StreamingError ), py.get_type::<StreamingError>())?;
        module.add(stringify!( IndexIsNotAChildError ), py.get_type::<IndexIsNotAChildError>())?;
        module.add(stringify!( CycleFoundError ), py.get_type::<CycleFoundError>())?;
        module.add(stringify!( BlockIndexOutOfBoundsError ), py.get_type::<BlockIndexOutOfBoundsError>())?;

        Ok(())
    }
}
#[cfg(feature = "py-bindings")]
impl From<Error> for pyo3::PyErr {
    fn from(err: Error) -> pyo3::PyErr {
        let message = err.to_string();
        match err {
            Error::FailedLoadingMetadata(..) => python_exceptions::FailedLoadingMetadataError::new_err(message),
            Error::FailedLoadingNode(..) => python_exceptions::FailedLoadingNodeError::new_err(message),
            Error::InvalidBlobLength(..) => python_exceptions::InvalidBlobLengthError::new_err(message),
            Error::KeyAlreadyPresent(..) => python_exceptions::KeyAlreadyPresentError::new_err(message),
            Error::UnableToInsertAsRootOfNonEmptyTree(..) => python_exceptions::UnableToInsertAsRootOfNonEmptyTreeError::new_err(message),
            Error::UnableToFindALeaf(..) => python_exceptions::UnableToFindALeafError::new_err(message),
            Error::UnknownKey(..) => python_exceptions::UnknownKeyError::new_err(message),
            Error::IntegrityKeyNotInCache(..) => python_exceptions::IntegrityKeyNotInCacheError::new_err(message),
            Error::IntegrityKeyToIndexCacheIndex(..) => python_exceptions::IntegrityKeyToIndexCacheIndexError::new_err(message),
            Error::IntegrityParentChildMismatch(..) => python_exceptions::IntegrityParentChildMismatchError::new_err(message),
            Error::IntegrityKeyToIndexCacheLength(..) => python_exceptions::IntegrityKeyToIndexCacheLengthError::new_err(message),
            Error::IntegrityUnmatchedChildParentRelationships(..) => python_exceptions::IntegrityUnmatchedChildParentRelationshipsError::new_err(message),
            Error::IntegrityTotalNodeCount(..) => python_exceptions::IntegrityTotalNodeCountError::new_err(message),
            Error::ZeroLengthSeedNotAllowed(..) => python_exceptions::ZeroLengthSeedNotAllowedError::new_err(message),
            Error::BlockIndexOutOfRange(..) => python_exceptions::BlockIndexOutOfRangeError::new_err(message),
            Error::NodeNotALeaf(..) => python_exceptions::NodeNotALeafError::new_err(message),
            Error::Streaming(..) => python_exceptions::StreamingError::new_err(message),
            Error::IndexIsNotAChild(..) => python_exceptions::IndexIsNotAChildError::new_err(message),
            Error::CycleFound(..) => python_exceptions::CycleFoundError::new_err(message),
            Error::BlockIndexOutOfBounds(..) => python_exceptions::BlockIndexOutOfBoundsError::new_err(message),
        }
    }
}
```

</details>