### PR TITLE
extend `SpendBundleConditions` with the cost broken out

### DIFF
--- a/crates/chia-consensus/fuzz/fuzz_targets/run-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/run-generator.rs
@@ -49,6 +49,8 @@ fuzz_target!(|data: &[u8]| {
         }
         (Ok(a), Ok(b)) => {
             assert!(a.cost >= b.cost);
+            assert!(a.execution_cost > b.execution_cost);
+            assert_eq!(a.condition_cost, b.condition_cost);
             assert_eq!(a.reserve_fee, b.reserve_fee);
             assert_eq!(a.removal_amount, b.removal_amount);
             assert_eq!(a.addition_amount, b.addition_amount);

--- a/crates/chia-consensus/src/gen/conditions.rs
+++ b/crates/chia-consensus/src/gen/conditions.rs
@@ -715,6 +715,12 @@ pub struct SpendBundleConditions {
     // the total cost)
     pub cost: u64,
 
+    // the cost of executing the Chialisp
+    pub execution_cost: u64,
+
+    // the cost of the conditions
+    pub condition_cost: u64,
+
     // the sum of all values of all spent coins
     pub removal_amount: u128,
 
@@ -921,6 +927,7 @@ pub fn parse_conditions<V: SpendVisitor>(
                     return Err(ValidationErr(c, ErrorCode::CostExceeded));
                 }
                 *max_cost -= CREATE_COIN_COST;
+                ret.condition_cost += CREATE_COIN_COST;
             }
             AGG_SIG_UNSAFE
             | AGG_SIG_ME
@@ -934,6 +941,7 @@ pub fn parse_conditions<V: SpendVisitor>(
                     return Err(ValidationErr(c, ErrorCode::CostExceeded));
                 }
                 *max_cost -= AGG_SIG_COST;
+                ret.condition_cost += AGG_SIG_COST;
             }
             _ => (),
         }
@@ -1212,6 +1220,7 @@ pub fn parse_conditions<V: SpendVisitor>(
                     return Err(ValidationErr(c, ErrorCode::CostExceeded));
                 }
                 *max_cost -= cost;
+                ret.condition_cost += cost;
             }
             Condition::SendMessage(src_mode, dst, msg) => {
                 decrement(&mut announce_countdown, msg)?;

--- a/crates/chia-consensus/src/gen/owned_conditions.rs
+++ b/crates/chia-consensus/src/gen/owned_conditions.rs
@@ -70,6 +70,8 @@ pub struct OwnedSpendBundleConditions {
     // set if the aggregate signature of the block/spend bundle was
     // successfully validated
     pub validated_signature: bool,
+    pub execution_cost: u64,
+    pub condition_cost: u64,
 }
 
 impl OwnedSpendConditions {
@@ -144,6 +146,8 @@ impl OwnedSpendBundleConditions {
             removal_amount: sb.removal_amount,
             addition_amount: sb.addition_amount,
             validated_signature: sb.validated_signature,
+            execution_cost: sb.execution_cost,
+            condition_cost: sb.condition_cost,
         }
     }
 }

--- a/tests/test_run_block_generator.py
+++ b/tests/test_run_block_generator.py
@@ -15,9 +15,16 @@ def test_run_block_generator_cost() -> None:
     # longer pay the cost of the generator ROM
     hard_fork_consensus_cost = 596498808
 
+    # the generator always produce the same set of conditions, and their cost
+    # is the same regardless of pre- or post- hard fork.
+    condition_cost = 122400000
+
     generator = bytes.fromhex(
         open("generator-tests/block-834768.txt", "r").read().split("\n")[0]
     )
+
+    byte_cost = len(generator) * 12000
+
     err, conds = run_block_generator(
         generator,
         [],
@@ -29,6 +36,9 @@ def test_run_block_generator_cost() -> None:
     )
     assert err is None
     assert conds is not None
+    assert conds.cost == original_consensus_cost
+    assert conds.execution_cost + condition_cost + byte_cost == original_consensus_cost
+    assert conds.condition_cost == condition_cost
 
     err2, conds2 = run_block_generator2(
         generator,
@@ -41,6 +51,11 @@ def test_run_block_generator_cost() -> None:
     )
     assert err2 is None
     assert conds2 is not None
+    assert conds2.cost == hard_fork_consensus_cost
+    assert conds2.condition_cost == condition_cost
+    assert (
+        conds2.execution_cost + condition_cost + byte_cost == hard_fork_consensus_cost
+    )
 
     output1 = print_spend_bundle_conditions(conds)
     output2 = print_spend_bundle_conditions(conds2)
@@ -81,7 +96,7 @@ def test_run_block_generator_cost() -> None:
     err, conds = run_block_generator(
         generator,
         [],
-        len(generator) * 12000 - 1,
+        byte_cost - 1,
         DONT_VALIDATE_SIGNATURE,
         G2Element(),
         None,
@@ -95,7 +110,7 @@ def test_run_block_generator_cost() -> None:
     err, conds = run_block_generator2(
         generator,
         [],
-        len(generator) * 12000 - 1,
+        byte_cost - 1,
         DONT_VALIDATE_SIGNATURE,
         G2Element(),
         None,

--- a/tests/test_streamable.py
+++ b/tests/test_streamable.py
@@ -85,10 +85,34 @@ def test_hash_spend() -> None:
 def test_hash_spend_bundle_conditions() -> None:
 
     a1 = SpendBundleConditions(
-        [], 1000, 1337, 42, None, None, [(pk, b"msg")], 12345678, 123, 456, False
+        [],
+        1000,
+        1337,
+        42,
+        None,
+        None,
+        [(pk, b"msg")],
+        12345678,
+        123,
+        456,
+        False,
+        4321,
+        8765,
     )
     a2 = SpendBundleConditions(
-        [], 1001, 1337, 42, None, None, [(pk, b"msg")], 12345678, 123, 456, False
+        [],
+        1001,
+        1337,
+        42,
+        None,
+        None,
+        [(pk, b"msg")],
+        12345678,
+        123,
+        456,
+        False,
+        4321,
+        8765,
     )
     b = hash(a1)
     c = hash(a2)
@@ -391,7 +415,19 @@ def test_missing_field() -> None:
 def test_json_spend_bundle_conditions() -> None:
 
     a = SpendBundleConditions(
-        [], 1000, 1337, 42, None, None, [(pk, b"msg")], 12345678, 123, 456, False
+        [],
+        1000,
+        1337,
+        42,
+        None,
+        None,
+        [(pk, b"msg")],
+        12345678,
+        123,
+        456,
+        False,
+        4321,
+        8765,
     )
 
     assert a.to_json_dict() == {
@@ -406,13 +442,27 @@ def test_json_spend_bundle_conditions() -> None:
         "removal_amount": 123,
         "addition_amount": 456,
         "validated_signature": False,
+        "execution_cost": 4321,
+        "condition_cost": 8765,
     }
 
 
 def test_from_json_spend_bundle_conditions() -> None:
 
     a = SpendBundleConditions(
-        [], 1000, 1337, 42, None, None, [(pk, b"msg")], 12345678, 123, 456, False
+        [],
+        1000,
+        1337,
+        42,
+        None,
+        None,
+        [(pk, b"msg")],
+        12345678,
+        123,
+        456,
+        False,
+        4321,
+        8765,
     )
     b = SpendBundleConditions.from_json_dict(
         {
@@ -427,6 +477,8 @@ def test_from_json_spend_bundle_conditions() -> None:
             "removal_amount": 123,
             "addition_amount": 456,
             "validated_signature": False,
+            "execution_cost": 4321,
+            "condition_cost": 8765,
         }
     )
     assert a == b
@@ -468,7 +520,19 @@ def test_copy_spend() -> None:
 def test_copy_spend_bundle_conditions() -> None:
 
     a = SpendBundleConditions(
-        [], 1000, 1337, 42, None, None, [(pk, b"msg")], 12345678, 123, 456, False
+        [],
+        1000,
+        1337,
+        42,
+        None,
+        None,
+        [(pk, b"msg")],
+        12345678,
+        123,
+        456,
+        False,
+        4321,
+        8765,
     )
     b = copy.copy(a)
 

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -514,6 +514,8 @@ class MerkleSet:
             "removal_amount: int",
             "addition_amount: int",
             "validated_signature: bool",
+            "execution_cost: int",
+            "condition_cost: int",
         ],
     )
 

--- a/wheel/python/chia_rs/chia_rs.pyi
+++ b/wheel/python/chia_rs/chia_rs.pyi
@@ -350,6 +350,8 @@ class SpendBundleConditions:
     removal_amount: int
     addition_amount: int
     validated_signature: bool
+    execution_cost: int
+    condition_cost: int
     def __init__(
         self,
         spends: Sequence[SpendConditions],
@@ -362,7 +364,9 @@ class SpendBundleConditions:
         cost: int,
         removal_amount: int,
         addition_amount: int,
-        validated_signature: bool
+        validated_signature: bool,
+        execution_cost: int,
+        condition_cost: int
     ) -> None: ...
     def __hash__(self) -> int: ...
     def __repr__(self) -> str: ...
@@ -391,7 +395,9 @@ class SpendBundleConditions:
         cost: Union[ int, _Unspec] = _Unspec(),
         removal_amount: Union[ int, _Unspec] = _Unspec(),
         addition_amount: Union[ int, _Unspec] = _Unspec(),
-        validated_signature: Union[ bool, _Unspec] = _Unspec()) -> SpendBundleConditions: ...
+        validated_signature: Union[ bool, _Unspec] = _Unspec(),
+        execution_cost: Union[ int, _Unspec] = _Unspec(),
+        condition_cost: Union[ int, _Unspec] = _Unspec()) -> SpendBundleConditions: ...
 
 @final
 class BlockRecord:


### PR DESCRIPTION
into `execution_time` and `condition_time` (as well as the existing total cost).

This is part of preparations for incrementally serialize compressed block generators. The cost we use for mempool items can't include the byte-cost, since it's only known as we're building the block. So this gives us access to the cost broken up into its components