### PR TITLE
minor cleanups and fix test-block-generators command line parsing

### DIFF
--- a/crates/chia-consensus/src/gen/test_generators.rs
+++ b/crates/chia-consensus/src/gen/test_generators.rs
@@ -228,8 +228,7 @@ fn run_generator(#[case] name: &str) {
         block_refs.push(hex::decode(env_hex).expect("hex decode env-file"));
     }
 
-    const DEFAULT_FLAGS: u32 = 0;
-    for (flags, expected) in zip(&[DEFAULT_FLAGS, DEFAULT_FLAGS | MEMPOOL_MODE], expected) {
+    for (flags, expected) in zip(&[0, MEMPOOL_MODE], expected) {
         println!("flags: {flags:x}");
         let mut a = make_allocator(*flags);
         let conds = run_block_generator(

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -204,9 +204,6 @@ mod tests {
         assert_eq!(conditions.cost, cost);
     }
 
-    #[cfg(not(debug_assertions))]
-    const DEFAULT_FLAGS: u32 = MEMPOOL_MODE;
-
     // given a block generator and block-refs, convert run the generator to
     // produce the SpendBundle for the block without runningi, or validating,
     // the puzzles.
@@ -220,11 +217,11 @@ mod tests {
         use clvmr::serde::node_from_bytes_backrefs;
         use clvmr::serde::node_to_bytes;
 
-        let mut a = make_allocator(DEFAULT_FLAGS);
+        let mut a = make_allocator(MEMPOOL_MODE);
 
         let generator = node_from_bytes_backrefs(&mut a, generator).expect("node_from_bytes");
         let args = setup_generator_args(&mut a, block_refs).expect("setup_generator_args");
-        let dialect = ChiaDialect::new(DEFAULT_FLAGS);
+        let dialect = ChiaDialect::new(MEMPOOL_MODE);
         let Reduction(_, mut all_spends) =
             run_program(&mut a, &dialect, generator, args, 11_000_000_000).expect("run_program");
 
@@ -336,13 +333,13 @@ mod tests {
         // output conditions match and update the cost. The cost
         // of just the spend bundle will be lower
         let (block_cost, block_output) = {
-            let mut a = make_allocator(DEFAULT_FLAGS);
+            let mut a = make_allocator(MEMPOOL_MODE);
             let block_conds = run_block_generator(
                 &mut a,
                 &generator_buffer,
                 &block_refs,
                 11_000_000_000,
-                DEFAULT_FLAGS | DONT_VALIDATE_SIGNATURE,
+                MEMPOOL_MODE | DONT_VALIDATE_SIGNATURE,
                 &Signature::default(),
                 None,
                 &TEST_CONSTANTS,

--- a/crates/chia-tools/src/bin/test-block-generators.rs
+++ b/crates/chia-tools/src/bin/test-block-generators.rs
@@ -19,7 +19,6 @@ use std::time::{Duration, Instant};
 #[allow(clippy::struct_excessive_bools)]
 struct Args {
     /// Path to blockchain database file to analyze
-    #[arg(short, long)]
     file: String,
 
     /// The number of paralell thread to run block generators in
@@ -43,7 +42,7 @@ struct Args {
 
     /// The hard fork block height. Defaults to mainnet (5,496,000). For
     /// testnet11, set to 0.
-    #[arg(short, long, default_value_t = 5_496_000)]
+    #[arg(long, default_value_t = 5_496_000)]
     hard_fork_height: u32,
 
     /// stop running block generators when reaching this height


### PR DESCRIPTION
the tool `test-block-generators` was failing on startup because the implied short command line switch for `hard_fork_height` was `-h`, clashing with `--help`.

This also makes `FILE` a positional required argument.

And it removes some unnecessary constants in tests.