### PR TITLE
update chia-bls adding `dep:` to `dep:chia_py_streamable_macro`

### DIFF
--- a/crates/chia-bls/Cargo.toml
+++ b/crates/chia-bls/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/Chia-Network/chia_rs"
 workspace = true
 
 [features]
-py-bindings = ["dep:pyo3", "chia_py_streamable_macro", "chia-traits/py-bindings"]
+py-bindings = ["dep:pyo3", "dep:chia_py_streamable_macro", "chia-traits/py-bindings"]
 arbitrary = ["dep:arbitrary"]
 serde = ["dep:serde", "dep:chia-serde"]
 


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies
Looks like it was implicit until Rust 1.60 which is when they introduced the `dep:` syntax

(thanks @Rigidity)