### PR TITLE
fixup stubtest for mypy 0.15.0

### DIFF
--- a/wheel/stubtest.allowlist.3-11-plus
+++ b/wheel/stubtest.allowlist.3-11-plus
@@ -1,10 +1,6 @@
 # TODO: ask stubtest/mypy about these as they seem unlikely to be our doing
-chia_rs\.sized_byte_class\.TypeVar\.__bound__
-chia_rs\.sized_byte_class\.TypeVar\.__constraints__
-chia_rs\.sized_byte_class\.TypeVar\.__contravariant__
-chia_rs\.sized_byte_class\.TypeVar\.__covariant__
-
-chia_rs\.struct_stream\.TypeVar\.__bound__
-chia_rs\.struct_stream\.TypeVar\.__constraints__
-chia_rs\.struct_stream\.TypeVar\.__contravariant__
-chia_rs\.struct_stream\.TypeVar\.__covariant__
+chia_rs\..*\.TypeVar\.__init__
+chia_rs\..*\.TypeVar\.__bound__
+chia_rs\..*\.TypeVar\.__constraints__
+chia_rs\..*\.TypeVar\.__contravariant__
+chia_rs\..*\.TypeVar\.__covariant__


### PR DESCRIPTION
https://github.com/Chia-Network/chia_rs/actions/runs/13160210820/job/36726792631#step:12:32
```
  chia_rs.sized_byte_class.TypeVar.__init__ is inconsistent, stub does not have argument "name"
  chia_rs.sized_byte_class.TypeVar.__init__ is inconsistent, stub does not have *args argument "constraints"
  chia_rs.sized_byte_class.TypeVar.__init__ is inconsistent, stub does not have argument "bound"
  chia_rs.sized_byte_class.TypeVar.__init__ is inconsistent, stub does not have argument "contravariant"
  chia_rs.sized_byte_class.TypeVar.__init__ is inconsistent, stub does not have argument "covariant"
  chia_rs.struct_stream.TypeVar.__init__ is inconsistent, stub does not have argument "name"
  chia_rs.struct_stream.TypeVar.__init__ is inconsistent, stub does not have *args argument "constraints"
  chia_rs.struct_stream.TypeVar.__init__ is inconsistent, stub does not have argument "bound"
  chia_rs.struct_stream.TypeVar.__init__ is inconsistent, stub does not have argument "contravariant"
  chia_rs.struct_stream.TypeVar.__init__ is inconsistent, stub does not have argument "covariant"
```