### PR TITLE
Update Rust toolchain to 1.85.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.85.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
To resolve `cargo-machete` installation errors due to the new 2024 Rust edition