### PR TITLE
Add VersionedBlob and ClawbackMetadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,8 @@ dependencies = [
  "chia-protocol",
  "chia-puzzles",
  "chia-sha2 0.20.0",
+ "chia-traits 0.20.0",
+ "chia_streamable_macro 0.20.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",

--- a/crates/chia-puzzle-types/Cargo.toml
+++ b/crates/chia-puzzle-types/Cargo.toml
@@ -25,6 +25,8 @@ chia-bls = { workspace = true }
 chia-protocol = { workspace = true }
 chia-puzzles = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"], optional = true }
+chia_streamable_macro.workspace = true
+chia-traits.workspace = true
 
 [dev-dependencies]
 hex = { workspace = true }

--- a/crates/chia-puzzle-types/src/lib.rs
+++ b/crates/chia-puzzle-types/src/lib.rs
@@ -1,7 +1,9 @@
 mod derive_synthetic;
 mod proof;
 mod puzzles;
+mod versioned_blob;
 
 pub use derive_synthetic::*;
 pub use proof::*;
 pub use puzzles::*;
+pub use versioned_blob::*;

--- a/crates/chia-puzzle-types/src/versioned_blob.rs
+++ b/crates/chia-puzzle-types/src/versioned_blob.rs
@@ -1,0 +1,16 @@
+// This is used for the CR Cat and the Clawback spends
+use chia_protocol::{Bytes, Bytes32};
+use chia_streamable_macro::streamable;
+
+#[streamable]
+pub struct VersionedBlob {
+    version: u16,
+    blob: Bytes,
+}
+
+#[streamable]
+pub struct ClawbackMetadata {
+    timelock: u64,
+    sender_puzzle_hash: Bytes32,
+    recipient_puzzle_hash: Bytes32,
+}


### PR DESCRIPTION
The implementation of Clawback relies on serialized data structures posted as blobs onto the blockchain.
This PR adds the following Streamable types which are required for Clawback functionality.

VersionedBlob from:
https://github.com/Chia-Network/chia-blockchain/blob/main/chia/util/streamable.py#L626

ClawbackMetadata from 
https://github.com/Chia-Network/chia-blockchain/blob/main/chia/wallet/puzzles/clawback/metadata.py