### PR TITLE
Unpin rust-toolchain.toml temporarily to resolve CI issue

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.0"
+channel = "stable"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Until we can figure out why `1.85.0` isn't considered the same as `stable` by Rustup