### PR TITLE
bump clvmr dependency to 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -763,13 +763,15 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1485694ccaae3198b921ce3dac1954235acadd971289bae970c030f0a4f66174"
+checksum = "2630e56b575dc9a923b1070d25f5efc140f09a95b65badd4fdf02f58f485c8fe"
 dependencies = [
  "bitvec",
+ "bumpalo",
  "chia-bls 0.15.0",
  "chia-sha2 0.15.0",
+ "hex",
  "hex-literal",
  "k256",
  "lazy_static",
@@ -778,6 +780,7 @@ dependencies = [
  "num-traits",
  "p256",
  "rand",
+ "sha1",
  "sha3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ chia-puzzle-types-fuzz = { path = "./crates/chia-puzzle-types/fuzz", version = "
 clvm-traits-fuzz = { path = "./crates/clvm-traits/fuzz", version = "0.21.0" }
 clvm-utils-fuzz = { path = "./crates/clvm-utils/fuzz", version = "0.21.0" }
 blst = { version = "0.3.14", features = ["portable"] }
-clvmr = "0.12.0"
+clvmr = "0.12.1"
 syn = "2.0.100"
 quote = "1.0.40"
 proc-macro2 = "1.0.94"


### PR DESCRIPTION
This comes with the optimized `Serializer` class, which can be seen in the timing of the following test:

before:
```
$ cargo test --release build_compressed_block
running 1 test
test gen::build_compressed_block::tests::test_build_block ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2268 filtered out; finished in 22.29s
```

after:
```
$ cargo test --release build_compressed_block
running 1 test
test gen::build_compressed_block::tests::test_build_block ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2268 filtered out; finished in 6.17s
```