### PR TITLE
update ProofOfSpace to support the new plot format

### DIFF
--- a/crates/chia-protocol/src/proof_of_space.rs
+++ b/crates/chia-protocol/src/proof_of_space.rs
@@ -8,6 +8,74 @@ pub struct ProofOfSpace {
     pool_public_key: Option<G1Element>,
     pool_contract_puzzle_hash: Option<Bytes32>,
     plot_public_key: G1Element,
-    size: u8,
+    version_and_size: u8,
     proof: Bytes,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum PlotSize {
+    V1(u8),
+    V2(u8),
+}
+
+impl ProofOfSpace {
+    pub fn size(&self) -> PlotSize {
+        if (self.version_and_size & 0x80) == 0 {
+            PlotSize::V1(self.version_and_size)
+        } else {
+            PlotSize::V2(self.version_and_size & 0x7f)
+        }
+    }
+}
+
+#[cfg(feature = "py-bindings")]
+use pyo3::prelude::*;
+
+#[cfg(feature = "py-bindings")]
+#[pymethods]
+impl ProofOfSpace {
+    fn size_v1(&self) -> Option<u8> {
+        match self.size() {
+            PlotSize::V1(s) => Some(s),
+            PlotSize::V2(_) => None,
+        }
+    }
+
+    fn size_v2(&self) -> Option<u8> {
+        match self.size() {
+            PlotSize::V1(_) => None,
+            PlotSize::V2(s) => Some(s),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::needless_pass_by_value)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(0x00, PlotSize::V1(0))]
+    #[case(0x01, PlotSize::V1(1))]
+    #[case(0x08, PlotSize::V1(8))]
+    #[case(0x7f, PlotSize::V1(0x7f))]
+    #[case(0x80, PlotSize::V2(0))]
+    #[case(0x81, PlotSize::V2(1))]
+    #[case(0x80 + 28, PlotSize::V2(28))]
+    #[case(0x80 + 30, PlotSize::V2(30))]
+    #[case(0x80 + 32, PlotSize::V2(32))]
+    #[case(0xff, PlotSize::V2(0x7f))]
+    fn proof_of_space_size(#[case] size_field: u8, #[case] expect: PlotSize) {
+        let pos = ProofOfSpace::new(
+            Bytes32::from(b"abababababababababababababababab"),
+            None,
+            None,
+            G1Element::default(),
+            size_field,
+            Bytes::from(vec![]),
+        );
+
+        assert_eq!(pos.size(), expect);
+    }
 }

--- a/tests/test_proof_of_space.py
+++ b/tests/test_proof_of_space.py
@@ -1,0 +1,25 @@
+import pytest
+from chia_rs.sized_ints import uint8
+
+from chia_rs import (
+    G1Element,
+    ProofOfSpace,
+)
+
+
+def test_proof_of_space() -> None:
+    challenge = b"abababababababababababababababab"
+
+    pos = ProofOfSpace(
+        challenge, None, None, G1Element(), uint8(5), bytes.fromhex("80")
+    )
+
+    assert pos.size_v1() == 5
+    assert pos.size_v2() is None
+
+    pos = ProofOfSpace(
+        challenge, None, None, G1Element(), uint8(0x85), bytes.fromhex("80")
+    )
+
+    assert pos.size_v1() is None
+    assert pos.size_v2() == 5

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -252,6 +252,10 @@ extra_members = {
         "def sp_sub_slot_total_iters(self, constants: ConsensusConstants) -> uint128: ...",
         "def sp_total_iters(self, constants: ConsensusConstants) -> uint128: ...",
     ],
+    "ProofOfSpace": [
+        "def size_v1(self) -> Optional[uint8]: ...",
+        "def size_v2(self) -> Optional[uint8]: ...",
+    ],
 }
 
 classes = []

--- a/wheel/python/chia_rs/chia_rs.pyi
+++ b/wheel/python/chia_rs/chia_rs.pyi
@@ -2065,15 +2065,17 @@ class ProofOfSpace:
     pool_public_key: Optional[G1Element]
     pool_contract_puzzle_hash: Optional[bytes32]
     plot_public_key: G1Element
-    size: uint8
+    version_and_size: uint8
     proof: bytes
+    def size_v1(self) -> Optional[uint8]: ...
+    def size_v2(self) -> Optional[uint8]: ...
     def __init__(
         self,
         challenge: bytes,
         pool_public_key: Optional[G1Element],
         pool_contract_puzzle_hash: Optional[bytes32],
         plot_public_key: G1Element,
-        size: uint8,
+        version_and_size: uint8,
         proof: bytes
     ) -> None: ...
     def __hash__(self) -> int: ...
@@ -2097,7 +2099,7 @@ class ProofOfSpace:
         pool_public_key: Union[ Optional[G1Element], _Unspec] = _Unspec(),
         pool_contract_puzzle_hash: Union[ Optional[bytes32], _Unspec] = _Unspec(),
         plot_public_key: Union[ G1Element, _Unspec] = _Unspec(),
-        size: Union[ uint8, _Unspec] = _Unspec(),
+        version_and_size: Union[ uint8, _Unspec] = _Unspec(),
         proof: Union[ bytes, _Unspec] = _Unspec()) -> ProofOfSpace: ...
 
 @final


### PR DESCRIPTION
repurpose the most significant bit in the `size` field of `ProofOfSpace` to indicate version 1 or 2 of the plot format.