### PR TITLE
Reduce potential for panics in chia-bls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,7 @@ dependencies = [
 name = "chia-bls"
 version = "0.23.0"
 dependencies = [
+ "anyhow",
  "arbitrary",
  "blst",
  "chia-serde",

--- a/crates/chia-bls/Cargo.toml
+++ b/crates/chia-bls/Cargo.toml
@@ -35,6 +35,7 @@ chia-serde = { workspace = true, optional = true }
 rand = { workspace = true }
 criterion = { workspace = true }
 rstest = { workspace = true }
+anyhow = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/chia-bls/benches/cache.rs
+++ b/crates/chia-bls/benches/cache.rs
@@ -9,14 +9,14 @@ fn cache_benchmark(c: &mut Criterion) {
     let mut data = [0u8; 32];
     rng.fill(data.as_mut_slice());
 
-    let sk = SecretKey::from_seed(&data);
+    let sk = SecretKey::from_seed(&data).unwrap();
     let msg = b"The quick brown fox jumps over the lazy dog";
 
     let mut pks = Vec::new();
 
     let mut agg_sig = Signature::default();
     for i in 0..1000 {
-        let derived = sk.derive_hardened(i);
+        let derived = sk.derive_hardened(i).unwrap();
         let pk = derived.public_key();
         let sig = sign(&derived, msg);
         agg_sig.aggregate(&sig);
@@ -79,7 +79,7 @@ fn cache_benchmark(c: &mut Criterion) {
 
     // Add more pairs to the cache so we can evict a relatively larger number
     for i in 1_000..20_000 {
-        let derived = sk.derive_hardened(i);
+        let derived = sk.derive_hardened(i).unwrap();
         let pk = derived.public_key();
         let sig = sign(&derived, msg);
         agg_sig.aggregate(&sig);

--- a/crates/chia-bls/benches/derive_key.rs
+++ b/crates/chia-bls/benches/derive_key.rs
@@ -9,7 +9,7 @@ fn key_derivation_benchmark(c: &mut Criterion) {
     let mut data = [0u8; 32];
     rng.fill(data.as_mut_slice());
 
-    let sk = SecretKey::from_seed(&data);
+    let sk = SecretKey::from_seed(&data).unwrap();
     let pk = sk.public_key();
 
     c.bench_function("secret key, unhardened", |b| {
@@ -25,7 +25,7 @@ fn key_derivation_benchmark(c: &mut Criterion) {
         b.iter_custom(|iters| {
             let start = Instant::now();
             for i in 0..iters {
-                black_box(sk.derive_hardened(i as u32));
+                black_box(sk.derive_hardened(i as u32).unwrap());
             }
             start.elapsed()
         });

--- a/crates/chia-bls/benches/parse.rs
+++ b/crates/chia-bls/benches/parse.rs
@@ -10,7 +10,7 @@ fn parse_benchmark(c: &mut Criterion) {
     let mut data = [0u8; 32];
     rng.fill(data.as_mut_slice());
 
-    let sk = SecretKey::from_seed(&data);
+    let sk = SecretKey::from_seed(&data).unwrap();
     let pk = sk.public_key();
     let msg = b"The quick brown fox jumps over the lazy dog";
     let sig = sign(&sk, msg);

--- a/crates/chia-bls/benches/sign.rs
+++ b/crates/chia-bls/benches/sign.rs
@@ -8,7 +8,7 @@ fn sign_benchmark(c: &mut Criterion) {
     let mut data = [0u8; 32];
     rng.fill(data.as_mut_slice());
 
-    let sk = SecretKey::from_seed(&data);
+    let sk = SecretKey::from_seed(&data).unwrap();
     let small_msg = b"The quick brown fox jumps over the lazy dog";
     let large_msg = [42_u8; 4096];
 

--- a/crates/chia-bls/benches/verify.rs
+++ b/crates/chia-bls/benches/verify.rs
@@ -11,7 +11,7 @@ fn verify_benchmark(c: &mut Criterion) {
     let mut data = [0u8; 32];
     rng.fill(data.as_mut_slice());
 
-    let sk = SecretKey::from_seed(&data);
+    let sk = SecretKey::from_seed(&data).unwrap();
     let pk = sk.public_key();
     let msg_small = b"The quick brown fox jumps over the lazy dog";
     let msg_large = [42_u8; 4096];
@@ -22,7 +22,7 @@ fn verify_benchmark(c: &mut Criterion) {
     let mut gts = Vec::<GTElement>::new();
     let mut pks = Vec::<PublicKey>::new();
     for idx in 0..1000 {
-        let derived = sk.derive_hardened(idx as u32);
+        let derived = sk.derive_hardened(idx as u32).unwrap();
         let pk = derived.public_key();
         let sig = sign(&derived, msg_small);
         agg_sig.aggregate(&sig);

--- a/crates/chia-bls/fuzz/Cargo.toml
+++ b/crates/chia-bls/fuzz/Cargo.toml
@@ -29,3 +29,10 @@ path = "fuzz_targets/blspy-fidelity.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "invalid-bytes"
+path = "fuzz_targets/invalid-bytes.rs"
+test = false
+doc = false
+bench = false

--- a/crates/chia-bls/fuzz/fuzz_targets/blspy-fidelity.rs
+++ b/crates/chia-bls/fuzz/fuzz_targets/blspy-fidelity.rs
@@ -39,7 +39,7 @@ fuzz_target!(|data: &[u8]| {
         let aug = blspy.getattr("AugSchemeMPL").unwrap();
 
         // Generate key pair from seed
-        let rust_sk = SecretKey::from_seed(data);
+        let rust_sk = SecretKey::from_seed(data).unwrap();
         let py_sk = aug
             .call_method1(
                 "key_gen",
@@ -103,7 +103,7 @@ fuzz_target!(|data: &[u8]| {
 
         // derive hardened
         let idx = u32::from_be_bytes(<[u8; 4]>::try_from(&data[4..8]).unwrap());
-        let rust_sk2 = rust_sk.derive_hardened(idx);
+        let rust_sk2 = rust_sk.derive_hardened(idx).unwrap();
         let py_sk2 = aug
             .call_method1(
                 "derive_child_sk",

--- a/crates/chia-bls/fuzz/fuzz_targets/derive.rs
+++ b/crates/chia-bls/fuzz/fuzz_targets/derive.rs
@@ -9,7 +9,7 @@ fuzz_target!(|data: &[u8]| {
         return;
     }
 
-    let sk = SecretKey::from_seed(data);
+    let sk = SecretKey::from_seed(data).unwrap();
     let pk = sk.public_key();
 
     // round-trip SecretKey

--- a/crates/chia-bls/fuzz/fuzz_targets/invalid-bytes.rs
+++ b/crates/chia-bls/fuzz/fuzz_targets/invalid-bytes.rs
@@ -1,0 +1,21 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use chia_bls::{PublicKey, SecretKey, Signature};
+
+fuzz_target!(|data: &[u8]| {
+    // It will be an error if the data is less than 32 bytes
+    assert_eq!(SecretKey::from_seed(data).is_ok(), data.len() >= 32);
+
+    if let Ok(bytes) = <[u8; 32]>::try_from(data) {
+        SecretKey::from_bytes(&bytes).ok();
+    }
+
+    if let Ok(bytes) = <[u8; 48]>::try_from(data) {
+        PublicKey::from_bytes(&bytes).ok();
+    }
+
+    if let Ok(bytes) = <[u8; 96]>::try_from(data) {
+        Signature::from_bytes(&bytes).ok();
+    }
+});

--- a/crates/chia-bls/src/derive_keys.rs
+++ b/crates/chia-bls/src/derive_keys.rs
@@ -1,4 +1,4 @@
-use crate::secret_key::SecretKey;
+use crate::{secret_key::SecretKey, Result};
 
 pub trait DerivableKey {
     #[must_use]
@@ -13,12 +13,12 @@ fn derive_path_unhardened<Key: DerivableKey>(key: &Key, path: &[u32]) -> Key {
     derived
 }
 
-fn derive_path_hardened(key: &SecretKey, path: &[u32]) -> SecretKey {
-    let mut derived = key.derive_hardened(path[0]);
+fn derive_path_hardened(key: &SecretKey, path: &[u32]) -> Result<SecretKey> {
+    let mut derived = key.derive_hardened(path[0])?;
     for idx in &path[1..] {
-        derived = derived.derive_hardened(*idx);
+        derived = derived.derive_hardened(*idx)?;
     }
-    derived
+    Ok(derived)
 }
 
 pub fn master_to_wallet_unhardened_intermediate<Key: DerivableKey>(key: &Key) -> Key {
@@ -29,22 +29,26 @@ pub fn master_to_wallet_unhardened<Key: DerivableKey>(key: &Key, idx: u32) -> Ke
     derive_path_unhardened(key, &[12381_u32, 8444, 2, idx])
 }
 
-pub fn master_to_wallet_hardened_intermediate(key: &SecretKey) -> SecretKey {
+pub fn master_to_wallet_hardened_intermediate(key: &SecretKey) -> Result<SecretKey> {
     derive_path_hardened(key, &[12381_u32, 8444, 2])
 }
 
-pub fn master_to_wallet_hardened(key: &SecretKey, idx: u32) -> SecretKey {
+pub fn master_to_wallet_hardened(key: &SecretKey, idx: u32) -> Result<SecretKey> {
     derive_path_hardened(key, &[12381_u32, 8444, 2, idx])
 }
 
-pub fn master_to_pool_singleton(key: &SecretKey, pool_wallet_idx: u32) -> SecretKey {
+pub fn master_to_pool_singleton(key: &SecretKey, pool_wallet_idx: u32) -> Result<SecretKey> {
     derive_path_hardened(key, &[12381_u32, 8444, 5, pool_wallet_idx])
 }
 
 /// # Panics
 ///
 /// Panics if `pool_wallet_idx` or `idx` is greater than or equal to 10000.
-pub fn master_to_pool_authentication(key: &SecretKey, pool_wallet_idx: u32, idx: u32) -> SecretKey {
+pub fn master_to_pool_authentication(
+    key: &SecretKey,
+    pool_wallet_idx: u32,
+    idx: u32,
+) -> Result<SecretKey> {
     assert!(pool_wallet_idx < 10000);
     assert!(idx < 10000);
     derive_path_hardened(key, &[12381_u32, 8444, 6, pool_wallet_idx * 10000 + idx])

--- a/crates/chia-bls/src/error.rs
+++ b/crates/chia-bls/src/error.rs
@@ -5,14 +5,22 @@ use thiserror::Error;
 pub enum Error {
     #[error("SecretKey byte data must be less than the group order")]
     SecretKeyGroupOrder,
+
+    #[error("Seed must be at least 32 bytes")]
+    InvalidSeedLength,
+
     #[error("Given G1 infinity element must be canonical")]
     G1NotCanonical,
+
     #[error("Given G1 non-infinity element must start with 0b10")]
     G1InfinityInvalidBits,
+
     #[error("G1 non-infinity element can't have only zeros")]
     G1InfinityNotZero,
+
     #[error("PublicKey is invalid (BLST ERROR: {0:?})")]
     InvalidPublicKey(BLST_ERROR),
+
     #[error("Signature is invalid (BLST ERROR: {0:?})")]
     InvalidSignature(BLST_ERROR),
 }

--- a/crates/chia-bls/src/gtelement.rs
+++ b/crates/chia-bls/src/gtelement.rs
@@ -102,7 +102,9 @@ impl Streamable for GTElement {
 
     fn parse<const TRUSTED: bool>(input: &mut Cursor<&[u8]>) -> Result<Self> {
         Ok(GTElement::from_bytes(
-            read_bytes(input, Self::SIZE)?.try_into().unwrap(),
+            read_bytes(input, Self::SIZE)?
+                .try_into()
+                .expect("length already checked"),
         ))
     }
 }
@@ -161,7 +163,7 @@ mod pybindings {
                 parse_hex_string(o, Self::SIZE, "GTElement")?
                     .as_slice()
                     .try_into()
-                    .unwrap(),
+                    .expect("length already checked"),
             ))
         }
     }

--- a/crates/chia-bls/src/lib.rs
+++ b/crates/chia-bls/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unsafe_code)]
+#![deny(clippy::unwrap_used)]
 
 mod bls_cache;
 mod derive_keys;

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -320,8 +320,8 @@ impl AugSchemeMPL {
     }
 
     #[staticmethod]
-    pub fn derive_child_sk(sk: &SecretKey, index: u32) -> SecretKey {
-        sk.derive_hardened(index)
+    pub fn derive_child_sk(sk: &SecretKey, index: u32) -> PyResult<SecretKey> {
+        Ok(sk.derive_hardened(index)?)
     }
 
     #[staticmethod]
@@ -341,7 +341,7 @@ impl AugSchemeMPL {
                 "Seed size must be at leat 32 bytes",
             ));
         }
-        Ok(SecretKey::from_seed(seed))
+        Ok(SecretKey::from_seed(seed)?)
     }
 }
 


### PR DESCRIPTION
Adds a fuzzer for `SecretKey::from_seed`, `SecretKey::from_bytes`, `PublicKey::from_bytes`, and `Signature::from_bytes`, to make sure they return errors instead of panics if provided invalid inputs.

`SecretKey::from_seed` now returns a `Result`, and therefore hardened key derivation does as well.

Added `anyhow` to tests to simplify `Result` handling, and enabled the `unwrap_used` lint in `chia-bls` specifically. Replaced all of the `.unwrap()` calls with either `?` or `expect` as appropriate, and disabled the lint for `unwrap_err` for now.