### PR TITLE
backwards compatibility

### DIFF
--- a/crates/chia-protocol/src/proof_of_space.rs
+++ b/crates/chia-protocol/src/proof_of_space.rs
@@ -8,6 +8,10 @@ pub struct ProofOfSpace {
     pool_public_key: Option<G1Element>,
     pool_contract_puzzle_hash: Option<Bytes32>,
     plot_public_key: G1Element,
+    // this field was renamed when adding support for v2 plots since the top
+    // bit now means whether it's v1 or v2. To stay backwards compabible with
+    // JSON serialization, we still serialize this as its original name
+    #[serde(rename = "size", alias = "version_and_size")]
     version_and_size: u8,
     proof: Bytes,
 }

--- a/crates/chia-protocol/src/proof_of_space.rs
+++ b/crates/chia-protocol/src/proof_of_space.rs
@@ -2,7 +2,7 @@ use crate::bytes::{Bytes, Bytes32};
 use chia_bls::G1Element;
 use chia_streamable_macro::streamable;
 
-#[streamable]
+#[streamable(no_json)]
 pub struct ProofOfSpace {
     challenge: Bytes32,
     pool_public_key: Option<G1Element>,
@@ -11,7 +11,7 @@ pub struct ProofOfSpace {
     // this field was renamed when adding support for v2 plots since the top
     // bit now means whether it's v1 or v2. To stay backwards compabible with
     // JSON serialization, we still serialize this as its original name
-    #[serde(rename = "size", alias = "version_and_size")]
+    #[cfg_attr(feature = "serde", serde(rename = "size", alias = "version_and_size"))]
     version_and_size: u8,
     proof: Bytes,
 }
@@ -33,6 +33,8 @@ impl ProofOfSpace {
 }
 
 #[cfg(feature = "py-bindings")]
+use chia_traits::{FromJsonDict, ToJsonDict};
+#[cfg(feature = "py-bindings")]
 use pyo3::prelude::*;
 
 #[cfg(feature = "py-bindings")]
@@ -50,6 +52,49 @@ impl ProofOfSpace {
             PlotSize::V1(_) => None,
             PlotSize::V2(s) => Some(s),
         }
+    }
+}
+
+#[cfg(feature = "py-bindings")]
+impl ToJsonDict for ProofOfSpace {
+    fn to_json_dict(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::PyObject> {
+        use pyo3::prelude::PyDictMethods;
+        let ret = pyo3::types::PyDict::new(py);
+
+        ret.set_item("challenge", self.challenge.to_json_dict(py)?)?;
+        ret.set_item("pool_public_key", self.pool_public_key.to_json_dict(py)?)?;
+        ret.set_item(
+            "pool_contract_puzzle_hash",
+            self.pool_contract_puzzle_hash.to_json_dict(py)?,
+        )?;
+        ret.set_item("plot_public_key", self.plot_public_key.to_json_dict(py)?)?;
+
+        // "size" was the original name of this field. We keep it to remain backwards compatible
+        ret.set_item("size", self.version_and_size.to_json_dict(py)?)?;
+        ret.set_item("proof", self.proof.to_json_dict(py)?)?;
+
+        Ok(ret.into())
+    }
+}
+
+#[cfg(feature = "py-bindings")]
+impl FromJsonDict for ProofOfSpace {
+    fn from_json_dict(o: &pyo3::Bound<'_, pyo3::PyAny>) -> pyo3::PyResult<Self> {
+        use pyo3::prelude::PyAnyMethods;
+        Ok(Self {
+            challenge: <Bytes32 as FromJsonDict>::from_json_dict(&o.get_item("challenge")?)?,
+            pool_public_key: <Option<G1Element> as FromJsonDict>::from_json_dict(
+                &o.get_item("pool_public_key")?,
+            )?,
+            pool_contract_puzzle_hash: <Option<Bytes32> as FromJsonDict>::from_json_dict(
+                &o.get_item("pool_contract_puzzle_hash")?,
+            )?,
+            plot_public_key: <G1Element as FromJsonDict>::from_json_dict(
+                &o.get_item("plot_public_key")?,
+            )?,
+            version_and_size: <u8 as FromJsonDict>::from_json_dict(&o.get_item("size")?)?,
+            proof: <Bytes as FromJsonDict>::from_json_dict(&o.get_item("proof")?)?,
+        })
     }
 }
 


### PR DESCRIPTION
renaming the field `size` -> `version_and_size` was important to make sure source code referring to this field is updated to handle the change in semantics. However, in order to stay backwards compatible with the RPC protocol, the field should still be called "size" in JSON dicts.

I've tested this change in `chia-blockchain` which has coverage of the JSON serialization of this type.