### PR TITLE
[CHIA-2884] Pot iterations

### DIFF
--- a/crates/chia-protocol/src/block_record.rs
+++ b/crates/chia-protocol/src/block_record.rs
@@ -75,7 +75,7 @@ impl BlockRecord {
         calculate_sp_iters(
             num_sps_sub_slot,
             self.sub_slot_iters,
-            self.signage_point_index as u32,
+            self.signage_point_index,
         )
     }
 
@@ -84,7 +84,7 @@ impl BlockRecord {
             num_sps_sub_slot,
             num_sp_intervals_extra,
             self.sub_slot_iters,
-            self.signage_point_index as u32,
+            self.signage_point_index,
             self.required_iters,
         )
     }

--- a/crates/chia-protocol/src/pot_iterations.rs
+++ b/crates/chia-protocol/src/pot_iterations.rs
@@ -23,15 +23,13 @@ fn div_catch_error(a: u64, b: u64) -> Result<u64> {
 pub fn is_overflow_block(
     num_sps_sub_slot: u32,
     num_sp_intervals_extra: u8,
-    signage_point_index: u32,
+    signage_point_index: u8,
 ) -> Result<bool> {
-    if signage_point_index >= num_sps_sub_slot {
+    if u32::from(signage_point_index) >= num_sps_sub_slot {
         return Err(Error::InvalidPotIteration);
     }
-    Ok(
-        signage_point_index
-            >= sub_catch_underflow(num_sps_sub_slot, num_sp_intervals_extra as u32)?,
-    )
+    Ok(u32::from(signage_point_index)
+        >= sub_catch_underflow(num_sps_sub_slot, num_sp_intervals_extra as u32)?)
 }
 
 pub fn calculate_sp_interval_iters(num_sps_sub_slot: u32, sub_slot_iters: u64) -> Result<u64> {
@@ -44,9 +42,9 @@ pub fn calculate_sp_interval_iters(num_sps_sub_slot: u32, sub_slot_iters: u64) -
 pub fn calculate_sp_iters(
     num_sps_sub_slot: u32,
     sub_slot_iters: u64,
-    signage_point_index: u32,
+    signage_point_index: u8,
 ) -> Result<u64> {
-    if signage_point_index >= num_sps_sub_slot {
+    if u32::from(signage_point_index) >= num_sps_sub_slot {
         return Err(Error::InvalidPotIteration);
     }
     mult_catch_overflow(
@@ -59,7 +57,7 @@ pub fn calculate_ip_iters(
     num_sps_sub_slot: u32,
     num_sp_intervals_extra: u8,
     sub_slot_iters: u64,
-    signage_point_index: u32,
+    signage_point_index: u8,
     required_iters: u64,
 ) -> Result<u64> {
     let sp_interval_iters = calculate_sp_interval_iters(num_sps_sub_slot, sub_slot_iters)?;
@@ -89,7 +87,7 @@ pub fn calculate_ip_iters(
 pub fn py_is_overflow_block(
     num_sps_sub_slot: u32,
     num_sp_intervals_extra: u8,
-    signage_point_index: u32,
+    signage_point_index: u8,
 ) -> pyo3::PyResult<bool> {
     Ok(is_overflow_block(
         num_sps_sub_slot,
@@ -117,7 +115,7 @@ pub fn py_calculate_sp_interval_iters(
 pub fn py_calculate_sp_iters(
     num_sps_sub_slot: u32,
     sub_slot_iters: u64,
-    signage_point_index: u32,
+    signage_point_index: u8,
 ) -> pyo3::PyResult<u64> {
     Ok(calculate_sp_iters(
         num_sps_sub_slot,
@@ -133,7 +131,7 @@ pub fn py_calculate_ip_iters(
     num_sps_sub_slot: u32,
     num_sp_intervals_extra: u8,
     sub_slot_iters: u64,
-    signage_point_index: u32,
+    signage_point_index: u8,
     required_iters: u64,
 ) -> pyo3::PyResult<u64> {
     Ok(calculate_ip_iters(
@@ -194,42 +192,45 @@ mod tests {
         let sp_interval_iters = ssi / NUM_SPS_SUB_SLOT as u64;
 
         // Invalid signage point index
-        assert!(
+        assert_eq!(
             calculate_ip_iters(NUM_SPS_SUB_SLOT, NUM_SP_INTERVALS_EXTRA, ssi, 123, 100_000)
-                .is_err()
+                .unwrap_err(),
+            Error::InvalidPotIteration
         );
 
         let sp_iters = sp_interval_iters * 13;
 
         // required_iters too high
-        assert!(calculate_ip_iters(
-            NUM_SPS_SUB_SLOT,
-            NUM_SP_INTERVALS_EXTRA,
-            ssi,
-            sp_interval_iters.try_into().unwrap(),
-            sp_interval_iters
-        )
-        .is_err());
+        assert_eq!(
+            calculate_ip_iters(
+                NUM_SPS_SUB_SLOT,
+                NUM_SP_INTERVALS_EXTRA,
+                ssi,
+                13,
+                sp_interval_iters
+            )
+            .unwrap_err(),
+            Error::InvalidPotIteration
+        );
 
         // required_iters too high
-        assert!(calculate_ip_iters(
-            NUM_SPS_SUB_SLOT,
-            NUM_SP_INTERVALS_EXTRA,
-            ssi,
-            sp_interval_iters.try_into().unwrap(),
-            sp_interval_iters * 12
-        )
-        .is_err());
+        assert_eq!(
+            calculate_ip_iters(
+                NUM_SPS_SUB_SLOT,
+                NUM_SP_INTERVALS_EXTRA,
+                ssi,
+                13,
+                sp_interval_iters * 12
+            )
+            .unwrap_err(),
+            Error::InvalidPotIteration
+        );
 
         // required_iters too low (0)
-        assert!(calculate_ip_iters(
-            NUM_SPS_SUB_SLOT,
-            NUM_SP_INTERVALS_EXTRA,
-            ssi,
-            sp_interval_iters.try_into().unwrap(),
-            0
-        )
-        .is_err());
+        assert_eq!(
+            calculate_ip_iters(NUM_SPS_SUB_SLOT, NUM_SP_INTERVALS_EXTRA, ssi, 255, 0).unwrap_err(),
+            Error::InvalidPotIteration
+        );
 
         let required_iters = sp_interval_iters - 1;
         let ip_iters = calculate_ip_iters(
@@ -280,7 +281,7 @@ mod tests {
             NUM_SPS_SUB_SLOT,
             NUM_SP_INTERVALS_EXTRA,
             ssi,
-            NUM_SPS_SUB_SLOT - 1_u32,
+            (NUM_SPS_SUB_SLOT - 1_u32) as u8,
             required_iters,
         )
         .expect("valid");

--- a/crates/chia-protocol/src/pot_iterations.rs
+++ b/crates/chia-protocol/src/pot_iterations.rs
@@ -81,68 +81,6 @@ pub fn calculate_ip_iters(
     )
 }
 
-#[cfg(feature = "py-bindings")]
-#[pyo3::pyfunction]
-#[pyo3(name = "is_overflow_block")]
-pub fn py_is_overflow_block(
-    num_sps_sub_slot: u32,
-    num_sp_intervals_extra: u8,
-    signage_point_index: u8,
-) -> pyo3::PyResult<bool> {
-    Ok(is_overflow_block(
-        num_sps_sub_slot,
-        num_sp_intervals_extra,
-        signage_point_index,
-    )?)
-}
-
-#[cfg(feature = "py-bindings")]
-#[pyo3::pyfunction]
-#[pyo3(name = "calculate_sp_interval_iters")]
-pub fn py_calculate_sp_interval_iters(
-    num_sps_sub_slot: u32,
-    sub_slot_iters: u64,
-) -> pyo3::PyResult<u64> {
-    Ok(calculate_sp_interval_iters(
-        num_sps_sub_slot,
-        sub_slot_iters,
-    )?)
-}
-
-#[cfg(feature = "py-bindings")]
-#[pyo3::pyfunction]
-#[pyo3(name = "calculate_sp_iters")]
-pub fn py_calculate_sp_iters(
-    num_sps_sub_slot: u32,
-    sub_slot_iters: u64,
-    signage_point_index: u8,
-) -> pyo3::PyResult<u64> {
-    Ok(calculate_sp_iters(
-        num_sps_sub_slot,
-        sub_slot_iters,
-        signage_point_index,
-    )?)
-}
-
-#[cfg(feature = "py-bindings")]
-#[pyo3::pyfunction]
-#[pyo3(name = "calculate_ip_iters")]
-pub fn py_calculate_ip_iters(
-    num_sps_sub_slot: u32,
-    num_sp_intervals_extra: u8,
-    sub_slot_iters: u64,
-    signage_point_index: u8,
-    required_iters: u64,
-) -> pyo3::PyResult<u64> {
-    Ok(calculate_ip_iters(
-        num_sps_sub_slot,
-        num_sp_intervals_extra,
-        sub_slot_iters,
-        signage_point_index,
-        required_iters,
-    )?)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/test_pot_iterations.py
+++ b/tests/test_pot_iterations.py
@@ -21,42 +21,36 @@ test_constants = DEFAULT_CONSTANTS.replace(
 class TestPotIterations:
     def test_is_overflow_block(self) -> None:
         assert not is_overflow_block(
-            test_constants.NUM_SPS_SUB_SLOT,
-            test_constants.NUM_SP_INTERVALS_EXTRA,
+            test_constants,
             uint8(27),
         )
         assert not is_overflow_block(
-            test_constants.NUM_SPS_SUB_SLOT,
-            test_constants.NUM_SP_INTERVALS_EXTRA,
+            test_constants,
             uint8(28),
         )
         assert is_overflow_block(
-            test_constants.NUM_SPS_SUB_SLOT,
-            test_constants.NUM_SP_INTERVALS_EXTRA,
+            test_constants,
             uint8(29),
         )
         assert is_overflow_block(
-            test_constants.NUM_SPS_SUB_SLOT,
-            test_constants.NUM_SP_INTERVALS_EXTRA,
+            test_constants,
             uint8(30),
         )
         assert is_overflow_block(
-            test_constants.NUM_SPS_SUB_SLOT,
-            test_constants.NUM_SP_INTERVALS_EXTRA,
+            test_constants,
             uint8(31),
         )
         with raises(ValueError):
             assert is_overflow_block(
-                test_constants.NUM_SPS_SUB_SLOT,
-                test_constants.NUM_SP_INTERVALS_EXTRA,
+                test_constants,
                 uint8(32),
             )
 
     def test_calculate_sp_iters(self) -> None:
         ssi: uint64 = uint64(100001 * 64 * 4)
         with raises(ValueError):
-            calculate_sp_iters(test_constants.NUM_SPS_SUB_SLOT, ssi, uint8(32))
-        calculate_sp_iters(test_constants.NUM_SPS_SUB_SLOT, ssi, uint8(31))
+            calculate_sp_iters(test_constants, ssi, uint8(32))
+        calculate_sp_iters(test_constants, ssi, uint8(31))
 
     def test_expected_plot_size(self) -> None:
         assert (
@@ -87,8 +81,7 @@ class TestPotIterations:
         with raises(ValueError):
             # Invalid signage point index
             calculate_ip_iters(
-                test_constants.NUM_SPS_SUB_SLOT,
-                test_constants.NUM_SP_INTERVALS_EXTRA,
+                test_constants,
                 ssi,
                 uint8(123),
                 uint64(100000),
@@ -99,8 +92,7 @@ class TestPotIterations:
         with raises(ValueError):
             # required_iters too high
             calculate_ip_iters(
-                test_constants.NUM_SPS_SUB_SLOT,
-                test_constants.NUM_SP_INTERVALS_EXTRA,
+                test_constants,
                 ssi,
                 uint8(255),
                 sp_interval_iters,
@@ -109,8 +101,7 @@ class TestPotIterations:
         with raises(ValueError):
             # required_iters too high
             calculate_ip_iters(
-                test_constants.NUM_SPS_SUB_SLOT,
-                test_constants.NUM_SP_INTERVALS_EXTRA,
+                test_constants,
                 ssi,
                 uint8(255),
                 uint64(sp_interval_iters * 12),
@@ -119,8 +110,7 @@ class TestPotIterations:
         with raises(ValueError):
             # required_iters too low (0)
             calculate_ip_iters(
-                test_constants.NUM_SPS_SUB_SLOT,
-                test_constants.NUM_SP_INTERVALS_EXTRA,
+                test_constants,
                 ssi,
                 uint8(255),
                 uint64(0),
@@ -128,8 +118,7 @@ class TestPotIterations:
 
         required_iters = uint64(sp_interval_iters - 1)
         ip_iters = calculate_ip_iters(
-            test_constants.NUM_SPS_SUB_SLOT,
-            test_constants.NUM_SP_INTERVALS_EXTRA,
+            test_constants,
             ssi,
             uint8(13),
             required_iters,
@@ -143,8 +132,7 @@ class TestPotIterations:
 
         required_iters = uint64(1)
         ip_iters = calculate_ip_iters(
-            test_constants.NUM_SPS_SUB_SLOT,
-            test_constants.NUM_SP_INTERVALS_EXTRA,
+            test_constants,
             ssi,
             uint8(13),
             required_iters,
@@ -158,8 +146,7 @@ class TestPotIterations:
 
         required_iters = uint64(int(ssi * 4 / 300))
         ip_iters = calculate_ip_iters(
-            test_constants.NUM_SPS_SUB_SLOT,
-            test_constants.NUM_SP_INTERVALS_EXTRA,
+            test_constants,
             ssi,
             uint8(13),
             required_iters,
@@ -175,8 +162,7 @@ class TestPotIterations:
         # Overflow
         sp_iters = sp_interval_iters * (test_constants.NUM_SPS_SUB_SLOT - 1)
         ip_iters = calculate_ip_iters(
-            test_constants.NUM_SPS_SUB_SLOT,
-            test_constants.NUM_SP_INTERVALS_EXTRA,
+            test_constants,
             ssi,
             uint8(test_constants.NUM_SPS_SUB_SLOT - 1),
             required_iters,

--- a/tests/test_pot_iterations.py
+++ b/tests/test_pot_iterations.py
@@ -19,7 +19,7 @@ test_constants = DEFAULT_CONSTANTS.replace(
 
 
 class TestPotIterations:
-    def test_is_overflow_block(self):
+    def test_is_overflow_block(self) -> None:
         assert not is_overflow_block(
             test_constants.NUM_SPS_SUB_SLOT,
             test_constants.NUM_SP_INTERVALS_EXTRA,
@@ -52,13 +52,13 @@ class TestPotIterations:
                 uint8(32),
             )
 
-    def test_calculate_sp_iters(self):
+    def test_calculate_sp_iters(self) -> None:
         ssi: uint64 = uint64(100001 * 64 * 4)
         with raises(ValueError):
             calculate_sp_iters(test_constants.NUM_SPS_SUB_SLOT, ssi, uint8(32))
         calculate_sp_iters(test_constants.NUM_SPS_SUB_SLOT, ssi, uint8(31))
 
-    def test_expected_plot_size(self):
+    def test_expected_plot_size(self) -> None:
         assert (
             expected_plot_size(32) == 139586437120
         )  # number retrieved from old implementation
@@ -75,14 +75,14 @@ class TestPotIterations:
             expected_plot_size(36) == 2508260900864
         )  # number retrieved from old implementation
 
-    def test_calculate_ip_iters(self):
+    def test_calculate_ip_iters(self) -> None:
         # num_sps_sub_slot: u32,
         # num_sp_intervals_extra: u8,
         # sub_slot_iters: u64,
         # signage_point_index: u8,
         # required_iters: u64,
         ssi: uint64 = uint64(100001 * 64 * 4)
-        sp_interval_iters = ssi // test_constants.NUM_SPS_SUB_SLOT
+        sp_interval_iters = uint64(ssi // test_constants.NUM_SPS_SUB_SLOT)
 
         with raises(ValueError):
             # Invalid signage point index
@@ -102,7 +102,7 @@ class TestPotIterations:
                 test_constants.NUM_SPS_SUB_SLOT,
                 test_constants.NUM_SP_INTERVALS_EXTRA,
                 ssi,
-                sp_interval_iters,
+                uint8(255),
                 sp_interval_iters,
             )
 
@@ -112,8 +112,8 @@ class TestPotIterations:
                 test_constants.NUM_SPS_SUB_SLOT,
                 test_constants.NUM_SP_INTERVALS_EXTRA,
                 ssi,
-                sp_interval_iters,
-                sp_interval_iters * 12,
+                uint8(255),
+                uint64(sp_interval_iters * 12),
             )
 
         with raises(ValueError):
@@ -122,11 +122,11 @@ class TestPotIterations:
                 test_constants.NUM_SPS_SUB_SLOT,
                 test_constants.NUM_SP_INTERVALS_EXTRA,
                 ssi,
-                sp_interval_iters,
+                uint8(255),
                 uint64(0),
             )
 
-        required_iters = sp_interval_iters - 1
+        required_iters = uint64(sp_interval_iters - 1)
         ip_iters = calculate_ip_iters(
             test_constants.NUM_SPS_SUB_SLOT,
             test_constants.NUM_SP_INTERVALS_EXTRA,

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -344,14 +344,14 @@ def calculate_ip_iters(
     num_sps_sub_slot: uint32,
     num_sp_intervals_extra: uint8,
     sub_slot_iters: uint64,
-    signage_point_index: uint32,
+    signage_point_index: uint8,
     required_iters: uint64,
 ) -> uint64: ...
 
 def calculate_sp_iters(
     num_sps_sub_slot: uint32,
     sub_slot_iters: uint64,
-    signage_point_index: uint32,
+    signage_point_index: uint8,
 ) -> uint64: ...
 
 def calculate_sp_interval_iters(
@@ -362,7 +362,7 @@ def calculate_sp_interval_iters(
 def is_overflow_block(
     num_sps_sub_slot: uint32,
     num_sp_intervals_extra: uint8,
-    signage_point_index: uint32,
+    signage_point_index: uint8,
 ) -> bool: ...
 
 def expected_plot_size(

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -341,27 +341,25 @@ def get_flags_for_height_and_constants(
 ) -> int: ...
 
 def calculate_ip_iters(
-    num_sps_sub_slot: uint32,
-    num_sp_intervals_extra: uint8,
+    constants: ConsensusConstants,
     sub_slot_iters: uint64,
     signage_point_index: uint8,
     required_iters: uint64,
 ) -> uint64: ...
 
 def calculate_sp_iters(
-    num_sps_sub_slot: uint32,
+    constants: ConsensusConstants,
     sub_slot_iters: uint64,
     signage_point_index: uint8,
 ) -> uint64: ...
 
 def calculate_sp_interval_iters(
-    num_sps_sub_slot: uint32,
+    constants: ConsensusConstants,
     sub_slot_iters: uint64,
 ) -> uint64: ...
 
 def is_overflow_block(
-    num_sps_sub_slot: uint32,
-    num_sp_intervals_extra: uint8,
+    constants: ConsensusConstants,
     signage_point_index: uint8,
 ) -> bool: ...
 

--- a/wheel/python/chia_rs/chia_rs.pyi
+++ b/wheel/python/chia_rs/chia_rs.pyi
@@ -69,14 +69,14 @@ def calculate_ip_iters(
     num_sps_sub_slot: uint32,
     num_sp_intervals_extra: uint8,
     sub_slot_iters: uint64,
-    signage_point_index: uint32,
+    signage_point_index: uint8,
     required_iters: uint64,
 ) -> uint64: ...
 
 def calculate_sp_iters(
     num_sps_sub_slot: uint32,
     sub_slot_iters: uint64,
-    signage_point_index: uint32,
+    signage_point_index: uint8,
 ) -> uint64: ...
 
 def calculate_sp_interval_iters(
@@ -87,7 +87,7 @@ def calculate_sp_interval_iters(
 def is_overflow_block(
     num_sps_sub_slot: uint32,
     num_sp_intervals_extra: uint8,
-    signage_point_index: uint32,
+    signage_point_index: uint8,
 ) -> bool: ...
 
 def expected_plot_size(

--- a/wheel/python/chia_rs/chia_rs.pyi
+++ b/wheel/python/chia_rs/chia_rs.pyi
@@ -66,27 +66,25 @@ def get_flags_for_height_and_constants(
 ) -> int: ...
 
 def calculate_ip_iters(
-    num_sps_sub_slot: uint32,
-    num_sp_intervals_extra: uint8,
+    constants: ConsensusConstants,
     sub_slot_iters: uint64,
     signage_point_index: uint8,
     required_iters: uint64,
 ) -> uint64: ...
 
 def calculate_sp_iters(
-    num_sps_sub_slot: uint32,
+    constants: ConsensusConstants,
     sub_slot_iters: uint64,
     signage_point_index: uint8,
 ) -> uint64: ...
 
 def calculate_sp_interval_iters(
-    num_sps_sub_slot: uint32,
+    constants: ConsensusConstants,
     sub_slot_iters: uint64,
 ) -> uint64: ...
 
 def is_overflow_block(
-    num_sps_sub_slot: uint32,
-    num_sp_intervals_extra: uint8,
+    constants: ConsensusConstants,
     signage_point_index: uint8,
 ) -> bool: ...
 

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -18,8 +18,8 @@ use chia_consensus::spendbundle_validation::{
     get_flags_for_height_and_constants, validate_clvm_and_signature,
 };
 use chia_protocol::{
-    py_calculate_ip_iters, py_calculate_sp_interval_iters, py_calculate_sp_iters,
-    py_expected_plot_size, py_is_overflow_block,
+    calculate_ip_iters, calculate_sp_interval_iters, calculate_sp_iters, is_overflow_block,
+    py_expected_plot_size,
 };
 use chia_protocol::{
     BlockRecord, Bytes32, ChallengeBlockInfo, ChallengeChainSubSlot, ClassgroupElement, Coin,
@@ -442,6 +442,61 @@ pub fn py_get_flags_for_height_and_constants(height: u32, constants: &ConsensusC
     get_flags_for_height_and_constants(height, constants)
 }
 
+#[pyo3::pyfunction]
+#[pyo3(name = "is_overflow_block")]
+pub fn py_is_overflow_block(
+    constants: &ConsensusConstants,
+    signage_point_index: u8,
+) -> pyo3::PyResult<bool> {
+    Ok(is_overflow_block(
+        constants.num_sps_sub_slot,
+        constants.num_sp_intervals_extra,
+        signage_point_index,
+    )?)
+}
+
+#[pyo3::pyfunction]
+#[pyo3(name = "calculate_sp_interval_iters")]
+pub fn py_calculate_sp_interval_iters(
+    constants: &ConsensusConstants,
+    sub_slot_iters: u64,
+) -> pyo3::PyResult<u64> {
+    Ok(calculate_sp_interval_iters(
+        constants.num_sps_sub_slot,
+        sub_slot_iters,
+    )?)
+}
+
+#[pyo3::pyfunction]
+#[pyo3(name = "calculate_sp_iters")]
+pub fn py_calculate_sp_iters(
+    constants: &ConsensusConstants,
+    sub_slot_iters: u64,
+    signage_point_index: u8,
+) -> pyo3::PyResult<u64> {
+    Ok(calculate_sp_iters(
+        constants.num_sps_sub_slot,
+        sub_slot_iters,
+        signage_point_index,
+    )?)
+}
+
+#[pyo3::pyfunction]
+#[pyo3(name = "calculate_ip_iters")]
+pub fn py_calculate_ip_iters(
+    constants: &ConsensusConstants,
+    sub_slot_iters: u64,
+    signage_point_index: u8,
+    required_iters: u64,
+) -> pyo3::PyResult<u64> {
+    Ok(calculate_ip_iters(
+        constants.num_sps_sub_slot,
+        constants.num_sp_intervals_extra,
+        sub_slot_iters,
+        signage_point_index,
+        required_iters,
+    )?)
+}
 #[pymodule]
 pub fn chia_rs(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // generator functions


### PR DESCRIPTION
* enable mypy on some test functions
* turn `signage_point_index` into a `u8`, like python.
* update python binding signatures to match the python implementation