### PR TITLE
remove components from `rust-toolchain.toml`

### DIFF
--- a/.github/workflows/build-crate.yml
+++ b/.github/workflows/build-crate.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -272,7 +272,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           components: rustfmt, clippy
 
@@ -286,7 +286,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85.0
         with:
           components: clippy
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
 channel = "1.85.0"
-components = ["rustfmt", "clippy"]


### PR DESCRIPTION
they are not required to build and maturin presently installs them while building

also, while there is some other issue going on that would be nice to address separately, this does avoid the symptom of generator benchmarking builds failing on beast.

https://github.com/Chia-Network/chia_rs/actions/runs/15169429653/job/42655535606?pr=1051
```
💥 maturin failed
  Caused by: Failed to run rustc to get the host target
  Caused by: error from command -- stderr:

info: syncing channel updates for '1.85.0-x86_64-unknown-linux-gnu'
info: latest update on 2025-02-20, rust version 1.85.0 (4d91de4e4 2025-02-[17](https://github.com/Chia-Network/chia_rs/actions/runs/15169429653/job/42655535606?pr=1051#step:14:18))
info: downloading component 'clippy'
info: downloading component 'rustfmt'
info: installing component 'clippy'
info: rolling back changes
error: failed to install component: 'clippy-preview-x86_64-unknown-linux-gnu', detected conflict: 'bin/cargo-clippy'
```

note successful runs on both benchmark runners.

- sumo: https://github.com/Chia-Network/chia_rs/actions/runs/15170143800/job/42657873973?pr=1073#step:1:2
- beast: https://github.com/Chia-Network/chia_rs/actions/runs/15170143800/job/42658372670?pr=1073#step:1:2