### PR TITLE
disable benchmarks for root crate

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -170,4 +170,4 @@ jobs:
 
       - name: cargo bench
         run: |
-          cargo bench --workspace --exclude chia_rs
+          cargo bench --workspace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,9 @@ openssl = ["chia-sha2/openssl", "clvmr/openssl"]
 [profile.release]
 lto = "thin"
 
+[lib]
+bench = false
+
 [workspace.dependencies]
 chia_py_streamable_macro = { path = "./crates/chia_py_streamable_macro", version = "0.26.0" }
 chia_streamable_macro = { path = "./crates/chia_streamable_macro", version = "0.26.0" }


### PR DESCRIPTION
to allow running `cargo bench --workspace`