### PR TITLE
Instead of collecting nodes with multiple references in deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6b7142674607f3a213addaf261bd70b07537297e460a9cc6a389068a62934f"
+checksum = "76949d41a75c258803cf3d78053305386ac818cf64777e79ac860e5735784b9e"
 dependencies = [
  "bitvec",
  "bumpalo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ chia-puzzle-types-fuzz = { path = "./crates/chia-puzzle-types/fuzz", version = "
 clvm-traits-fuzz = { path = "./crates/clvm-traits/fuzz", version = "0.26.0" }
 clvm-utils-fuzz = { path = "./crates/clvm-utils/fuzz", version = "0.26.0" }
 blst = { version = "0.3.14", features = ["portable"] }
-clvmr = "0.14.0"
+clvmr = "0.15.0"
 syn = "2.0.101"
 quote = "1.0.40"
 proc-macro2 = "1.0.95"

--- a/crates/chia-consensus/fuzz/fuzz_targets/puzzle-coin-solution.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/puzzle-coin-solution.rs
@@ -5,7 +5,6 @@ use chia_consensus::get_puzzle_and_solution::get_puzzle_and_solution_for_coin;
 use chia_fuzz::{make_tree, BitCursor};
 use chia_protocol::Coin;
 use clvmr::allocator::Allocator;
-use std::collections::HashSet;
 
 const HASH: [u8; 32] = [
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -15,10 +14,6 @@ fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();
     let input = make_tree(&mut a, &mut BitCursor::new(data), false);
 
-    let _ret = get_puzzle_and_solution_for_coin(
-        &a,
-        input,
-        &HashSet::new(),
-        &Coin::new(HASH.into(), HASH.into(), 1337),
-    );
+    let _ret =
+        get_puzzle_and_solution_for_coin(&a, input, &Coin::new(HASH.into(), HASH.into(), 1337));
 });

--- a/crates/chia-consensus/src/additions_and_removals.rs
+++ b/crates/chia-consensus/src/additions_and_removals.rs
@@ -7,13 +7,12 @@ use crate::consensus_constants::ConsensusConstants;
 use crate::validation_error::{atom, first, next, rest, ErrorCode, ValidationErr};
 use chia_protocol::{Bytes, Bytes32};
 use clvm_traits::FromClvm;
-use clvm_utils::{tree_hash_cached, TreeHash};
+use clvm_utils::{tree_hash_cached, TreeCache};
 use clvmr::allocator::NodePtr;
 use clvmr::chia_dialect::ChiaDialect;
 use clvmr::reduction::Reduction;
 use clvmr::run_program::run_program;
-use clvmr::serde::node_from_bytes_backrefs_record;
-use std::collections::HashMap;
+use clvmr::serde::node_from_bytes_backrefs;
 
 /// Run a *trusted* block generator and return its additions and removals. This
 /// function does not validate the block, it is assumed to be valid.
@@ -34,7 +33,7 @@ where
 
     let mut cost_left = constants.max_block_cost_clvm;
 
-    let (program, backrefs) = node_from_bytes_backrefs_record(&mut a, program)?;
+    let program = node_from_bytes_backrefs(&mut a, program)?;
 
     let args = setup_generator_args(&mut a, block_refs)?;
     let dialect = ChiaDialect::new(flags);
@@ -45,7 +44,7 @@ where
     subtract_cost(&a, &mut cost_left, clvm_cost)?;
     all_spends = first(&a, all_spends)?;
 
-    let mut cache = HashMap::<NodePtr, TreeHash>::new();
+    let mut cache = TreeCache::default();
     // at this point all_spends is a list of:
     // (parent-coin-id puzzle-reveal amount solution . extra)
     // where extra may be nil, or additional extension data
@@ -62,7 +61,7 @@ where
 
         subtract_cost(&a, &mut cost_left, clvm_cost)?;
 
-        let puzzle_hash = tree_hash_cached(&a, puzzle, &backrefs, &mut cache);
+        let puzzle_hash = tree_hash_cached(&a, puzzle, &mut cache);
 
         let coin = Coin {
             parent_coin_info: parent_id,

--- a/crates/chia-consensus/src/get_puzzle_and_solution.rs
+++ b/crates/chia-consensus/src/get_puzzle_and_solution.rs
@@ -1,9 +1,8 @@
 use crate::validation_error::{atom, check_nil, first, next, rest, ErrorCode, ValidationErr};
 use chia_protocol::Coin;
-use clvm_utils::{tree_hash_cached, TreeHash};
+use clvm_utils::{tree_hash_cached, TreeCache};
 use clvmr::allocator::{Allocator, Atom, NodePtr};
 use clvmr::op_utils::u64_from_bytes;
-use std::collections::{HashMap, HashSet};
 
 // returns parent-coin ID, amount, puzzle-reveal and solution
 pub fn parse_coin_spend(
@@ -25,7 +24,6 @@ pub fn parse_coin_spend(
 pub fn get_puzzle_and_solution_for_coin(
     a: &Allocator,
     generator_result: NodePtr,
-    backrefs: &HashSet<NodePtr>,
     find_coin: &Coin,
 ) -> Result<(NodePtr, NodePtr), ValidationErr> {
     // the output from the block generator is a list of CoinSpends
@@ -33,7 +31,7 @@ pub fn get_puzzle_and_solution_for_coin(
     // this function is given the generator output and a parent_coin_id, amount
     // and puzzle_hash and it will return the puzzle and solution for that given
     // coin spend, or fail if it cannot be found
-    let mut cache = HashMap::<NodePtr, TreeHash>::new();
+    let mut cache = TreeCache::default();
     let mut iter = first(a, generator_result)?;
     while let Some((coin_spend, next)) = next(a, iter)? {
         iter = next;
@@ -46,7 +44,7 @@ pub fn get_puzzle_and_solution_for_coin(
             continue;
         }
 
-        let puzzle_hash = tree_hash_cached(a, puzzle, backrefs, &mut cache);
+        let puzzle_hash = tree_hash_cached(a, puzzle, &mut cache);
         if puzzle_hash != find_coin.puzzle_hash.into() {
             continue;
         }
@@ -135,7 +133,6 @@ mod test {
             get_puzzle_and_solution_for_coin(
                 &a,
                 generator_output,
-                &HashSet::new(),
                 &Coin::new(parent, tree_hash(&a, puzzle1).into(), 1337),
             )
             .unwrap(),
@@ -147,7 +144,6 @@ mod test {
             get_puzzle_and_solution_for_coin(
                 &a,
                 generator_output,
-                &HashSet::new(),
                 &Coin::new(make_dummy_id(2), tree_hash(&a, puzzle1).into(), 1337),
             )
             .unwrap_err()
@@ -160,7 +156,6 @@ mod test {
             get_puzzle_and_solution_for_coin(
                 &a,
                 generator_output,
-                &HashSet::new(),
                 &Coin::new(parent, tree_hash(&a, puzzle1).into(), 42),
             )
             .unwrap_err()
@@ -173,7 +168,6 @@ mod test {
             get_puzzle_and_solution_for_coin(
                 &a,
                 generator_output,
-                &HashSet::new(),
                 &Coin::new(parent, make_dummy_id(4), 1337),
             )
             .unwrap_err()
@@ -268,7 +262,6 @@ mod test {
             let (puzzle, solution) = get_puzzle_and_solution_for_coin(
                 &a2,
                 result,
-                &HashSet::new(),
                 &Coin::new(
                     a.atom(s.parent_id).as_ref().try_into().unwrap(),
                     a.atom(s.puzzle_hash).as_ref().try_into().unwrap(),

--- a/crates/chia-consensus/src/run_block_generator.rs
+++ b/crates/chia-consensus/src/run_block_generator.rs
@@ -7,14 +7,13 @@ use crate::flags::DONT_VALIDATE_SIGNATURE;
 use crate::generator_rom::{CLVM_DESERIALIZER, GENERATOR_ROM};
 use crate::validation_error::{first, ErrorCode, ValidationErr};
 use chia_bls::{BlsCache, Signature};
-use clvm_utils::{tree_hash_cached, TreeHash};
+use clvm_utils::{tree_hash_cached, TreeCache};
 use clvmr::allocator::{Allocator, NodePtr};
 use clvmr::chia_dialect::ChiaDialect;
 use clvmr::cost::Cost;
 use clvmr::reduction::Reduction;
 use clvmr::run_program::run_program;
-use clvmr::serde::{node_from_bytes, node_from_bytes_backrefs, node_from_bytes_backrefs_record};
-use std::collections::HashMap;
+use clvmr::serde::{node_from_bytes, node_from_bytes_backrefs};
 
 pub fn subtract_cost(
     a: &Allocator,
@@ -174,18 +173,18 @@ where
     let mut cost_left = max_cost;
     subtract_cost(a, &mut cost_left, byte_cost)?;
 
-    let (program, backrefs) = node_from_bytes_backrefs_record(a, program)?;
+    let program = node_from_bytes_backrefs(a, program)?;
 
     let args = setup_generator_args(a, block_refs)?;
     let dialect = ChiaDialect::new(flags);
 
-    let Reduction(clvm_cost, mut all_spends) = run_program(a, &dialect, program, args, cost_left)?;
+    let Reduction(clvm_cost, all_spends) = run_program(a, &dialect, program, args, cost_left)?;
 
     subtract_cost(a, &mut cost_left, clvm_cost)?;
 
     let mut ret = SpendBundleConditions::default();
 
-    all_spends = first(a, all_spends)?;
+    let all_spends = first(a, all_spends)?;
     ret.execution_cost += clvm_cost;
 
     // at this point all_spends is a list of:
@@ -193,10 +192,21 @@ where
     // where extra may be nil, or additional extension data
 
     let mut state = ParseState::default();
-    let mut cache = HashMap::<NodePtr, TreeHash>::new();
+    let mut cache = TreeCache::default();
 
-    while let Some((spend, rest)) = a.next(all_spends) {
-        all_spends = rest;
+    // first iterate over all puzzle reveals to find duplicate nodes, to know
+    // what to memoize during tree hash computations. This is managed by
+    // TreeCache
+    let mut iter = all_spends;
+    while let Some((spend, rest)) = a.next(iter) {
+        iter = rest;
+        let [_, puzzle, _, _, _] = extract_n::<5>(a, spend, ErrorCode::InvalidCondition)?;
+        cache.visit_tree(a, puzzle);
+    }
+
+    let mut iter = all_spends;
+    while let Some((spend, rest)) = a.next(iter) {
+        iter = rest;
         // process the spend
         let [parent_id, puzzle, amount, solution, _spend_level_extra] =
             extract_n::<5>(a, spend, ErrorCode::InvalidCondition)?;
@@ -207,7 +217,7 @@ where
         subtract_cost(a, &mut cost_left, clvm_cost)?;
         ret.execution_cost += clvm_cost;
 
-        let buf = tree_hash_cached(a, puzzle, &backrefs, &mut cache);
+        let buf = tree_hash_cached(a, puzzle, &mut cache);
         let puzzle_hash = a.new_atom(&buf)?;
 
         process_single_spend::<EmptyVisitor>(
@@ -223,8 +233,8 @@ where
             constants,
         )?;
     }
-    if a.atom_len(all_spends) != 0 {
-        return Err(ValidationErr(all_spends, ErrorCode::GeneratorRuntimeError));
+    if a.atom_len(iter) != 0 {
+        return Err(ValidationErr(iter, ErrorCode::GeneratorRuntimeError));
     }
 
     validate_conditions(a, &ret, &state, a.nil(), flags)?;

--- a/crates/clvm-utils/fuzz/fuzz_targets/tree-hash.rs
+++ b/crates/clvm-utils/fuzz/fuzz_targets/tree-hash.rs
@@ -2,27 +2,25 @@
 use libfuzzer_sys::fuzz_target;
 
 use chia_fuzz::{make_tree, BitCursor};
-use clvm_utils::{tree_hash, tree_hash_cached, TreeHash};
+use clvm_utils::{tree_hash, tree_hash_cached, TreeCache};
 use clvmr::{Allocator, NodePtr};
-use std::collections::{HashMap, HashSet};
 
-use clvmr::serde::{node_from_bytes_backrefs_record, node_to_bytes_backrefs};
+use clvmr::serde::{node_from_bytes_backrefs, node_to_bytes_backrefs};
 
-fn test_hash(a: &Allocator, node: NodePtr, backrefs: &HashSet<NodePtr>) {
+fn test_hash(a: &Allocator, node: NodePtr) {
     let hash1 = tree_hash(a, node);
 
-    let mut cache = HashMap::<NodePtr, TreeHash>::new();
-    let hash2 = tree_hash_cached(a, node, backrefs, &mut cache);
+    let mut cache = TreeCache::default();
+    let hash2 = tree_hash_cached(a, node, &mut cache);
     assert_eq!(hash1, hash2);
 }
 
 fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();
     let input = make_tree(&mut a, &mut BitCursor::new(data), false);
-    test_hash(&a, input, &HashSet::new());
+    test_hash(&a, input);
 
     let bytes = node_to_bytes_backrefs(&a, input).expect("node_to_bytes_backrefs");
-    let (input, backrefs) =
-        node_from_bytes_backrefs_record(&mut a, &bytes).expect("node_from_bytes_backrefs_record");
-    test_hash(&a, input, &backrefs);
+    let input = node_from_bytes_backrefs(&mut a, &bytes).expect("node_from_bytes_backrefs");
+    test_hash(&a, input);
 });

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -61,7 +61,6 @@ use pyo3::types::PyBytes;
 use pyo3::types::PyList;
 use pyo3::types::PyTuple;
 use pyo3::wrap_pyfunction;
-use std::collections::HashSet;
 use std::iter::zip;
 
 use crate::run_program::{run_chia_program, serialized_length};
@@ -75,9 +74,7 @@ use clvmr::reduction::EvalErr;
 use clvmr::reduction::Reduction;
 use clvmr::run_program;
 use clvmr::serde::is_canonical_serialization;
-use clvmr::serde::{
-    node_from_bytes, node_from_bytes_backrefs, node_from_bytes_backrefs_record, node_to_bytes,
-};
+use clvmr::serde::{node_from_bytes, node_from_bytes_backrefs, node_to_bytes};
 use clvmr::ChiaDialect;
 
 use chia_bls::{
@@ -155,7 +152,6 @@ pub fn get_puzzle_and_solution_for_coin<'a>(
             match parse_puzzle_solution(
                 &allocator,
                 result,
-                &HashSet::new(),
                 &Coin::new(find_parent, find_ph, find_amount),
             ) {
                 Err(ValidationErr(n, _)) => Err(EvalErr(n, "coin not found".to_string())),
@@ -198,8 +194,7 @@ pub fn get_puzzle_and_solution_for_coin2<'a>(
         py_to_slice::<'a>(buf)
     });
 
-    let (generator, backrefs) =
-        node_from_bytes_backrefs_record(&mut allocator, generator.as_ref())?;
+    let generator = node_from_bytes_backrefs(&mut allocator, generator.as_ref())?;
     let args = setup_generator_args(&mut allocator, refs)?;
     let dialect = &ChiaDialect::new(flags);
 
@@ -207,7 +202,7 @@ pub fn get_puzzle_and_solution_for_coin2<'a>(
         .allow_threads(|| -> Result<(NodePtr, NodePtr), EvalErr> {
             let Reduction(_cost, result) =
                 run_program(&mut allocator, dialect, generator, args, max_cost)?;
-            match parse_puzzle_solution(&allocator, result, &backrefs, find_coin) {
+            match parse_puzzle_solution(&allocator, result, find_coin) {
                 Err(ValidationErr(n, _)) => Err(EvalErr(n, "coin not found".to_string())),
                 Ok(pair) => Ok(pair),
             }


### PR DESCRIPTION
run an extra pass over puzzle reveals count references. Use these counters for memoizing tree hash instead.