### PR TITLE
make `additions_and_removals()` also return the coin-id of spends

### DIFF
--- a/crates/chia-consensus/benches/run-generator.rs
+++ b/crates/chia-consensus/benches/run-generator.rs
@@ -77,7 +77,7 @@ fn run(c: &mut Criterion) {
                         gen,
                         &block_refs,
                         11_000_000_000,
-                        0,
+                        DONT_VALIDATE_SIGNATURE,
                         &Signature::default(),
                         None,
                         &TEST_CONSTANTS,

--- a/crates/chia-consensus/fuzz/fuzz_targets/additions-and-removals.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/additions-and-removals.rs
@@ -77,6 +77,6 @@ fuzz_target!(|data: &[u8]| {
     }
 
     for r in &removals {
-        assert!(expect_removals.contains(r));
+        assert!(expect_removals.contains(&r.0));
     }
 });

--- a/tests/test_additions_and_removals.py
+++ b/tests/test_additions_and_removals.py
@@ -77,9 +77,10 @@ def test_additions_and_removals() -> None:
                 assert addition in expected_additions
                 expected_additions.remove(addition)
 
-            for rem in removals:
+            for rem, coin_id in removals:
                 removal = (f"{rem.name().hex()}", f"{rem.puzzle_hash.hex()}")
                 assert removal in expected_removals
+                assert rem.name() == coin_id
                 expected_removals.remove(removal)
             assert expected_additions == set()
             assert expected_removals == set()

--- a/tests/test_additions_and_removals.py
+++ b/tests/test_additions_and_removals.py
@@ -78,7 +78,7 @@ def test_additions_and_removals() -> None:
                 expected_additions.remove(addition)
 
             for rem, coin_id in removals:
-                removal = (f"{rem.name().hex()}", f"{rem.puzzle_hash.hex()}")
+                removal = (f"{coin_id.hex()}", f"{rem.puzzle_hash.hex()}")
                 assert removal in expected_removals
                 assert rem.name() == coin_id
                 expected_removals.remove(removal)

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -306,7 +306,7 @@ def run_block_generator2(
 
 def additions_and_removals(
     program: ReadableBuffer, block_refs: list[ReadableBuffer], flags: int, constants: ConsensusConstants
-) -> tuple[list[tuple[Coin, Optional[bytes]]], list[Coin]]: ...
+) -> tuple[list[tuple[Coin, Optional[bytes]]], list[tuple[Coin, bytes32]]]: ...
 
 def confirm_included_already_hashed(
     root: bytes32,

--- a/wheel/python/chia_rs/chia_rs.pyi
+++ b/wheel/python/chia_rs/chia_rs.pyi
@@ -33,7 +33,7 @@ def run_block_generator2(
 
 def additions_and_removals(
     program: ReadableBuffer, block_refs: list[ReadableBuffer], flags: int, constants: ConsensusConstants
-) -> tuple[list[tuple[Coin, Optional[bytes]]], list[Coin]]: ...
+) -> tuple[list[tuple[Coin, Optional[bytes]]], list[tuple[Coin, bytes32]]]: ...
 
 def confirm_included_already_hashed(
     root: bytes32,

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -6,8 +6,7 @@ use chia_consensus::owned_conditions::OwnedSpendBundleConditions;
 use chia_consensus::run_block_generator::run_block_generator as native_run_block_generator;
 use chia_consensus::run_block_generator::run_block_generator2 as native_run_block_generator2;
 use chia_consensus::validation_error::ValidationErr;
-use chia_protocol::Bytes;
-use chia_protocol::Coin;
+use chia_protocol::{Bytes, Bytes32, Coin};
 
 use clvmr::cost::Cost;
 
@@ -134,7 +133,7 @@ pub fn additions_and_removals<'a>(
     block_refs: &Bound<'_, PyList>,
     flags: u32,
     constants: &ConsensusConstants,
-) -> PyResult<(Vec<(Coin, Option<Bytes>)>, Vec<Coin>)> {
+) -> PyResult<(Vec<(Coin, Option<Bytes>)>, Vec<(Coin, Bytes32)>)> {
     let refs = block_refs
         .into_iter()
         .map(|b| {


### PR DESCRIPTION
We need the coin ID of the coin we're spending, and currently we comput it twice. Once in this function and once in the caller (on the python side). This saves one coin ID calculation per spend.

Also fix the benchmark for `run_block_generator2()` to not validate signatures. That's not what we're interested in benchmarking there.