### PR TITLE
flip the order of pre-computed coin ID and the Coin

### DIFF
--- a/crates/chia-consensus/fuzz/fuzz_targets/additions-and-removals.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/additions-and-removals.rs
@@ -77,6 +77,6 @@ fuzz_target!(|data: &[u8]| {
     }
 
     for r in &removals {
-        assert!(expect_removals.contains(&r.0));
+        assert!(expect_removals.contains(&r.1));
     }
 });

--- a/crates/chia-consensus/src/additions_and_removals.rs
+++ b/crates/chia-consensus/src/additions_and_removals.rs
@@ -24,13 +24,13 @@ pub fn additions_and_removals<GenBuf: AsRef<[u8]>, I: IntoIterator<Item = GenBuf
     block_refs: I,
     flags: u32,
     constants: &ConsensusConstants,
-) -> Result<(Vec<(Coin, Option<Bytes>)>, Vec<(Coin, Bytes32)>), ValidationErr>
+) -> Result<(Vec<(Coin, Option<Bytes>)>, Vec<(Bytes32, Coin)>), ValidationErr>
 where
     <I as IntoIterator>::IntoIter: DoubleEndedIterator,
 {
     let mut a = make_allocator(flags);
     let mut additions = Vec::<(Coin, Option<Bytes>)>::new();
-    let mut removals = Vec::<(Coin, Bytes32)>::new();
+    let mut removals = Vec::<(Bytes32, Coin)>::new();
 
     let mut cost_left = constants.max_block_cost_clvm;
 
@@ -83,7 +83,7 @@ where
         };
 
         let spend_id = coin.coin_id();
-        removals.push((coin, spend_id));
+        removals.push((spend_id, coin));
 
         while let Some((mut c, next)) = next(&a, iter)? {
             iter = next;
@@ -240,7 +240,7 @@ mod test {
         }
 
         for r in &removals {
-            assert!(expect_removals.contains(&r.0));
+            assert!(expect_removals.contains(&r.1));
         }
     }
 }

--- a/tests/test_additions_and_removals.py
+++ b/tests/test_additions_and_removals.py
@@ -77,7 +77,7 @@ def test_additions_and_removals() -> None:
                 assert addition in expected_additions
                 expected_additions.remove(addition)
 
-            for rem, coin_id in removals:
+            for coin_id, rem in removals:
                 removal = (f"{coin_id.hex()}", f"{rem.puzzle_hash.hex()}")
                 assert removal in expected_removals
                 assert rem.name() == coin_id

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -306,7 +306,7 @@ def run_block_generator2(
 
 def additions_and_removals(
     program: ReadableBuffer, block_refs: list[ReadableBuffer], flags: int, constants: ConsensusConstants
-) -> tuple[list[tuple[Coin, Optional[bytes]]], list[tuple[Coin, bytes32]]]: ...
+) -> tuple[list[tuple[Coin, Optional[bytes]]], list[tuple[bytes32, Coin]]]: ...
 
 def confirm_included_already_hashed(
     root: bytes32,

--- a/wheel/python/chia_rs/chia_rs.pyi
+++ b/wheel/python/chia_rs/chia_rs.pyi
@@ -33,7 +33,7 @@ def run_block_generator2(
 
 def additions_and_removals(
     program: ReadableBuffer, block_refs: list[ReadableBuffer], flags: int, constants: ConsensusConstants
-) -> tuple[list[tuple[Coin, Optional[bytes]]], list[tuple[Coin, bytes32]]]: ...
+) -> tuple[list[tuple[Coin, Optional[bytes]]], list[tuple[bytes32, Coin]]]: ...
 
 def confirm_included_already_hashed(
     root: bytes32,

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -133,7 +133,7 @@ pub fn additions_and_removals<'a>(
     block_refs: &Bound<'_, PyList>,
     flags: u32,
     constants: &ConsensusConstants,
-) -> PyResult<(Vec<(Coin, Option<Bytes>)>, Vec<(Coin, Bytes32)>)> {
+) -> PyResult<(Vec<(Coin, Option<Bytes>)>, Vec<(Bytes32, Coin)>)> {
     let refs = block_refs
         .into_iter()
         .map(|b| {


### PR DESCRIPTION
in `additions_and_removals()` return value. This matches what you would get from `dict.items()` with the key first