### PR TITLE
enable allocator-debug in unit tests on CI

### DIFF
--- a/.github/workflows/build-crate.yml
+++ b/.github/workflows/build-crate.yml
@@ -42,7 +42,7 @@ jobs:
         run: cargo test --workspace --all-features
 
       - name: Tests (release)
-        run: cargo test --workspace --all-features --release
+        run: cargo test --workspace --all-features --release --features=clvmr/allocator-debug
 
       - name: Build (release)
         run: cargo build --workspace --all-features --release

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -341,7 +341,7 @@ jobs:
           python -m venv venv
           . venv/bin/activate
           pip install colorama maturin pytest pytest-xdist blspy clvm==0.9.8
-          maturin develop --release -m wheel/Cargo.toml
+          maturin develop --release -m wheel/Cargo.toml --features=clvmr/allocator-debug
           # run pytest in a single process to avoid a race writing the coverage report
           pytest -n 0 tests
           sudo apt-get update

--- a/crates/chia-consensus/src/build_compressed_block.rs
+++ b/crates/chia-consensus/src/build_compressed_block.rs
@@ -259,7 +259,7 @@ impl BlockBuilder {
 }
 
 // this test is expensive and takes forever in debug builds
-//#[cfg(not(debug_assertions))]
+#[cfg(not(debug_assertions))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/chia-consensus/src/test_generators.rs
+++ b/crates/chia-consensus/src/test_generators.rs
@@ -160,7 +160,9 @@ pub(crate) fn print_diff(output: &str, expected: &str) {
 }
 
 #[rstest]
-#[case("aa-million-messages")]
+// in CI we run with the clvmr/debug-allocator feature enabled, which makes this
+// test use too much RAM (about 6.8 GB)
+//#[case("aa-million-messages")]
 #[case("new-agg-sigs")]
 #[case("infinity-g1")]
 #[case("block-1ee588dc")]


### PR DESCRIPTION
This will prevent `Allocator` related bugs going forward, at least if they're covered by a test.