### PR TITLE
Remove extract_n() from external uses

### DIFF
--- a/crates/chia-consensus/src/run_block_generator.rs
+++ b/crates/chia-consensus/src/run_block_generator.rs
@@ -131,7 +131,7 @@ where
     Ok(result)
 }
 
-pub fn extract_n<const N: usize>(
+fn extract_n<const N: usize>(
     a: &Allocator,
     mut n: NodePtr,
     e: ErrorCode,

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -216,12 +216,12 @@ mod tests {
     #[cfg(not(debug_assertions))]
     fn convert_block_to_bundle(generator: &[u8], block_refs: &[Vec<u8>]) -> SpendBundle {
         use crate::run_block_generator::setup_generator_args;
-        use chia_protocol::Coin;
-        use clvmr::op_utils::first;
-        use clvmr::serde::node_from_bytes_backrefs;
         use chia_protocol::BytesImpl;
+        use chia_protocol::Coin;
         use chia_protocol::Program;
         use clvm_traits::{destructure_list, match_list, FromClvm};
+        use clvmr::op_utils::first;
+        use clvmr::serde::node_from_bytes_backrefs;
 
         let mut a = make_allocator(MEMPOOL_MODE);
 
@@ -244,15 +244,18 @@ mod tests {
             // let [parent_id, puzzle, amount, solution, _spend_level_extra] =
             //     extract_n::<5>(&a, spend, ErrorCode::InvalidCondition).expect("extract_n");
             let destructure_list!(parent_id, puzzle, amount, solution, _spend_level_extra) =
-                <match_list!(BytesImpl<32>, Program, u64, Program, Program)>::from_clvm(&a, spend).expect("parsing CLVM");
+                <match_list!(BytesImpl<32>, Program, u64, Program, Program)>::from_clvm(&a, spend)
+                    .expect("parsing CLVM");
             spends.push(CoinSpend::new(
                 Coin::new(
                     parent_id.try_into().expect("parent_id"),
-                     clvm_utils::tree_hash_from_bytes(puzzle.as_ref()).expect("hash").into(),
+                    clvm_utils::tree_hash_from_bytes(puzzle.as_ref())
+                        .expect("hash")
+                        .into(),
                     amount,
                 ),
                 puzzle,
-                solution
+                solution,
             ));
         }
         SpendBundle::new(spends, Signature::default())

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -244,7 +244,7 @@ mod tests {
             all_spends = rest;
             // process the spend
             let destructure_tuple!(parent_id, puzzle, amount, solution, _) =
-                <match_tuple!(BytesImpl<32>, Program, u64, Program, NodePtr)>::from_clvm(&a, spend)
+                <match_tuple!(Bytes32, Program, u64, Program, NodePtr)>::from_clvm(&a, spend)
                     .expect("parsing CLVM");
             spends.push(CoinSpend::new(
                 Coin::new(

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -216,7 +216,7 @@ mod tests {
     #[cfg(not(debug_assertions))]
     fn convert_block_to_bundle(generator: &[u8], block_refs: &[Vec<u8>]) -> SpendBundle {
         use crate::run_block_generator::setup_generator_args;
-        use chia_protocol::BytesImpl;
+        use chia_protocol::Bytes32;
         use chia_protocol::Coin;
         use chia_protocol::Program;
         use clvm_traits::{destructure_tuple, match_tuple, FromClvm};

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -220,6 +220,7 @@ mod tests {
         use chia_protocol::Coin;
         use chia_protocol::Program;
         use clvm_traits::{destructure_list, match_list, FromClvm};
+        use clvm_utils::tree_hash_from_bytes;
         use clvmr::op_utils::first;
         use clvmr::serde::node_from_bytes_backrefs;
 
@@ -247,9 +248,7 @@ mod tests {
             spends.push(CoinSpend::new(
                 Coin::new(
                     parent_id.try_into().expect("parent_id"),
-                    clvm_utils::tree_hash_from_bytes(puzzle.as_ref())
-                        .expect("hash")
-                        .into(),
+                    tree_hash_from_bytes(puzzle.as_ref()).expect("hash").into(),
                     amount,
                 ),
                 puzzle,

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -241,8 +241,8 @@ mod tests {
         while let Some((spend, rest)) = a.next(all_spends) {
             all_spends = rest;
             // process the spend
-            let destructure_list!(parent_id, puzzle, amount, solution, _spend_level_extra) =
-                <match_list!(BytesImpl<32>, Program, u64, Program, Program)>::from_clvm(&a, spend)
+            let destructure_list!(parent_id, puzzle, amount, solution) =
+                <match_list!(BytesImpl<32>, Program, u64, Program)>::from_clvm(&a, spend)
                     .expect("parsing CLVM");
             spends.push(CoinSpend::new(
                 Coin::new(

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -223,6 +223,7 @@ mod tests {
         use clvm_utils::tree_hash_from_bytes;
         use clvmr::op_utils::first;
         use clvmr::serde::node_from_bytes_backrefs;
+        use clvmr::NodePtr;
 
         let mut a = make_allocator(MEMPOOL_MODE);
 

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -241,8 +241,6 @@ mod tests {
         while let Some((spend, rest)) = a.next(all_spends) {
             all_spends = rest;
             // process the spend
-            // let [parent_id, puzzle, amount, solution, _spend_level_extra] =
-            //     extract_n::<5>(&a, spend, ErrorCode::InvalidCondition).expect("extract_n");
             let destructure_list!(parent_id, puzzle, amount, solution, _spend_level_extra) =
                 <match_list!(BytesImpl<32>, Program, u64, Program, Program)>::from_clvm(&a, spend)
                     .expect("parsing CLVM");

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -219,7 +219,7 @@ mod tests {
         use chia_protocol::BytesImpl;
         use chia_protocol::Coin;
         use chia_protocol::Program;
-        use clvm_traits::{destructure_list, match_list, FromClvm};
+        use clvm_traits::{destructure_tuple, match_tuple, FromClvm};
         use clvm_utils::tree_hash_from_bytes;
         use clvmr::op_utils::first;
         use clvmr::serde::node_from_bytes_backrefs;
@@ -242,9 +242,8 @@ mod tests {
         while let Some((spend, rest)) = a.next(all_spends) {
             all_spends = rest;
             // process the spend
-            let destructure_list!(parent_id, puzzle, amount, solution) =
-                <match_list!(BytesImpl<32>, Program, u64, Program)>::from_clvm(&a, spend)
-                    .expect("parsing CLVM");
+            let destructure_tuple!(parent_id, puzzle, amount, solution, _) =
+                match_tuple!(BytesImpl<32>, Program, u64, Program, NodePtr).expect("parsing CLVM");
             spends.push(CoinSpend::new(
                 Coin::new(
                     parent_id.try_into().expect("parent_id"),

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -243,7 +243,8 @@ mod tests {
             all_spends = rest;
             // process the spend
             let destructure_tuple!(parent_id, puzzle, amount, solution, _) =
-                match_tuple!(BytesImpl<32>, Program, u64, Program, NodePtr).expect("parsing CLVM");
+                <match_tuple!(BytesImpl<32>, Program, u64, Program, NodePtr)>::from_clvm(&a, spend)
+                    .expect("parsing CLVM");
             spends.push(CoinSpend::new(
                 Coin::new(
                     parent_id.try_into().expect("parent_id"),

--- a/crates/chia-tools/src/visit_spends.rs
+++ b/crates/chia-tools/src/visit_spends.rs
@@ -126,8 +126,6 @@ pub fn visit_spends<
     while let Some((spend, rest)) = a.next(all_spends) {
         all_spends = rest;
         // process the spend
-        // let [parent_id, puzzle, amount, solution, _spend_level_extra] =
-        //     extract_n::<5>(a, spend, ErrorCode::InvalidCondition)?;
         let destructure_list!(parent_id, puzzle, amount, solution, _spend_level_extra) =
             <match_list!(Bytes32, NodePtr, u64, NodePtr, NodePtr)>::from_clvm(a, spend)
                 .map_err(|_| ValidationErr(spend, ErrorCode::InvalidCondition))?;

--- a/crates/chia-tools/src/visit_spends.rs
+++ b/crates/chia-tools/src/visit_spends.rs
@@ -1,7 +1,7 @@
 use chia_consensus::generator_rom::CLVM_DESERIALIZER;
 use chia_consensus::validation_error::{first, ErrorCode, ValidationErr};
 use chia_protocol::FullBlock;
-use chia_protocol::{Bytes32, Program};
+use chia_protocol::Bytes32;
 use chia_traits::streamable::Streamable;
 use clvm_traits::{destructure_list, match_list, FromClvm};
 use clvmr::allocator::NodePtr;
@@ -129,7 +129,7 @@ pub fn visit_spends<
         // let [parent_id, puzzle, amount, solution, _spend_level_extra] =
         //     extract_n::<5>(a, spend, ErrorCode::InvalidCondition)?;
         let destructure_list!(parent_id, puzzle, amount, solution, _spend_level_extra) =
-            <match_list!(Bytes32, NodePtr, u64, NodePtr, NodePtr)>::from_clvm(&a, spend)
+            <match_list!(Bytes32, NodePtr, u64, NodePtr, NodePtr)>::from_clvm(a, spend)
                 .map_err(|_| ValidationErr(spend, ErrorCode::InvalidCondition))?;
         callback(a, parent_id, amount, puzzle, solution);
     }

--- a/crates/chia-tools/src/visit_spends.rs
+++ b/crates/chia-tools/src/visit_spends.rs
@@ -1,7 +1,7 @@
 use chia_consensus::generator_rom::CLVM_DESERIALIZER;
 use chia_consensus::validation_error::{first, ErrorCode, ValidationErr};
-use chia_protocol::FullBlock;
 use chia_protocol::Bytes32;
+use chia_protocol::FullBlock;
 use chia_traits::streamable::Streamable;
 use clvm_traits::{destructure_list, match_list, FromClvm};
 use clvmr::allocator::NodePtr;


### PR DESCRIPTION
This PR identifies and removes the two places that use `extract_n()` outside of `run_block_generators()` and removes them in favour of `match_list!` and `destructure_list!`.

It also changes `extract_n` to be a private function to prevent people from using it again.