### PR TITLE
fix `test_get_puzzle_and_solution()`

### DIFF
--- a/crates/chia-consensus/src/get_puzzle_and_solution.rs
+++ b/crates/chia-consensus/src/get_puzzle_and_solution.rs
@@ -241,12 +241,10 @@ mod test {
         )
         .expect("run_block_generator2");
 
-        let mut a2 = Allocator::new();
-        let generator_node =
-            node_from_bytes_backrefs(&mut a2, &generator).expect("node_from_bytes_backrefs");
-        let checkpoint = a2.checkpoint();
         for s in &conds.spends {
-            a2.restore_checkpoint(&checkpoint);
+            let mut a2 = Allocator::new();
+            let generator_node =
+                node_from_bytes_backrefs(&mut a2, &generator).expect("node_from_bytes_backrefs");
             let mut expected_additions: HashSet<(Bytes32, u64)> = s
                 .create_coin
                 .iter()


### PR DESCRIPTION
don't reuse the same allocator, as the debug-allocator feature has a limit on the number of times you can restore to a previous checkpoint.

Fixes this issue: https://github.com/Chia-Network/chia_rs/actions/runs/16680635805/job/47218189564#step:9:2763
```
---- get_puzzle_and_solution::test::test_get_puzzle_and_solution::case_02 stdout ----
file: ../../generator-tests/block-6fe59b24.txt

thread 'get_puzzle_and_solution::test::test_get_puzzle_and_solution::case_02' panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clvmr-0.16.1/src/allocator.rs:383:9:
assertion failed: self.versions.len() <= 255
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```