### PR TITLE
release the GIL when calling get_coinspends_with_conditions

### DIFF
--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -550,7 +550,8 @@ pub fn get_spends_for_trusted_block<'a>(
         })
         .collect::<Vec<&'a [u8]>>();
 
-    let output = get_coinspends_for_trusted_block(constants, &generator, &refs, flags)?;
+    let output =
+        py.allow_threads(|| get_coinspends_for_trusted_block(constants, &generator, &refs, flags))?;
 
     let dict = PyDict::new(py);
     dict.set_item("block_spends", output)?;
@@ -575,8 +576,9 @@ pub fn get_spends_for_trusted_block_with_conditions<'a>(
         })
         .collect::<Vec<&'a [u8]>>();
 
-    let output =
-        get_coinspends_with_conditions_for_trusted_block(constants, &generator, &refs, flags)?;
+    let output = py.allow_threads(|| {
+        get_coinspends_with_conditions_for_trusted_block(constants, &generator, &refs, flags)
+    })?;
 
     let pylist = PyList::empty(py);
     for (coinspend, cond_output) in output {


### PR DESCRIPTION
This seems to have been an oversight. We would like to make these calls from a python thread pool.