### PR TITLE
parallelize `analyze-chain`

### DIFF
--- a/crates/chia-tools/graph.gnuplot
+++ b/crates/chia-tools/graph.gnuplot
@@ -29,11 +29,6 @@ plot "chain-resource-usage.dat" using 1:7 with dots title "block generator"
 #"chain-resource-usage.dat" using 1:12 with dots title "block reference lookup", \
 #"chain-resource-usage.dat" using 1:14 with dots title "conditions`
 
-set output "block-wall-clock-delta.png"
-set title "transaction block timestamp delta"
-set xlabel "s"
-plot "chain-resource-usage.dat" using 1:9 with dots title "block timestamp delta", \
-
 set output "block-cost-vs-time.png"
 set title "block execution time versus cost"
 set xlabel "cost (millions)"
@@ -89,15 +84,3 @@ plot "chain-resource-usage-cdf.dat" using 7:1 with lines title "block generator"
 #plot "chain-resource-usage-cdf.dat" using 11:1 with lines title "block decompress + parse", \
 #"chain-resource-usage-cdf.dat" using 12:1 with lines title "block reference lookup", \
 #"chain-resource-usage-cdf.dat" using 14:1 with lines title "conditions"
-
-set output "block-wall-clock-delta-cdf.png"
-set title "transaction block timestamp delta"
-set xrange [0:200]
-set xlabel "s"
-
-plot "chain-resource-usage-cdf.dat" using 9:1 with lines title "block time delta (wall-clock)"
-
-set output "block-wall-clock-delta-cdf-zoom.png"
-set xrange [0:60]
-
-replot

--- a/crates/chia-tools/parse-analyze-chain.py
+++ b/crates/chia-tools/parse-analyze-chain.py
@@ -8,7 +8,6 @@ keys = ["atoms:",
      "block_cost:",
      "execute_time:",
      "timestamp:",
-     "time_delta:",
 ]
 
 def to_int(value: str) -> int:

--- a/crates/chia-tools/src/bin/analyze-chain.rs
+++ b/crates/chia-tools/src/bin/analyze-chain.rs
@@ -6,7 +6,7 @@ use std::thread::available_parallelism;
 use std::time::Instant;
 
 use chia_consensus::consensus_constants::TEST_CONSTANTS;
-use chia_consensus::flags::MEMPOOL_MODE;
+use chia_consensus::flags::{DONT_VALIDATE_SIGNATURE, MEMPOOL_MODE};
 use chia_consensus::run_block_generator::{run_block_generator, run_block_generator2};
 use chia_tools::iterate_blocks;
 use clvmr::Allocator;
@@ -39,7 +39,7 @@ struct Args {
 fn main() {
     let args = Args::parse();
 
-    let flags = if args.mempool_mode { MEMPOOL_MODE } else { 0 };
+    let flags = if args.mempool_mode { MEMPOOL_MODE } else { 0 } | DONT_VALIDATE_SIGNATURE;
 
     let num_cores = args
         .num_jobs
@@ -47,7 +47,7 @@ fn main() {
 
     let pool = blocking_threadpool::Builder::new()
         .num_threads(num_cores)
-        .queue_len(num_cores + 5)
+        .queue_len(num_cores * 2)
         .build();
 
     let output = Arc::new(Mutex::new(

--- a/crates/chia-tools/src/bin/analyze-chain.rs
+++ b/crates/chia-tools/src/bin/analyze-chain.rs
@@ -1,7 +1,9 @@
 use clap::Parser;
 
-use std::io::Write;
-use std::time::SystemTime;
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+use std::thread::available_parallelism;
+use std::time::Instant;
 
 use chia_consensus::consensus_constants::TEST_CONSTANTS;
 use chia_consensus::flags::MEMPOOL_MODE;
@@ -21,6 +23,10 @@ struct Args {
     #[arg(short, long, default_value_t = false)]
     mempool_mode: bool,
 
+    /// The number of parallell thread to run block generators in
+    #[arg(short = 'j', long)]
+    num_jobs: Option<usize>,
+
     /// Start at this block height
     #[arg(short, long, default_value_t = 225694)]
     start: u32,
@@ -35,87 +41,99 @@ fn main() {
 
     let flags = if args.mempool_mode { MEMPOOL_MODE } else { 0 };
 
-    let mut output =
-        std::fs::File::create("chain-resource-usage.log").expect("failed to open output file");
+    let num_cores = args
+        .num_jobs
+        .unwrap_or_else(|| available_parallelism().unwrap().into());
 
-    // We only create a single allocator and keep reusing it
-    let mut a = Allocator::new_limited(500_000_000);
-    let allocator_checkpoint = a.checkpoint();
-    let mut prev_timestamp = 0;
+    let pool = blocking_threadpool::Builder::new()
+        .num_threads(num_cores)
+        .queue_len(num_cores + 5)
+        .build();
+
+    let output = Arc::new(Mutex::new(
+        std::fs::File::create("chain-resource-usage.log").expect("failed to open output file"),
+    ));
+
+    let mut start_time = Instant::now();
+
     iterate_blocks(
         &args.file,
         args.start,
         Some(args.end),
         |height, block, block_refs| {
+            if start_time.elapsed().as_secs() > 5 {
+                start_time = Instant::now();
+                print!("  {height}\r");
+                io::stdout().flush().unwrap();
+            }
             if block.transactions_generator.is_none() {
                 return;
             }
-            // after the hard fork, we run blocks without paying for the
-            // CLVM generator ROM
-            let block_runner = if height >= 5_496_000 {
-                run_block_generator2
-            } else {
-                run_block_generator
-            };
+            let output = output.clone();
+            pool.execute(move || {
+                // after the hard fork, we run blocks without paying for the
+                // CLVM generator ROM
+                let block_runner = if height >= 5_496_000 {
+                    run_block_generator2
+                } else {
+                    run_block_generator
+                };
 
-            let generator = block
-                .transactions_generator
-                .as_ref()
-                .expect("transactions_generator");
+                let generator = block
+                    .transactions_generator
+                    .as_ref()
+                    .expect("transactions_generator");
 
-            let ti = block.transactions_info.as_ref().expect("transactions_info");
+                let ti = block.transactions_info.as_ref().expect("transactions_info");
 
-            let ftb = block
-                .foliage_transaction_block
-                .expect("foliage_transaction_block");
+                let ftb = block
+                    .foliage_transaction_block
+                    .expect("foliage_transaction_block");
 
-            if prev_timestamp == 0 {
-                prev_timestamp = ftb.timestamp;
-            }
-            let time_delta = ftb.timestamp - prev_timestamp;
-            prev_timestamp = ftb.timestamp;
+                let mut a = Allocator::new_limited(500_000_000);
 
-            a.restore_checkpoint(&allocator_checkpoint);
-
-            let start_run_block = SystemTime::now();
-            let conditions = block_runner(
-                &mut a,
-                generator,
-                &block_refs,
-                ti.cost,
-                flags,
-                &ti.aggregated_signature,
-                None,
-                &TEST_CONSTANTS,
-            )
-            .expect("failed to run block generator");
-
-            let execute_timing = start_run_block
-                .elapsed()
-                .expect("failed to get system time");
-
-            assert_eq!(conditions.cost, ti.cost);
-            output
-                .write_fmt(format_args!(
-                    "{height} \
-                atoms: {} \
-                small_atoms: {} \
-                pairs: {} \
-                heap: {} \
-                block_cost: {} \
-                execute_time: {} \
-                timestamp: {} \
-                time_delta: {time_delta} \
-                \n",
-                    a.atom_count(),
-                    a.small_atom_count(),
-                    a.pair_count(),
-                    a.heap_size(),
+                let start_run_block = Instant::now();
+                let conditions = block_runner(
+                    &mut a,
+                    generator,
+                    &block_refs,
                     ti.cost,
-                    execute_timing.as_micros(),
-                    ftb.timestamp,
-                ))
-                .expect("failed to write to output file");
+                    flags,
+                    &ti.aggregated_signature,
+                    None,
+                    &TEST_CONSTANTS,
+                )
+                .expect("failed to run block generator");
+
+                let execute_timing = start_run_block.elapsed();
+
+                assert_eq!(conditions.cost, ti.cost);
+                output
+                    .lock()
+                    .unwrap()
+                    .write_fmt(format_args!(
+                        "{height} \
+                    atoms: {} \
+                    small_atoms: {} \
+                    pairs: {} \
+                    heap: {} \
+                    block_cost: {} \
+                    execute_time: {} \
+                    timestamp: {} \
+                    \n",
+                        a.atom_count(),
+                        a.small_atom_count(),
+                        a.pair_count(),
+                        a.heap_size(),
+                        ti.cost,
+                        execute_timing.as_micros(),
+                        ftb.timestamp,
+                    ))
+                    .expect("failed to write to output file");
+            });
         },
     );
+
+    pool.join();
+    assert_eq!(pool.panic_count(), 0);
 }

--- a/crates/chia-tools/src/bin/analyze-chain.rs
+++ b/crates/chia-tools/src/bin/analyze-chain.rs
@@ -73,7 +73,7 @@ fn main() {
             pool.execute(move || {
                 // after the hard fork, we run blocks without paying for the
                 // CLVM generator ROM
-                let block_runner = if height >= 5_496_000 {
+                let block_runner = if height >= TEST_CONSTANTS.hard_fork_height {
                     run_block_generator2
                 } else {
                     run_block_generator


### PR DESCRIPTION
The indentation level is changed for a good portion of this patch. It's best viewed ignoring whitespace.

* run block generators in parallel
* don't validate signatures (to speed up analysis)

The log entries are no longer ordered by height, but gnuplot nor the parser cares.