### PR TITLE
[CHIA-3854] Alternative: pure storage cost model (12000/0) for generator identity HF

### DIFF
--- a/crates/chia-consensus/src/flags.rs
+++ b/crates/chia-consensus/src/flags.rs
@@ -49,6 +49,11 @@ bitflags! {
 
         /// Limit the number of spends per block.
         const LIMIT_SPENDS = 0x200_0000;
+
+        /// After the generator-identity hard fork, generators must be validated from
+        /// the INTERNED (canonical) tree so atom/pair limits and cost apply to the same
+        /// structure independent of serialization.
+        const INTERNED_GENERATOR = 0x0800_0000;
     }
 }
 

--- a/crates/chia-consensus/src/generator_cost.rs
+++ b/crates/chia-consensus/src/generator_cost.rs
@@ -1,0 +1,71 @@
+//! Chia-specific generator cost calculation.
+//!
+//! Pure storage model: cost = (atom_bytes + 2*atoms + 3*pairs) * COST_PER_BYTE.
+//! SHA tree-hash cost is not charged separately — it is structurally bounded
+//! by the size component (worst-case ratio <= 3.33, ~37ms SHA CPU on a 2012
+//! Celeron). See PR #1371 for the alternative split model (6000/4500).
+
+use clvmr::serde::InternedTree;
+
+const COST_PER_BYTE: u64 = 12000;
+
+/// Compute total generator cost from an interned tree.
+///
+/// The size formula `atom_bytes + 2*atom_count + 3*pair_count` is proven to
+/// be an upper bound on the serialized byte count (P=3 accounts for pair
+/// opcodes and back-reference overhead).
+#[inline]
+pub fn total_cost_from_tree(tree: &InternedTree) -> u64 {
+    let atom_count = tree.atoms.len() as u64;
+    let pair_count = tree.pairs.len() as u64;
+
+    let mut atom_bytes: u64 = 0;
+    for &atom in &tree.atoms {
+        atom_bytes += tree.allocator.atom_len(atom) as u64;
+    }
+
+    (atom_bytes + 2 * atom_count + 3 * pair_count) * COST_PER_BYTE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clvmr::allocator::Allocator;
+    use clvmr::serde::intern_tree;
+
+    #[test]
+    fn test_empty_atom() {
+        let allocator = Allocator::new();
+        let node = allocator.nil();
+        let tree = intern_tree(&allocator, node).unwrap();
+        assert_eq!(total_cost_from_tree(&tree), 24_000);
+    }
+
+    #[test]
+    fn test_simple_pair() {
+        let mut allocator = Allocator::new();
+        let left = allocator.new_atom(&[1, 2, 3]).unwrap();
+        let right = allocator.new_atom(&[4, 5, 6]).unwrap();
+        let node = allocator.new_pair(left, right).unwrap();
+        let tree = intern_tree(&allocator, node).unwrap();
+        assert_eq!(total_cost_from_tree(&tree), 156_000);
+    }
+
+    #[test]
+    fn test_shared_subtree() {
+        let mut allocator = Allocator::new();
+        let atom = allocator.new_atom(&[42]).unwrap();
+        let node = allocator.new_pair(atom, atom).unwrap();
+        let tree = intern_tree(&allocator, node).unwrap();
+        assert_eq!(total_cost_from_tree(&tree), 72_000);
+    }
+
+    #[test]
+    fn test_intern_cost_only() {
+        let mut allocator = Allocator::new();
+        let atom = allocator.new_atom(&[1, 2, 3, 4, 5]).unwrap();
+        let node = allocator.new_pair(atom, allocator.nil()).unwrap();
+        let tree = intern_tree(&allocator, node).unwrap();
+        assert_eq!(total_cost_from_tree(&tree), 144_000);
+    }
+}

--- a/crates/chia-consensus/src/lib.rs
+++ b/crates/chia-consensus/src/lib.rs
@@ -12,6 +12,7 @@ pub mod consensus_constants;
 pub mod error;
 pub mod fast_forward;
 pub mod flags;
+pub mod generator_cost;
 pub mod get_puzzle_and_solution;
 pub mod make_aggsig_final_message;
 pub mod merkle_set;

--- a/crates/chia-consensus/src/run_block_generator.rs
+++ b/crates/chia-consensus/src/run_block_generator.rs
@@ -6,6 +6,7 @@ use crate::conditions::{
 };
 use crate::consensus_constants::ConsensusConstants;
 use crate::flags::ConsensusFlags;
+use crate::generator_cost::total_cost_from_tree;
 use crate::opcodes::{
     AGG_SIG_AMOUNT, AGG_SIG_ME, AGG_SIG_PARENT, AGG_SIG_PARENT_AMOUNT, AGG_SIG_PARENT_PUZZLE,
     AGG_SIG_PUZZLE, AGG_SIG_PUZZLE_AMOUNT, AGG_SIG_UNSAFE, CREATE_COIN,
@@ -23,7 +24,7 @@ use clvmr::chia_dialect::ChiaDialect;
 use clvmr::cost::Cost;
 use clvmr::reduction::Reduction;
 use clvmr::run_program::run_program;
-use clvmr::serde::{node_from_bytes, node_from_bytes_backrefs};
+use clvmr::serde::{intern_tree_limited, node_from_bytes, node_from_bytes_backrefs, InternedTree};
 
 pub fn subtract_cost(
     a: &Allocator,
@@ -229,13 +230,28 @@ where
     <I as IntoIterator>::IntoIter: DoubleEndedIterator,
 {
     check_generator_quote(program, flags)?;
-    let mut a = make_allocator(flags);
-    let byte_cost = program.len() as u64 * constants.cost_per_byte;
+
+    let (mut a, base_cost, program) = if flags.contains(ConsensusFlags::INTERNED_GENERATOR) {
+        let mut decode_allocator = Allocator::new();
+        let program_node = node_from_bytes_backrefs(&mut decode_allocator, program)?;
+        let interned = intern_tree_limited(&decode_allocator, program_node, u32::MAX as usize)
+            .map_err(|_| ValidationErr(NodePtr::NIL, ErrorCode::GeneratorRuntimeError))?;
+        let cost = total_cost_from_tree(&interned);
+        let InternedTree {
+            allocator, root, ..
+        } = interned;
+        drop(decode_allocator);
+        (allocator, cost, root)
+    } else {
+        let mut a = make_allocator(flags);
+        let byte_cost = program.len() as u64 * constants.cost_per_byte;
+        let program = node_from_bytes_backrefs(&mut a, program)?;
+        (a, byte_cost, program)
+    };
 
     let mut cost_left = max_cost;
-    subtract_cost(&a, &mut cost_left, byte_cost)?;
+    subtract_cost(&a, &mut cost_left, base_cost)?;
 
-    let program = node_from_bytes_backrefs(&mut a, program)?;
     check_generator_node(&a, program, flags)?;
 
     let args = setup_generator_args(&mut a, block_refs, flags)?;

--- a/crates/chia-consensus/src/run_block_generator.rs
+++ b/crates/chia-consensus/src/run_block_generator.rs
@@ -24,7 +24,7 @@ use clvmr::chia_dialect::ChiaDialect;
 use clvmr::cost::Cost;
 use clvmr::reduction::Reduction;
 use clvmr::run_program::run_program;
-use clvmr::serde::{intern_tree_limited, node_from_bytes, node_from_bytes_backrefs, InternedTree};
+use clvmr::serde::{InternedTree, intern_tree_limited, node_from_bytes, node_from_bytes_backrefs};
 
 pub fn subtract_cost(
     a: &Allocator,

--- a/crates/chia-consensus/src/solution_generator.rs
+++ b/crates/chia-consensus/src/solution_generator.rs
@@ -5,7 +5,7 @@ use clvmr::allocator::{Allocator, NodePtr};
 use clvmr::serde::{node_from_bytes_backrefs, node_to_bytes, node_to_bytes_backrefs};
 
 /// the tuple has the Coin, puzzle-reveal and solution
-fn build_generator<BufRef, I>(a: &mut Allocator, spends: I) -> Result<NodePtr>
+pub(crate) fn build_generator<BufRef, I>(a: &mut Allocator, spends: I) -> Result<NodePtr>
 where
     BufRef: AsRef<[u8]>,
     I: IntoIterator<Item = (Coin, BufRef, BufRef)>,

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -4,9 +4,10 @@ use crate::conditions::{
 };
 use crate::consensus_constants::ConsensusConstants;
 use crate::flags::{ConsensusFlags, MEMPOOL_MODE};
+use crate::generator_cost::total_cost_from_tree;
 use crate::puzzle_fingerprint::compute_puzzle_fingerprint;
 use crate::run_block_generator::subtract_cost;
-use crate::solution_generator::calculate_generator_length;
+use crate::solution_generator::{build_generator, calculate_generator_length};
 use crate::spend_visitor::SpendVisitor;
 use crate::spendbundle_validation::get_flags_for_height_and_constants;
 use crate::validation_error::ErrorCode;
@@ -15,10 +16,12 @@ use chia_bls::PublicKey;
 use chia_protocol::{Bytes, SpendBundle};
 
 use clvm_utils::tree_hash;
+use clvmr::NodePtr;
 use clvmr::allocator::Allocator;
 use clvmr::chia_dialect::ChiaDialect;
 use clvmr::reduction::Reduction;
 use clvmr::run_program::run_program;
+use clvmr::serde::intern_tree_limited;
 use clvmr::serde::node_from_bytes;
 
 const QUOTE_BYTES: usize = 2;
@@ -41,6 +44,38 @@ pub fn get_conditions_from_spendbundle(
     .0)
 }
 
+/// Computes the base cost of a spend bundle's generator before any puzzles run.
+/// For INTERNED_GENERATOR, builds the generator tree, interns it, and charges
+/// based on the interned structure. Otherwise charges cost_per_byte on the raw
+/// generator length (excluding the quote wrapper).
+fn calculate_base_cost(
+    a: &mut Allocator,
+    spend_bundle: &SpendBundle,
+    flags: ConsensusFlags,
+    constants: &ConsensusConstants,
+) -> Result<u64, ValidationErr> {
+    if flags.contains(ConsensusFlags::INTERNED_GENERATOR) {
+        let mut gen_allocator = Allocator::new();
+        let generator = build_generator(
+            &mut gen_allocator,
+            spend_bundle
+                .coin_spends
+                .iter()
+                .map(|cs| (cs.coin, cs.puzzle_reveal.as_slice(), cs.solution.as_slice())),
+        )
+        .map_err(|_| ValidationErr(a.nil(), ErrorCode::GeneratorRuntimeError))?;
+        let interned = intern_tree_limited(&gen_allocator, generator, u32::MAX as usize)
+            .map_err(|_| ValidationErr(NodePtr::NIL, ErrorCode::GeneratorRuntimeError))?;
+        Ok(total_cost_from_tree(&interned))
+    } else {
+        // We don't pay the size cost (nor execution cost) of being wrapped by a
+        // quote (in solution_generator).
+        let generator_length_without_quote =
+            calculate_generator_length(&spend_bundle.coin_spends) - QUOTE_BYTES;
+        Ok(generator_length_without_quote as u64 * constants.cost_per_byte)
+    }
+}
+
 // returns the conditions for the spendbundle, along with the (public key,
 // message) pairs emitted by the spends (for validating the aggregate signature)
 #[allow(clippy::type_complexity)]
@@ -57,13 +92,8 @@ pub fn run_spendbundle(
     let dialect = ChiaDialect::new(flags.to_clvm_flags());
     let mut ret = SpendBundleConditions::default();
     let mut state = ParseState::default();
-    // We don't pay the size cost (nor execution cost) of being wrapped by a
-    // quote (in solution_generator).
-    let generator_length_without_quote =
-        calculate_generator_length(&spend_bundle.coin_spends) - QUOTE_BYTES;
-
-    let byte_cost = generator_length_without_quote as u64 * constants.cost_per_byte;
-    subtract_cost(a, &mut cost_left, byte_cost)?;
+    let base_cost = calculate_base_cost(a, spend_bundle, flags, constants)?;
+    subtract_cost(a, &mut cost_left, base_cost)?;
 
     if flags.contains(ConsensusFlags::LIMIT_SPENDS)
         && spend_bundle.coin_spends.len() > MAX_SPENDS_PER_BLOCK

--- a/crates/chia-consensus/src/spendbundle_validation.rs
+++ b/crates/chia-consensus/src/spendbundle_validation.rs
@@ -91,7 +91,8 @@ pub fn get_flags_for_height_and_constants(
         flags |= ConsensusFlags::ENABLE_KECCAK_OPS_OUTSIDE_GUARD
             | ConsensusFlags::COST_CONDITIONS
             | ConsensusFlags::ENABLE_SECP_OPS
-            | ConsensusFlags::RELAXED_BLS;
+            | ConsensusFlags::RELAXED_BLS
+            | ConsensusFlags::INTERNED_GENERATOR;
     }
 
     if prev_tx_height >= constants.soft_fork8_height {

--- a/crates/chia-consensus/src/spendbundle_validation.rs
+++ b/crates/chia-consensus/src/spendbundle_validation.rs
@@ -91,8 +91,7 @@ pub fn get_flags_for_height_and_constants(
         flags |= ConsensusFlags::ENABLE_KECCAK_OPS_OUTSIDE_GUARD
             | ConsensusFlags::COST_CONDITIONS
             | ConsensusFlags::ENABLE_SECP_OPS
-            | ConsensusFlags::RELAXED_BLS
-            | ConsensusFlags::INTERNED_GENERATOR;
+            | ConsensusFlags::RELAXED_BLS;
     }
 
     if prev_tx_height >= constants.soft_fork8_height {


### PR DESCRIPTION
> **See also:** #1371 — the split cost model (6000/4500), which is the other option.

## Summary

Alternative cost model for the generator identity hard fork. Instead of the split model in #1371 (which charges separately for size and SHA), this uses a **pure storage model**:

```
cost = (atom_bytes + 2*atom_count + 3*pair_count) * 12000
```

One constant, no SHA cost accounting. The SHA tree-hash computation is structurally bounded by the size component (worst-case ratio ≤ 3.33), so it doesn't need separate charging.

All other code (INTERNED_GENERATOR flag, interned tree path, run_block_generator_inner refactor) is identical to #1371. The only file that differs is `generator_cost.rs`, which is smaller here since the SHA calculation is removed entirely.

## Why this formula?

The hard fork switches generator identity from `SHA256(serialized_bytes)` to `SHA256_tree_hash(tree)` — content-addressable rather than serialization-dependent. This means cost can no longer be `len(serialized_bytes) * 12000` because different serializations of the same tree would have different costs. Instead, cost must be a function of the **interned tree structure**.

The formula `atom_bytes + 2*atom_count + 3*pair_count` counts the structural components of the deduplicated tree:

- **`atom_bytes`** — raw data stored on chain
- **`2 * atom_count`** — per-atom overhead (type byte + length encoding)
- **`3 * pair_count`** — per-pair overhead (P=3 is [formally proven](https://github.com/richardkiss/generator-identity-hf-analysis/blob/main/docs/GENERATOR_IDENTITY_HARDFORK.md) to be an upper bound on serialized byte count, accounting for pair opcodes and back-reference encoding overhead)

The multiplier 12000 matches the pre-HF2 `COST_PER_BYTE`, preserving the same cost scale.

Full analysis and derivation: [generator-identity-hf-analysis](https://github.com/richardkiss/generator-identity-hf-analysis/blob/main/docs/GENERATOR_IDENTITY_HARDFORK.md)

## Pure storage (this PR) vs split (#1371)

| | Pure storage (this PR) | Split (#1371) |
|---|---|---|
| **Formula** | `size * 12000` | `size * 6000 + sha * 4500` |
| **Coefficients** | 1 | 2 |
| **Typical generator cost** | ~20% higher | ~20% lower |
| **Effective TPS** | Lower | Higher |
| **DoS safety** | Structural bound (sha/size ≤ 3.33, worst-case ~37ms SHA CPU) | Explicit SHA charging |
| **Philosophy** | Charge for storage only | Charge for storage + computation |

### Pros of pure storage
- **Simpler:** one constant, no SHA block/invocation accounting
- **DoS safe:** structural bound guarantees SHA CPU is bounded by size budget (worst case ~37ms on 2012 Celeron)
- Returns to pre-HF2 philosophy: charge for what you store on chain
- `size_component` naturally correlates with SHA cost (pair-heavy trees have high SHA AND high size)

### Cons of pure storage
- ~20% higher base cost for typical generators → lower effective TPS
- Doesn't explicitly charge for SHA computation (relies on structural bound)

## Test plan
- [x] All existing tests pass (`cargo test -p chia-consensus`)
- [ ] `analyze-chain` full mainnet regression (in progress on #1371, same code path for existing blocks)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes consensus-critical generator cost accounting and decoding paths when `INTERNED_GENERATOR` is enabled, which can alter block/spendbundle acceptability at the cost limit. New interned-tree validation/costing logic introduces potential edge cases around decoding limits and allocator ownership transitions.
> 
> **Overview**
> Implements an alternative generator-identity hard fork path behind the new `ConsensusFlags::INTERNED_GENERATOR`, switching base generator costing from `len(serialized_bytes) * cost_per_byte` to a **pure storage model** computed from the *interned (deduplicated) CLVM tree*.
> 
> Adds `generator_cost::total_cost_from_tree()` and wires it into `run_block_generator2()` and mempool `run_spendbundle()` so both block generators and spendbundles can charge consistent, serialization-independent base cost; `solution_generator::build_generator()` is exposed for internal reuse to build the generator tree for interning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9774629f95af4cc95d27e6957efdc1a0963698f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->