### PR TITLE
bump chia-pos2 dependency to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "chia-pos2"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b9cdaf0fcffa4a83bcbdba7ef854ba76be1d7ba0294401d046d9d2cf579a73"
+checksum = "1aa3b1e899706eb86eb8d3d6d5e0f6f59259a3603d2a32aaae8c405f3814efc3"
 dependencies = [
  "cc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ chia-serde = { path = "./crates/chia-serde", version = "0.42.0" }
 clvm-traits = { path = "./crates/clvm-traits", version = "0.42.0" }
 clvm-utils = { path = "./crates/clvm-utils", version = "0.42.0" }
 clvm-derive = { path = "./crates/clvm-derive", version = "0.42.0" }
-chia-pos2 = "0.4.1"
+chia-pos2 = "0.4.2"
 chia-consensus-fuzz = { path = "./crates/chia-consensus/fuzz", version = "0.42.0" }
 chia-bls-fuzz = { path = "./crates/chia-bls/fuzz", version = "0.42.0" }
 chia-datalayer-fuzz = { path = "./crates/chia-datalayer/fuzz", version = "0.42.0" }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lockfile-only dependency bump with no source changes; risk is limited to any upstream behavior changes in `chia-pos2`.
> 
> **Overview**
> Bumps the `chia-pos2` dependency from `0.4.1` to `0.4.2` in workspace dependencies.
> 
> Updates `Cargo.lock` accordingly (new version and checksum) so builds resolve the new crate release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43cdaa17b3cafbea67c0821d159da03820141141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->