### PR TITLE
Check time lock

### DIFF
--- a/crates/chia-consensus/src/check_time_locks.rs
+++ b/crates/chia-consensus/src/check_time_locks.rs
@@ -14,6 +14,7 @@ pub fn check_time_locks(
     bundle_conds: &OwnedSpendBundleConditions,
     prev_transaction_block_height: u32,
     timestamp: u64,
+    nowrap: bool,
 ) -> Result<(), ErrorCode> {
     if prev_transaction_block_height < bundle_conds.height_absolute {
         return Err(ErrorCode::AssertHeightAbsoluteFailed);
@@ -48,24 +49,52 @@ pub fn check_time_locks(
             }
         }
         if let Some(height_relative) = spend.height_relative {
-            if prev_transaction_block_height < unspent.confirmed_block_index + height_relative {
+            if nowrap {
+                if prev_transaction_block_height
+                    < unspent
+                        .confirmed_block_index
+                        .saturating_add(height_relative)
+                {
+                    return Err(ErrorCode::AssertHeightRelativeFailed);
+                }
+            } else if prev_transaction_block_height
+                < unspent.confirmed_block_index.wrapping_add(height_relative)
+            {
                 return Err(ErrorCode::AssertHeightRelativeFailed);
             }
         }
         if let Some(seconds_relative) = spend.seconds_relative {
-            if timestamp < unspent.timestamp + seconds_relative {
+            if nowrap {
+                if timestamp < unspent.timestamp.saturating_add(seconds_relative) {
+                    return Err(ErrorCode::AssertSecondsRelativeFailed);
+                }
+            } else if timestamp < unspent.timestamp.wrapping_add(seconds_relative) {
                 return Err(ErrorCode::AssertSecondsRelativeFailed);
             }
         }
         if let Some(before_height_relative) = spend.before_height_relative {
-            if prev_transaction_block_height
-                >= unspent.confirmed_block_index + before_height_relative
+            if nowrap {
+                if prev_transaction_block_height
+                    >= unspent
+                        .confirmed_block_index
+                        .saturating_add(before_height_relative)
+                {
+                    return Err(ErrorCode::AssertBeforeHeightRelativeFailed);
+                }
+            } else if prev_transaction_block_height
+                >= unspent
+                    .confirmed_block_index
+                    .wrapping_add(before_height_relative)
             {
                 return Err(ErrorCode::AssertBeforeHeightRelativeFailed);
             }
         }
         if let Some(before_seconds_relative) = spend.before_seconds_relative {
-            if timestamp >= unspent.timestamp + before_seconds_relative {
+            if nowrap {
+                if timestamp >= unspent.timestamp.saturating_add(before_seconds_relative) {
+                    return Err(ErrorCode::AssertBeforeSecondsRelativeFailed);
+                }
+            } else if timestamp >= unspent.timestamp.wrapping_add(before_seconds_relative) {
                 return Err(ErrorCode::AssertBeforeSecondsRelativeFailed);
             }
         }
@@ -83,12 +112,14 @@ pub fn py_check_time_locks(
     bundle_conds: &OwnedSpendBundleConditions,
     prev_transaction_block_height: u32,
     timestamp: u64,
+    nowrap: bool,
 ) -> PyResult<Option<u32>> {
     let res = check_time_locks(
         &removal_coin_records,
         bundle_conds,
         prev_transaction_block_height,
         timestamp,
+        nowrap,
     );
 
     match res {
@@ -197,68 +228,130 @@ mod tests {
         #[case] prev_height: u32,
         #[case] timestamp: u64,
         #[case] expected: Result<(), ErrorCode>,
+        #[values(true, false)] nowrap: bool,
     ) {
-        let result = check_time_locks(&HashMap::new(), &bundle, prev_height, timestamp);
+        let result = check_time_locks(&HashMap::new(), &bundle, prev_height, timestamp, nowrap);
         assert_eq!(result, expected);
     }
 
     type Osc = OwnedSpendConditions;
 
     #[rstest]
-    // in the following cases, the coin is created at height 100, and time 1000
-    // and the time of check is height 200 and time 2000.
+    // Coin confirmed at height 100, timestamp 1000.
+    // Checked at height 200, timestamp 2000.
+    // Each case: (spend, expected_nowrap, expected_no_nowrap)
+    //
+    // height_relative check: prev_height < confirmed + height_relative -> Err
+    // 200 < 100 + 101 = 201 -> Err (both agree, no overflow)
     #[case::height_relative_under(
         Osc { height_relative: Some(101), ..Default::default() },
-        Err(ErrorCode::AssertHeightRelativeFailed)
+        Err(ErrorCode::AssertHeightRelativeFailed),
+        Err(ErrorCode::AssertHeightRelativeFailed),
     )]
+    // 200 < 100 + 100 = 200 -> Ok (both agree, no overflow)
     #[case::height_relative_exact(
         Osc { height_relative: Some(100), ..Default::default() },
-        Ok(())
+        Ok(()),
+        Ok(()),
     )]
+    // 200 < 100 + 99 = 199 -> Ok (both agree, no overflow)
     #[case::height_relative_over(
         Osc { height_relative: Some(99), ..Default::default() },
-        Ok(())
+        Ok(()),
+        Ok(()),
     )]
+    // 200 < 100 + u32::MAX -> Err with nowrap (saturates), Ok without (wraps)
+    #[case::height_relative_wrap(
+        Osc { height_relative: Some(0xffff_ffff), ..Default::default() },
+        Err(ErrorCode::AssertHeightRelativeFailed),
+        Ok(()),
+    )]
+    // seconds_relative check: timestamp < coin_time + seconds_relative -> Err
+    // 2000 < 1000 + 1001 = 2001 -> Err (both agree, no overflow)
     #[case::seconds_relative_under(
         Osc { seconds_relative: Some(1001), ..Default::default() },
-        Err(ErrorCode::AssertSecondsRelativeFailed)
+        Err(ErrorCode::AssertSecondsRelativeFailed),
+        Err(ErrorCode::AssertSecondsRelativeFailed),
     )]
+    // 2000 < 1000 + 1000 = 2000 -> Ok (both agree, no overflow)
     #[case::seconds_relative_exact(
         Osc { seconds_relative: Some(1000), ..Default::default() },
-        Ok(())
+        Ok(()),
+        Ok(()),
     )]
+    // 2000 < 1000 + 999 = 1999 -> Ok (both agree, no overflow)
     #[case::seconds_relative_over(
         Osc { seconds_relative: Some(999), ..Default::default() },
-        Ok(())
+        Ok(()),
+        Ok(()),
     )]
+    // 2000 < 1000 + u64::MAX -> Err with nowrap (saturates), Ok without (wraps)
+    #[case::seconds_relative_wrap(
+        Osc { seconds_relative: Some(0xffff_ffff_ffff_ffff), ..Default::default() },
+        Err(ErrorCode::AssertSecondsRelativeFailed),
+        Ok(()),
+    )]
+    // before_height_relative check: prev_height >= confirmed + before_height_relative -> Err
+    // 200 >= 100 + 101 = 201 -> Ok (both agree, no overflow)
     #[case::before_height_relative_under(
         Osc { before_height_relative: Some(101), ..Default::default() },
-        Ok(())
+        Ok(()),
+        Ok(()),
     )]
+    // 200 >= 100 + 100 = 200 -> Err (both agree, no overflow)
     #[case::before_height_relative_exact(
         Osc { before_height_relative: Some(100), ..Default::default() },
-        Err(ErrorCode::AssertBeforeHeightRelativeFailed)
+        Err(ErrorCode::AssertBeforeHeightRelativeFailed),
+        Err(ErrorCode::AssertBeforeHeightRelativeFailed),
     )]
+    // 200 >= 100 + 99 = 199 -> Err (both agree, no overflow)
     #[case::before_height_relative_over(
         Osc { before_height_relative: Some(99), ..Default::default() },
-        Err(ErrorCode::AssertBeforeHeightRelativeFailed)
+        Err(ErrorCode::AssertBeforeHeightRelativeFailed),
+        Err(ErrorCode::AssertBeforeHeightRelativeFailed),
     )]
+    // 200 >= 100 + 0xffff_ffff -> Ok with nowrap (saturates), Err without (wraps)
+    #[case::before_height_relative_wrap(
+        Osc { before_height_relative: Some(0xffff_ffff), ..Default::default() },
+        Ok(()),
+        Err(ErrorCode::AssertBeforeHeightRelativeFailed),
+    )]
+    // before_seconds_relative check: timestamp >= coin_time + before_seconds_relative -> Err
+    // 2000 >= 1000 + 1001 = 2001 -> Ok (both agree, no overflow)
     #[case::before_seconds_relative_under(
         Osc { before_seconds_relative: Some(1001), ..Default::default() },
-        Ok(())
+        Ok(()),
+        Ok(()),
     )]
+    // 2000 >= 1000 + 1000 = 2000 -> Err (both agree, no overflow)
     #[case::before_seconds_relative_exact(
         Osc { before_seconds_relative: Some(1000), ..Default::default() },
-        Err(ErrorCode::AssertBeforeSecondsRelativeFailed)
+        Err(ErrorCode::AssertBeforeSecondsRelativeFailed),
+        Err(ErrorCode::AssertBeforeSecondsRelativeFailed),
     )]
+    // 2000 >= 1000 + 999 = 1999 -> Err (both agree, no overflow)
     #[case::before_seconds_relative_over(
         Osc { before_seconds_relative: Some(999), ..Default::default() },
-        Err(ErrorCode::AssertBeforeSecondsRelativeFailed)
+        Err(ErrorCode::AssertBeforeSecondsRelativeFailed),
+        Err(ErrorCode::AssertBeforeSecondsRelativeFailed),
+    )]
+    // 2000 >= 1000 + u64::MAX -> Ok with nowrap (saturates), Err without (wraps)
+    #[case::before_seconds_relative_wrap(
+        Osc { before_seconds_relative: Some(0xffff_ffff_ffff_ffff), ..Default::default() },
+        Ok(()),
+        Err(ErrorCode::AssertBeforeSecondsRelativeFailed),
     )]
     fn test_relative_constraints(
         #[case] spend: OwnedSpendConditions,
-        #[case] expected: Result<(), ErrorCode>,
+        #[case] expected_nowrap: Result<(), ErrorCode>,
+        #[case] expected_no_nowrap: Result<(), ErrorCode>,
+        #[values(true, false)] nowrap: bool,
     ) {
+        let expected = if nowrap {
+            expected_nowrap
+        } else {
+            expected_no_nowrap
+        };
         let now_height = 200_u32;
         let now_timestamp = 2000_u64;
 
@@ -277,12 +370,12 @@ mod tests {
         };
 
         let result: Result<(), ErrorCode> =
-            check_time_locks(&map, &bundle, now_height, now_timestamp);
+            check_time_locks(&map, &bundle, now_height, now_timestamp, nowrap);
         assert_eq!(result, expected);
     }
 
-    #[test]
-    fn test_invalid_coin_id() {
+    #[rstest]
+    fn test_invalid_coin_id(#[values(true, false)] nowrap: bool) {
         let coin_id = Bytes32::from([1u8; 32]);
         let spend = OwnedSpendConditions {
             coin_id,
@@ -292,12 +385,12 @@ mod tests {
             spends: vec![spend],
             ..Default::default()
         };
-        let result = check_time_locks(&HashMap::new(), &bundle, 0, 0);
+        let result = check_time_locks(&HashMap::new(), &bundle, 0, 0, nowrap);
         assert_eq!(result, Err(ErrorCode::InvalidCoinId));
     }
 
     #[rstest]
-    fn test_all_checks_pass() {
+    fn test_all_checks_pass(#[values(true, false)] nowrap: bool) {
         let coin_id = Bytes32::from([2u8; 32]);
         let coin_record = dummy_coin_record(10, 500);
 
@@ -322,12 +415,12 @@ mod tests {
             ..Default::default()
         };
 
-        let result = check_time_locks(&map, &bundle, 20, 700);
+        let result = check_time_locks(&map, &bundle, 20, 700, nowrap);
         assert!(result.is_ok());
     }
 
     #[rstest]
-    fn test_birth_height_and_seconds_mismatch() {
+    fn test_birth_height_and_seconds_mismatch(#[values(true, false)] nowrap: bool) {
         let coin_id = Bytes32::from([4u8; 32]);
         let coin_record = dummy_coin_record(10, 500);
 
@@ -346,12 +439,12 @@ mod tests {
             ..Default::default()
         };
 
-        let result = check_time_locks(&map, &bundle, 100, 1000);
+        let result = check_time_locks(&map, &bundle, 100, 1000, nowrap);
         assert_eq!(result, Err(ErrorCode::AssertMyBirthHeightFailed));
     }
 
     #[rstest]
-    fn test_birth_seconds_mismatch() {
+    fn test_birth_seconds_mismatch(#[values(true, false)] nowrap: bool) {
         let coin_id = Bytes32::from([5u8; 32]);
         let coin_record = dummy_coin_record(10, 500);
 
@@ -370,12 +463,12 @@ mod tests {
             ..Default::default()
         };
 
-        let result = check_time_locks(&map, &bundle, 100, 1000);
+        let result = check_time_locks(&map, &bundle, 100, 1000, nowrap);
         assert_eq!(result, Err(ErrorCode::AssertMyBirthSecondsFailed));
     }
 
-    #[test]
-    fn test_multiple_spends_in_bundle() {
+    #[rstest]
+    fn test_multiple_spends_in_bundle(#[values(true, false)] nowrap: bool) {
         let coin_id_1 = Bytes32::from([1u8; 32]);
         let coin_id_2 = Bytes32::from([2u8; 32]);
         let coin_id_3 = Bytes32::from([3u8; 32]);
@@ -421,7 +514,7 @@ mod tests {
         };
 
         // spend_relative_fail should fail first as 59 is below required 61 height
-        let result = check_time_locks(&map, &bundle, 59, 600);
+        let result = check_time_locks(&map, &bundle, 59, 600, nowrap);
         assert_eq!(result, Err(ErrorCode::AssertHeightRelativeFailed));
 
         let mut map = HashMap::new();
@@ -433,8 +526,8 @@ mod tests {
             ..Default::default()
         };
 
-        // spend_birth_dail should now fail
-        let result = check_time_locks(&map, &bundle, 59, 600);
+        // spend_birth_fail should now fail
+        let result = check_time_locks(&map, &bundle, 59, 600, nowrap);
         assert_eq!(result, Err(ErrorCode::AssertMyBirthHeightFailed));
     }
 }

--- a/crates/chia-consensus/src/check_time_locks.rs
+++ b/crates/chia-consensus/src/check_time_locks.rs
@@ -202,124 +202,68 @@ mod tests {
         assert_eq!(result, expected);
     }
 
+    type Osc = OwnedSpendConditions;
+
     #[rstest]
-    // the following cases are created with height 50, and time 1000
+    // in the following cases, the coin is created at height 100, and time 1000
+    // and the time of check is height 200 and time 2000.
     #[case::height_relative_under(
-        OwnedSpendConditions {
-            height_relative: Some(100),
-            ..Default::default()
-        },
-        149, // initial height 50 + 99
-        2000,
+        Osc { height_relative: Some(101), ..Default::default() },
         Err(ErrorCode::AssertHeightRelativeFailed)
     )]
     #[case::height_relative_exact(
-        OwnedSpendConditions {
-            height_relative: Some(100),
-            ..Default::default()
-        },
-        150,  // initial height 50 + 100
-        2000,
+        Osc { height_relative: Some(100), ..Default::default() },
         Ok(())
     )]
     #[case::height_relative_over(
-        OwnedSpendConditions {
-            height_relative: Some(100),
-            ..Default::default()
-        },
-        151,  // initial height 50 + 101
-        2000,
+        Osc { height_relative: Some(99), ..Default::default() },
         Ok(())
     )]
     #[case::seconds_relative_under(
-        OwnedSpendConditions {
-            seconds_relative: Some(1000),
-            ..Default::default()
-        },
-        200,
-        1999, // 1000 + 999
+        Osc { seconds_relative: Some(1001), ..Default::default() },
         Err(ErrorCode::AssertSecondsRelativeFailed)
     )]
     #[case::seconds_relative_exact(
-        OwnedSpendConditions {
-            seconds_relative: Some(1000),
-            ..Default::default()
-        },
-        200,
-        2000,  // initial 1000 + 1000
+        Osc { seconds_relative: Some(1000), ..Default::default() },
         Ok(())
     )]
     #[case::seconds_relative_over(
-        OwnedSpendConditions {
-            seconds_relative: Some(1000),
-            ..Default::default()
-        },
-        200,
-        2001, // initial 1000 + 1001
+        Osc { seconds_relative: Some(999), ..Default::default() },
         Ok(())
     )]
     #[case::before_height_relative_under(
-        OwnedSpendConditions {
-            before_height_relative: Some(10),
-            ..Default::default()
-        },
-        59,  // initial height 50 + 9
-        1000,
+        Osc { before_height_relative: Some(101), ..Default::default() },
         Ok(())
     )]
     #[case::before_height_relative_exact(
-        OwnedSpendConditions {
-            before_height_relative: Some(10),
-            ..Default::default()
-        },
-        60,  // initial height 50 + 10
-        1000,
+        Osc { before_height_relative: Some(100), ..Default::default() },
         Err(ErrorCode::AssertBeforeHeightRelativeFailed)
     )]
     #[case::before_height_relative_over(
-        OwnedSpendConditions {
-            before_height_relative: Some(10),
-            ..Default::default()
-        },
-        61,  // initial height 50 + 11
-        1000,
+        Osc { before_height_relative: Some(99), ..Default::default() },
         Err(ErrorCode::AssertBeforeHeightRelativeFailed)
     )]
     #[case::before_seconds_relative_under(
-        OwnedSpendConditions {
-            before_seconds_relative: Some(1000),
-            ..Default::default()
-        },
-        100,
-        1999,  // initial time 1000 + 999
+        Osc { before_seconds_relative: Some(1001), ..Default::default() },
         Ok(())
     )]
     #[case::before_seconds_relative_exact(
-        OwnedSpendConditions {
-            before_seconds_relative: Some(1000),
-            ..Default::default()
-        },
-        100,
-        2000,  // initial time 1000 + 1000
+        Osc { before_seconds_relative: Some(1000), ..Default::default() },
         Err(ErrorCode::AssertBeforeSecondsRelativeFailed)
     )]
     #[case::before_seconds_relative_over(
-        OwnedSpendConditions {
-            before_seconds_relative: Some(1000),
-            ..Default::default()
-        },
-        100,
-        2001,  // initial time 1000 + 2001
+        Osc { before_seconds_relative: Some(999), ..Default::default() },
         Err(ErrorCode::AssertBeforeSecondsRelativeFailed)
     )]
-    fn test_relative_constraints_failures(
+    fn test_relative_constraints(
         #[case] spend: OwnedSpendConditions,
-        #[case] now_height: u32,
-        #[case] now_timestamp: u64,
         #[case] expected: Result<(), ErrorCode>,
     ) {
+        let now_height = 200_u32;
+        let now_timestamp = 2000_u64;
+
         let coin_id = Bytes32::from([3u8; 32]);
-        let coin_record = dummy_coin_record(50, 1000);
+        let coin_record = dummy_coin_record(100, 1000);
 
         let mut spend = spend;
         spend.coin_id = coin_id;

--- a/tests/test_check_time_locks.py
+++ b/tests/test_check_time_locks.py
@@ -211,10 +211,12 @@ class TestCheckTimeLocks:
             ),
         ],
     )
+    @pytest.mark.parametrize("nowrap", [True, False])
     def test_conditions(
         self,
         conds: SpendBundleConditions,
         expected: Optional[int],
+        nowrap: bool,
     ) -> None:
         assert (
             check_time_locks(
@@ -222,6 +224,7 @@ class TestCheckTimeLocks:
                 conds,
                 self.PREV_BLOCK_HEIGHT,
                 self.PREV_BLOCK_TIMESTAMP,
+                nowrap,
             )
             == expected
         )

--- a/tests/test_check_time_locks.py
+++ b/tests/test_check_time_locks.py
@@ -228,3 +228,72 @@ class TestCheckTimeLocks:
             )
             == expected
         )
+
+    @pytest.mark.parametrize(
+        "conds,expected_nowrap,expected_wrap",
+        [
+            # --- height_relative wrapping ---
+            # confirmed_height=10, prev_height=15
+            # 10 + (2^32 - 11) = u32::MAX, no overflow, 15 < u32::MAX -> Err both
+            (make_test_conds(height_relative=0xFFFF_FFF5), 13, 13),
+            # 10 + (2^32 - 10) overflows to 0, wrapping: 15 < 0 -> Ok
+            # saturating: clamps to u32::MAX, 15 < u32::MAX -> Err
+            (make_test_conds(height_relative=0xFFFF_FFF6), 13, None),
+            # 10 + u32::MAX overflows to 9, wrapping: 15 < 9 -> Ok
+            (make_test_conds(height_relative=0xFFFF_FFFF), 13, None),
+            # --- seconds_relative wrapping ---
+            # coin_timestamp=10000, prev_timestamp=10150
+            # 10000 + (u64::MAX - 10000) = u64::MAX, no overflow -> Err both
+            (make_test_conds(seconds_relative=0xFFFF_FFFF_FFFF_D8EF), 105, 105),
+            # 10000 + (u64::MAX - 9999) overflows to 0, wrapping: 10150 < 0 -> Ok
+            (make_test_conds(seconds_relative=0xFFFF_FFFF_FFFF_D8F0), 105, None),
+            # 10000 + u64::MAX overflows to 9999, wrapping: 10150 < 9999 -> Ok
+            (make_test_conds(seconds_relative=0xFFFF_FFFF_FFFF_FFFF), 105, None),
+            # --- before_height_relative wrapping ---
+            # check is >=, so wrapping to a small value causes failure
+            # 10 + (2^32 - 11) = u32::MAX, no overflow, 15 >= u32::MAX -> Ok both
+            (make_test_conds(before_height_relative=0xFFFF_FFF5), None, None),
+            # 10 + (2^32 - 10) overflows to 0, wrapping: 15 >= 0 -> Err
+            # saturating: 15 >= u32::MAX -> Ok
+            (make_test_conds(before_height_relative=0xFFFF_FFF6), None, 131),
+            # 10 + u32::MAX overflows to 9, wrapping: 15 >= 9 -> Err
+            (make_test_conds(before_height_relative=0xFFFF_FFFF), None, 131),
+            # --- before_seconds_relative wrapping ---
+            # 10000 + (u64::MAX - 10000) = u64::MAX, no overflow, 10150 >= u64::MAX -> Ok both
+            (
+                make_test_conds(before_seconds_relative=0xFFFF_FFFF_FFFF_D8EF),
+                None,
+                None,
+            ),
+            # 10000 + (u64::MAX - 9999) overflows to 0, wrapping: 10150 >= 0 -> Err
+            (make_test_conds(before_seconds_relative=0xFFFF_FFFF_FFFF_D8F0), None, 129),
+            # 10000 + u64::MAX overflows to 9999, wrapping: 10150 >= 9999 -> Err
+            (make_test_conds(before_seconds_relative=0xFFFF_FFFF_FFFF_FFFF), None, 129),
+        ],
+    )
+    def test_wrapping_conditions(
+        self,
+        conds: SpendBundleConditions,
+        expected_nowrap: Optional[int],
+        expected_wrap: Optional[int],
+    ) -> None:
+        assert (
+            check_time_locks(
+                dict(self.REMOVALS),
+                conds,
+                self.PREV_BLOCK_HEIGHT,
+                self.PREV_BLOCK_TIMESTAMP,
+                True,
+            )
+            == expected_nowrap
+        )
+        assert (
+            check_time_locks(
+                dict(self.REMOVALS),
+                conds,
+                self.PREV_BLOCK_HEIGHT,
+                self.PREV_BLOCK_TIMESTAMP,
+                False,
+            )
+            == expected_wrap
+        )

--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -347,6 +347,7 @@ def check_time_locks(
     bundle_conds: SpendBundleConditions,
     prev_transaction_block_height: uint32,
     timestamp: uint64,
+    nowrap: bool,
 ) -> Optional[int]: ...
 
 def confirm_included_already_hashed(

--- a/wheel/python/chia_rs/chia_rs.pyi
+++ b/wheel/python/chia_rs/chia_rs.pyi
@@ -40,6 +40,7 @@ def check_time_locks(
     bundle_conds: SpendBundleConditions,
     prev_transaction_block_height: uint32,
     timestamp: uint64,
+    nowrap: bool,
 ) -> Optional[int]: ...
 
 def confirm_included_already_hashed(


### PR DESCRIPTION
implement non-wrapping behavior in `check_time_lock()` to enable in the 3.0 hard fork

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Consensus-critical validation behavior changes (time-lock enforcement) and introduces a new mode that can reject/accept spends differently around integer overflow boundaries.
> 
> **Overview**
> Adds a new `nowrap` flag to `check_time_locks` (Rust + PyO3) to switch relative height/seconds time-lock math from wrapping additions to saturating additions, preventing overflow-based bypasses.
> 
> Updates Python bindings/type stubs and expands both Rust and Python tests to cover `nowrap` vs wrapping behavior, including explicit overflow/wraparound edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c5117980ccabfc5ce0aab8e97ff530889b80b31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->