### PR TITLE
Streamable size limits

### DIFF
--- a/crates/chia-protocol/src/full_node_protocol.rs
+++ b/crates/chia-protocol/src/full_node_protocol.rs
@@ -70,6 +70,7 @@ pub struct RequestBlocks {
 pub struct RespondBlocks {
     start_height: u32,
     end_height: u32,
+    #[chia(max_length = 64)]
     blocks: Vec<FullBlock>,
 }
 

--- a/crates/chia-protocol/src/wallet_protocol.rs
+++ b/crates/chia-protocol/src/wallet_protocol.rs
@@ -72,6 +72,7 @@ pub struct RejectHeaderRequest {
 pub struct RequestRemovals {
     height: u32,
     header_hash: Bytes32,
+    #[chia(max_length = 30000)]
     coin_names: Option<Vec<Bytes32>>,
 }
 
@@ -79,7 +80,9 @@ pub struct RequestRemovals {
 pub struct RespondRemovals {
     height: u32,
     header_hash: Bytes32,
+    #[chia(max_length = 30000)]
     coins: Vec<(Bytes32, Option<Coin>)>,
+    #[chia(max_length = 30000)]
     proofs: Option<Vec<(Bytes32, Bytes)>>,
 }
 
@@ -93,6 +96,7 @@ pub struct RejectRemovalsRequest {
 pub struct RequestAdditions {
     height: u32,
     header_hash: Option<Bytes32>,
+    #[chia(max_length = 30000)]
     puzzle_hashes: Option<Vec<Bytes32>>,
 }
 
@@ -100,7 +104,9 @@ pub struct RequestAdditions {
 pub struct RespondAdditions {
     height: u32,
     header_hash: Bytes32,
+    #[chia(max_length = 30000)]
     coins: Vec<(Bytes32, Vec<Coin>)>,
+    #[chia(max_length = 30000)]
     proofs: Option<Vec<(Bytes32, Bytes, Option<Bytes>)>>,
 }
 
@@ -114,6 +120,7 @@ pub struct RejectAdditionsRequest {
 pub struct RespondBlockHeaders {
     start_height: u32,
     end_height: u32,
+    #[chia(max_length = 64)]
     header_blocks: Vec<HeaderBlock>,
 }
 
@@ -146,32 +153,39 @@ pub struct RejectHeaderBlocks {
 pub struct RespondHeaderBlocks {
     start_height: u32,
     end_height: u32,
+    #[chia(max_length = 64)]
     header_blocks: Vec<HeaderBlock>,
 }
 
 #[streamable(message)]
 pub struct RegisterForPhUpdates {
+    #[chia(max_length = 1600000)]
     puzzle_hashes: Vec<Bytes32>,
     min_height: u32,
 }
 
 #[streamable(message)]
 pub struct RespondToPhUpdates {
+    #[chia(max_length = 1600000)]
     puzzle_hashes: Vec<Bytes32>,
     min_height: u32,
+    #[chia(max_length = 1600000)]
     coin_states: Vec<CoinState>,
 }
 
 #[streamable(message)]
 pub struct RegisterForCoinUpdates {
+    #[chia(max_length = 1600000)]
     coin_ids: Vec<Bytes32>,
     min_height: u32,
 }
 
 #[streamable(message)]
 pub struct RespondToCoinUpdates {
+    #[chia(max_length = 1600000)]
     coin_ids: Vec<Bytes32>,
     min_height: u32,
+    #[chia(max_length = 1600000)]
     coin_states: Vec<CoinState>,
 }
 
@@ -180,6 +194,7 @@ pub struct CoinStateUpdate {
     height: u32,
     fork_height: u32,
     peak_hash: Bytes32,
+    #[chia(max_length = 30000)]
     items: Vec<CoinState>,
 }
 
@@ -190,6 +205,7 @@ pub struct RequestChildren {
 
 #[streamable(message)]
 pub struct RespondChildren {
+    #[chia(max_length = 30000)]
     coin_states: Vec<CoinState>,
 }
 
@@ -217,21 +233,25 @@ pub struct RespondFeeEstimates {
 
 #[streamable(message)]
 pub struct RequestRemovePuzzleSubscriptions {
+    #[chia(max_length = 1600000)]
     puzzle_hashes: Option<Vec<Bytes32>>,
 }
 
 #[streamable(message)]
 pub struct RespondRemovePuzzleSubscriptions {
+    #[chia(max_length = 1600000)]
     puzzle_hashes: Vec<Bytes32>,
 }
 
 #[streamable(message)]
 pub struct RequestRemoveCoinSubscriptions {
+    #[chia(max_length = 1600000)]
     coin_ids: Option<Vec<Bytes32>>,
 }
 
 #[streamable(message)]
 pub struct RespondRemoveCoinSubscriptions {
+    #[chia(max_length = 1600000)]
     coin_ids: Vec<Bytes32>,
 }
 
@@ -245,6 +265,7 @@ pub struct CoinStateFilters {
 
 #[streamable(message)]
 pub struct RequestPuzzleState {
+    #[chia(max_length = 32700)]
     puzzle_hashes: Vec<Bytes32>,
     previous_height: Option<u32>,
     header_hash: Bytes32,
@@ -254,10 +275,12 @@ pub struct RequestPuzzleState {
 
 #[streamable(message)]
 pub struct RespondPuzzleState {
+    #[chia(max_length = 32700)]
     puzzle_hashes: Vec<Bytes32>,
     height: u32,
     header_hash: Bytes32,
     is_finished: bool,
+    #[chia(max_length = 32700)]
     coin_states: Vec<CoinState>,
 }
 
@@ -268,6 +291,7 @@ pub struct RejectPuzzleState {
 
 #[streamable(message)]
 pub struct RequestCoinState {
+    #[chia(max_length = 32700)]
     coin_ids: Vec<Bytes32>,
     previous_height: Option<u32>,
     header_hash: Bytes32,
@@ -276,7 +300,9 @@ pub struct RequestCoinState {
 
 #[streamable(message)]
 pub struct RespondCoinState {
+    #[chia(max_length = 32700)]
     coin_ids: Vec<Bytes32>,
+    #[chia(max_length = 32700)]
     coin_states: Vec<CoinState>,
 }
 
@@ -334,11 +360,13 @@ pub struct RemovedMempoolItem {
 
 #[streamable(message)]
 pub struct MempoolItemsAdded {
+    #[chia(max_length = 30000)]
     transaction_ids: Vec<Bytes32>,
 }
 
 #[streamable(message)]
 pub struct MempoolItemsRemoved {
+    #[chia(max_length = 30000)]
     removed_items: Vec<RemovedMempoolItem>,
 }
 

--- a/crates/chia-protocol/src/wallet_protocol.rs
+++ b/crates/chia-protocol/src/wallet_protocol.rs
@@ -120,7 +120,7 @@ pub struct RejectAdditionsRequest {
 pub struct RespondBlockHeaders {
     start_height: u32,
     end_height: u32,
-    #[chia(max_length = 64)]
+    #[chia(max_length = 128)]
     header_blocks: Vec<HeaderBlock>,
 }
 
@@ -169,7 +169,7 @@ pub struct RespondToPhUpdates {
     #[chia(max_length = 1600000)]
     puzzle_hashes: Vec<Bytes32>,
     min_height: u32,
-    #[chia(max_length = 1600000)]
+    #[chia(max_length = 500000)]
     coin_states: Vec<CoinState>,
 }
 
@@ -185,7 +185,7 @@ pub struct RespondToCoinUpdates {
     #[chia(max_length = 1600000)]
     coin_ids: Vec<Bytes32>,
     min_height: u32,
-    #[chia(max_length = 1600000)]
+    #[chia(max_length = 500000)]
     coin_states: Vec<CoinState>,
 }
 
@@ -265,7 +265,7 @@ pub struct CoinStateFilters {
 
 #[streamable(message)]
 pub struct RequestPuzzleState {
-    #[chia(max_length = 32700)]
+    #[chia(max_length = 35000)]
     puzzle_hashes: Vec<Bytes32>,
     previous_height: Option<u32>,
     header_hash: Bytes32,
@@ -275,12 +275,12 @@ pub struct RequestPuzzleState {
 
 #[streamable(message)]
 pub struct RespondPuzzleState {
-    #[chia(max_length = 32700)]
+    #[chia(max_length = 33000)]
     puzzle_hashes: Vec<Bytes32>,
     height: u32,
     header_hash: Bytes32,
     is_finished: bool,
-    #[chia(max_length = 32700)]
+    #[chia(max_length = 500000)]
     coin_states: Vec<CoinState>,
 }
 
@@ -291,7 +291,7 @@ pub struct RejectPuzzleState {
 
 #[streamable(message)]
 pub struct RequestCoinState {
-    #[chia(max_length = 32700)]
+    #[chia(max_length = 500000)]
     coin_ids: Vec<Bytes32>,
     previous_height: Option<u32>,
     header_hash: Bytes32,
@@ -300,9 +300,9 @@ pub struct RequestCoinState {
 
 #[streamable(message)]
 pub struct RespondCoinState {
-    #[chia(max_length = 32700)]
+    #[chia(max_length = 500000)]
     coin_ids: Vec<Bytes32>,
-    #[chia(max_length = 32700)]
+    #[chia(max_length = 500000)]
     coin_states: Vec<CoinState>,
 }
 

--- a/crates/chia-traits/src/streamable.rs
+++ b/crates/chia-traits/src/streamable.rs
@@ -124,18 +124,7 @@ impl<T: Streamable> Streamable for Vec<T> {
     }
 
     fn parse<const TRUSTED: bool>(input: &mut Cursor<&[u8]>) -> Result<Self> {
-        let len = u32::parse::<TRUSTED>(input)?;
-
-        let mut ret = if mem::size_of::<T>() == 0 {
-            Vec::<T>::new()
-        } else {
-            let limit = 2 * 1024 * 1024 / mem::size_of::<T>();
-            Vec::<T>::with_capacity(std::cmp::min(limit, len as usize))
-        };
-        for _ in 0..len {
-            ret.push(T::parse::<TRUSTED>(input)?);
-        }
-        Ok(ret)
+        parse_vec_with_max_length::<T, TRUSTED>(input, u32::MAX as usize)
     }
 }
 

--- a/crates/chia-traits/src/streamable.rs
+++ b/crates/chia-traits/src/streamable.rs
@@ -139,6 +139,26 @@ impl<T: Streamable> Streamable for Vec<T> {
     }
 }
 
+pub fn parse_vec_with_max_length<T: Streamable, const TRUSTED: bool>(
+    input: &mut Cursor<&[u8]>,
+    max_length: usize,
+) -> Result<Vec<T>> {
+    let len = u32::parse::<TRUSTED>(input)?;
+    if (len as usize) > max_length {
+        return Err(Error::SequenceTooLarge);
+    }
+    let mut ret = if mem::size_of::<T>() == 0 {
+        Vec::<T>::new()
+    } else {
+        let limit = 2 * 1024 * 1024 / mem::size_of::<T>();
+        Vec::<T>::with_capacity(std::cmp::min(limit, len as usize))
+    };
+    for _ in 0..len {
+        ret.push(T::parse::<TRUSTED>(input)?);
+    }
+    Ok(ret)
+}
+
 impl Streamable for String {
     fn update_digest(&self, digest: &mut Sha256) {
         let bytes = self.as_bytes();
@@ -783,4 +803,58 @@ fn test_stream_enum() {
     assert_eq!(stream::<TestEnum>(&TestEnum::A), &[0_u8]);
     assert_eq!(stream::<TestEnum>(&TestEnum::B), &[1_u8]);
     assert_eq!(stream::<TestEnum>(&TestEnum::C), &[255_u8]);
+}
+
+#[cfg(test)]
+#[derive(Streamable, PartialEq, Debug)]
+struct TestBoundedVec {
+    #[chia(max_length = 3)]
+    items: Vec<u32>,
+}
+
+#[test]
+fn test_parse_bounded_vec() {
+    let buf: &[u8] = &[0, 0, 0, 3, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3];
+    from_bytes::<TestBoundedVec>(
+        buf,
+        TestBoundedVec {
+            items: vec![1, 2, 3],
+        },
+    );
+}
+
+#[test]
+fn test_parse_bounded_vec_too_large() {
+    let buf: &[u8] = &[0, 0, 0, 4, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4];
+    from_bytes_fail::<TestBoundedVec>(buf, Error::SequenceTooLarge);
+}
+
+#[cfg(test)]
+#[derive(Streamable, PartialEq, Debug)]
+struct TestBoundedOptionVec {
+    #[chia(max_length = 2)]
+    items: Option<Vec<u32>>,
+}
+
+#[test]
+fn test_parse_bounded_option_vec_none() {
+    let buf: &[u8] = &[0];
+    from_bytes::<TestBoundedOptionVec>(buf, TestBoundedOptionVec { items: None });
+}
+
+#[test]
+fn test_parse_bounded_option_vec_some() {
+    let buf: &[u8] = &[1, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 2];
+    from_bytes::<TestBoundedOptionVec>(
+        buf,
+        TestBoundedOptionVec {
+            items: Some(vec![1, 2]),
+        },
+    );
+}
+
+#[test]
+fn test_parse_bounded_option_vec_too_large() {
+    let buf: &[u8] = &[1, 0, 0, 0, 3, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3];
+    from_bytes_fail::<TestBoundedOptionVec>(buf, Error::SequenceTooLarge);
 }

--- a/crates/chia_streamable_macro/src/lib.rs
+++ b/crates/chia_streamable_macro/src/lib.rs
@@ -6,8 +6,8 @@ use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::quote;
 use syn::token::Pub;
 use syn::{
-    Data, DeriveInput, Expr, Fields, FieldsNamed, FieldsUnnamed, Index, Lit, Type, Visibility,
-    parse_macro_input,
+    Attribute, Data, DeriveInput, Expr, Fields, FieldsNamed, FieldsUnnamed, GenericArgument, Index,
+    Lit, PathArguments, Type, Visibility, parse_macro_input,
 };
 
 #[proc_macro_attribute]
@@ -152,7 +152,71 @@ pub fn streamable(attr: TokenStream, item: TokenStream) -> TokenStream {
     .into()
 }
 
-#[proc_macro_derive(Streamable)]
+fn get_max_length(attrs: &[Attribute]) -> Option<usize> {
+    for attr in attrs {
+        if attr.path().is_ident("chia") {
+            let mut max_length = None;
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("max_length") {
+                    let value = meta.value()?;
+                    let lit: syn::LitInt = value.parse()?;
+                    max_length = Some(
+                        lit.base10_parse::<usize>()
+                            .expect("max_length must be a valid usize"),
+                    );
+                    Ok(())
+                } else {
+                    Err(meta.error("unsupported chia attribute"))
+                }
+            })
+            .expect("failed to parse chia attribute");
+            return max_length;
+        }
+    }
+    None
+}
+
+fn extract_inner_type<'a>(ty: &'a Type, name: &str) -> Option<&'a Type> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    let segment = type_path.path.segments.last()?;
+    if segment.ident != name {
+        return None;
+    }
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    match args.args.first() {
+        Some(GenericArgument::Type(inner)) => Some(inner),
+        _ => None,
+    }
+}
+
+fn generate_bounded_parse(ty: &Type, max_len: usize, crate_name: &TokenStream2) -> TokenStream2 {
+    if let Some(inner_type) = extract_inner_type(ty, "Vec") {
+        quote! {
+            #crate_name::parse_vec_with_max_length::<#inner_type, TRUSTED>(input, #max_len)?
+        }
+    } else if let Some(inner_option_type) = extract_inner_type(ty, "Option") {
+        let vec_inner_type = extract_inner_type(inner_option_type, "Vec")
+            .expect("max_length attribute is only supported on Vec<T> or Option<Vec<T>> fields");
+        quote! {
+            {
+                let val = #crate_name::read_bytes(input, 1)?[0];
+                match val {
+                    0 => None,
+                    1 => Some(#crate_name::parse_vec_with_max_length::<#vec_inner_type, TRUSTED>(input, #max_len)?),
+                    _ => return Err(#crate_name::chia_error::Error::InvalidOptional),
+                }
+            }
+        }
+    } else {
+        panic!("max_length attribute is only supported on Vec<T> or Option<Vec<T>> fields");
+    }
+}
+
+#[proc_macro_derive(Streamable, attributes(chia))]
 pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
     let found_crate = crate_name("chia-traits").expect("chia-traits is present in `Cargo.toml`");
 
@@ -169,6 +233,7 @@ pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
     let mut fnames = Vec::<Ident>::new();
     let mut findices = Vec::<Index>::new();
     let mut ftypes = Vec::<Type>::new();
+    let mut max_lengths = Vec::<Option<usize>>::new();
     match data {
         Data::Enum(e) => {
             let mut names = Vec::<Ident>::new();
@@ -216,6 +281,7 @@ pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
                 for (index, f) in unnamed.iter().enumerate() {
                     findices.push(Index::from(index));
                     ftypes.push(f.ty.clone());
+                    max_lengths.push(get_max_length(&f.attrs));
                 }
             }
             Fields::Unit => {}
@@ -223,10 +289,23 @@ pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
                 for f in &named {
                     fnames.push(f.ident.as_ref().unwrap().clone());
                     ftypes.push(f.ty.clone());
+                    max_lengths.push(get_max_length(&f.attrs));
                 }
             }
         },
     }
+
+    let parse_exprs: Vec<TokenStream2> = ftypes
+        .iter()
+        .zip(max_lengths.iter())
+        .map(|(ty, max_len)| {
+            if let Some(max_len) = max_len {
+                generate_bounded_parse(ty, *max_len, &crate_name)
+            } else {
+                quote!(<#ty as #crate_name::Streamable>::parse::<TRUSTED>(input)?)
+            }
+        })
+        .collect();
 
     if !fnames.is_empty() {
         let ret = quote! {
@@ -239,7 +318,7 @@ pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
                     Ok(())
                 }
                 fn parse<const TRUSTED: bool>(input: &mut std::io::Cursor<&[u8]>) -> #crate_name::chia_error::Result<Self> {
-                    Ok(Self { #( #fnames: <#ftypes as #crate_name::Streamable>::parse::<TRUSTED>(input)?, )* })
+                    Ok(Self { #( #fnames: #parse_exprs, )* })
                 }
             }
         };
@@ -255,7 +334,7 @@ pub fn chia_streamable_macro(input: TokenStream) -> TokenStream {
                     Ok(())
                 }
                 fn parse<const TRUSTED: bool>(input: &mut std::io::Cursor<&[u8]>) -> #crate_name::chia_error::Result<Self> {
-                    Ok(Self( #( <#ftypes as #crate_name::Streamable>::parse::<TRUSTED>(input)?, )* ))
+                    Ok(Self( #( #parse_exprs, )* ))
                 }
             }
         };


### PR DESCRIPTION
This adds an option to the streamable macro, to specify a limit on vectors in streamable types. It can short cut some validation by failing earlier for messages that are invalid.

The second commit employs the new option to set appropriate limits for some message types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deserialization behavior for `Streamable` structs by enforcing new per-field vector length limits, which can cause previously-accepted oversized network messages to be rejected. Risk is moderate because it touches core protocol parsing but is additive and guarded by explicit `#[chia(max_length = ...)]` annotations.
> 
> **Overview**
> Adds a new `#[chia(max_length = N)]` field attribute to the `Streamable` derive macro to enforce bounded parsing for `Vec<T>` and `Option<Vec<T>>`, failing early with `Error::SequenceTooLarge`.
> 
> Refactors vector parsing in `chia-traits` to route through a shared `parse_vec_with_max_length` helper and adds tests covering bounded `Vec`/`Option<Vec>` behavior.
> 
> Applies explicit maximum lengths to several full node and wallet protocol message fields (e.g., block/header responses, additions/removals queries, subscription update payloads, mempool notifications) to cap decoded list sizes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c79e84e9b7ef35b83e5d090d9c3f73f53f203f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->