### PR TITLE
remove map_pyerr_w_ptr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,6 @@ dependencies = [
  "chia-traits 0.42.1",
  "clvm-utils",
  "clvmr",
- "hex",
  "pyo3",
 ]
 

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -16,7 +16,7 @@ def test_raise() -> None:
         # We expect this to throw
         assert False
     except ValueError as e:
-        assert f"{e}" == "('clvm raise', '86666f6f626172')"
+        assert f"{e}" == "clvm raise"
 
 
 def test_raise_program() -> None:
@@ -39,7 +39,7 @@ def test_repr() -> None:
         run_chia_program(bytes(temp), bytes.fromhex("00"), 1100000000, 0)
         assert False
     except ValueError as e:
-        assert f"{e}" == "('clvm raise', '83666f6f')"
+        assert f"{e}" == "clvm raise"
 
 
 def test_print() -> None:

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -30,7 +30,6 @@ openssl = ["clvmr/openssl"]
 
 [dependencies]
 clvmr = { workspace = true }
-hex = { workspace = true }
 pyo3 = { workspace = true, features = ["multiple-pymethods"] }
 bincode = { workspace = true }
 chia-consensus = { workspace = true, features = ["py-bindings"] }

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -1,4 +1,4 @@
-use crate::error::{map_pyerr, map_pyerr_w_ptr};
+use crate::error::map_pyerr;
 use crate::run_generator::{
     additions_and_removals, py_to_slice, run_block_generator, run_block_generator2,
 };
@@ -176,10 +176,8 @@ pub fn get_puzzle_and_solution_for_coin<'a>(
     let program = py_to_slice::<'a>(program);
     let args = py_to_slice::<'a>(args);
 
-    let program = node_from_bytes_backrefs(&mut allocator, program)
-        .map_err(|e| map_pyerr_w_ptr(&e, &allocator))?;
-    let args = node_from_bytes_backrefs(&mut allocator, args)
-        .map_err(|e| map_pyerr_w_ptr(&e, &allocator))?;
+    let program = node_from_bytes_backrefs(&mut allocator, program).map_err(map_pyerr)?;
+    let args = node_from_bytes_backrefs(&mut allocator, args).map_err(map_pyerr)?;
     let dialect = &ChiaDialect::new(flags.to_clvm_flags());
 
     let (puzzle, solution) = py
@@ -197,19 +195,13 @@ pub fn get_puzzle_and_solution_for_coin<'a>(
                 Ok(pair) => Ok(pair),
             }
         })
-        .map_err(|e| map_pyerr_w_ptr(&e, &allocator))?;
+        .map_err(map_pyerr)?;
 
     // keep serializing normally, until wallets support backrefs
     let serialize = node_to_bytes;
     Ok((
-        PyBytes::new(
-            py,
-            &serialize(&allocator, puzzle).map_err(|e| map_pyerr_w_ptr(&e, &allocator))?,
-        ),
-        PyBytes::new(
-            py,
-            &serialize(&allocator, solution).map_err(|e| map_pyerr_w_ptr(&e, &allocator))?,
-        ),
+        PyBytes::new(py, &serialize(&allocator, puzzle).map_err(map_pyerr)?),
+        PyBytes::new(py, &serialize(&allocator, solution).map_err(map_pyerr)?),
     ))
 }
 
@@ -236,8 +228,8 @@ pub fn get_puzzle_and_solution_for_coin2<'a>(
         py_to_slice::<'a>(buf)
     });
 
-    let generator = node_from_bytes_backrefs(&mut allocator, generator.as_ref())
-        .map_err(|e| map_pyerr_w_ptr(&e, &allocator))?;
+    let generator =
+        node_from_bytes_backrefs(&mut allocator, generator.as_ref()).map_err(map_pyerr)?;
     let args = setup_generator_args(&mut allocator, refs, flags)?;
     let dialect = &ChiaDialect::new(flags.to_clvm_flags());
 
@@ -252,15 +244,13 @@ pub fn get_puzzle_and_solution_for_coin2<'a>(
                 Ok(pair) => Ok(pair),
             }
         })
-        .map_err(|e| map_pyerr_w_ptr(&e, &allocator))?;
+        .map_err(map_pyerr)?;
 
     // keep serializing normally, until wallets support backrefs
     Ok((
-        node_to_bytes(&allocator, puzzle)
-            .map_err(|e| map_pyerr_w_ptr(&e, &allocator))?
-            .into(),
+        node_to_bytes(&allocator, puzzle).map_err(map_pyerr)?.into(),
         node_to_bytes(&allocator, solution)
-            .map_err(|e| map_pyerr_w_ptr(&e, &allocator))?
+            .map_err(map_pyerr)?
             .into(),
     ))
 }
@@ -429,16 +419,14 @@ fn fast_forward_singleton<'p>(
     new_parent: &Coin,
 ) -> PyResult<Bound<'p, PyBytes>> {
     let mut a = make_allocator(ConsensusFlags::LIMIT_HEAP);
-    let puzzle = node_from_bytes(&mut a, spend.puzzle_reveal.as_slice())
-        .map_err(|e| map_pyerr_w_ptr(&e, &a))?;
-    let solution =
-        node_from_bytes(&mut a, spend.solution.as_slice()).map_err(|e| map_pyerr_w_ptr(&e, &a))?;
+    let puzzle = node_from_bytes(&mut a, spend.puzzle_reveal.as_slice()).map_err(map_pyerr)?;
+    let solution = node_from_bytes(&mut a, spend.solution.as_slice()).map_err(map_pyerr)?;
 
     let new_solution = native_ff(&mut a, puzzle, solution, &spend.coin, new_coin, new_parent)?;
     Ok(PyBytes::new(
         py,
         node_to_bytes(&a, new_solution)
-            .map_err(|e| map_pyerr_w_ptr(&e, &a))?
+            .map_err(map_pyerr)?
             .as_slice(),
     ))
 }

--- a/wheel/src/error.rs
+++ b/wheel/src/error.rs
@@ -1,13 +1,7 @@
-use clvmr::Allocator;
 use clvmr::error::EvalErr;
-use clvmr::serde::node_to_bytes;
 use pyo3::PyErr;
 use pyo3::exceptions::PyValueError;
 
 pub fn map_pyerr(err: EvalErr) -> PyErr {
     PyValueError::new_err(err.to_string())
-}
-pub fn map_pyerr_w_ptr(err: &EvalErr, alloc: &Allocator) -> PyErr {
-    let blob = node_to_bytes(alloc, err.node_ptr()).ok().map(hex::encode);
-    PyValueError::new_err((err.to_string(), blob))
 }

--- a/wheel/src/run_program.rs
+++ b/wheel/src/run_program.rs
@@ -1,4 +1,4 @@
-use crate::error::{map_pyerr, map_pyerr_w_ptr};
+use crate::error::map_pyerr;
 use chia_consensus::allocator::make_allocator;
 use chia_consensus::flags::ConsensusFlags;
 use chia_protocol::LazyNode;
@@ -44,15 +44,13 @@ pub fn run_chia_program(
     let flags = flags.to_clvm_flags();
 
     let reduction = (|| -> PyResult<Response> {
-        let program = node_from_bytes_backrefs(&mut allocator, program)
-            .map_err(|e| map_pyerr_w_ptr(&e, &allocator))?;
-        let args = node_from_bytes_backrefs(&mut allocator, args)
-            .map_err(|e| map_pyerr_w_ptr(&e, &allocator))?;
+        let program = node_from_bytes_backrefs(&mut allocator, program).map_err(map_pyerr)?;
+        let args = node_from_bytes_backrefs(&mut allocator, args).map_err(map_pyerr)?;
         let dialect = ChiaDialect::new(flags);
 
         Ok(py.detach(|| run_program(&mut allocator, &dialect, program, args, max_cost)))
     })()?
-    .map_err(|e| map_pyerr_w_ptr(&e, &allocator))?;
+    .map_err(map_pyerr)?;
     let val = LazyNode::new(Rc::new(allocator), reduction.1);
     Ok((reduction.0, val))
 }


### PR DESCRIPTION
simplify the error values we return to python. No caller looks at the `NodePtr` field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Python-facing exception payloads for CLVM execution/serialization errors, which may break callers that relied on the previous tuple `(message, node_blob)` format. Logic is otherwise a mechanical error-mapping refactor with low likelihood of affecting consensus behavior.
> 
> **Overview**
> **Python error reporting is simplified.** Removes `map_pyerr_w_ptr` and updates wheel bindings (`api.rs`, `run_program.rs`) to map `EvalErr` directly to `ValueError(err.to_string())`, dropping the extra serialized `NodePtr`/hex blob context.
> 
> **Dependencies/tests updated accordingly.** Removes the `hex` crate from the wheel build and adjusts `tests/test_program.py` expectations for raised errors to match the new string-only exception message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d09c6c35f28c107cd9fadea89125dc8d5fd1584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->