### PR TITLE
fix error in crates/chia-protocol/Cargo.toml

### DIFF
--- a/crates/chia-protocol/Cargo.toml
+++ b/crates/chia-protocol/Cargo.toml
@@ -17,7 +17,7 @@ arbitrary = ["dep:arbitrary", "chia-bls/arbitrary"]
 serde = ["dep:serde", "dep:chia-serde", "chia-bls/serde", "dep:serde_arrays"]
 
 [package.metadata.cargo-machete]
-ignored = "serde_arrays"
+ignored = [ "serde_arrays" ]
 
 [dependencies]
 pyo3 = { workspace = true, features = ["multiple-pymethods", "num-bigint"], optional = true }


### PR DESCRIPTION
to address:

```
error when handling ./crates/chia-protocol/Cargo.toml: TOML parse error at line 20, column 11
   |
20 | ignored = "serde_arrays"
   |           ^^^^^^^^^^^^^^
invalid type: string "serde_arrays", expected a sequence
: TOML parse error at line 20, column 11
   |
20 | ignored = "serde_arrays"
   |           ^^^^^^^^^^^^^^
invalid type: string "serde_arrays", expected a sequence
```

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4ad1e031e2e8fc92ef7982f9dc34f07ed65334e2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->