### PR TITLE
Remove (largely) unused NodePtr from ValidationError

### DIFF
--- a/crates/chia-consensus/fuzz/fuzz_targets/fast-forward.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/fast-forward.rs
@@ -166,8 +166,8 @@ fn test_ff(
     ];
 
     match (conditions1, conditions2) {
-        (Err(ValidationErr(n1, msg1)), Err(ValidationErr(n2, msg2))) => {
-            if msg1 != msg2 || node_to_bytes(a, n1).unwrap() != node_to_bytes(a, n2).unwrap() {
+        (Err(ValidationErr(msg1)), Err(ValidationErr(msg2))) => {
+            if msg1 != msg2 {
                 assert!(discrepancy_errors.contains(&msg1) || discrepancy_errors.contains(&msg2));
             }
         }
@@ -205,14 +205,14 @@ fn test_ff(
             assert_eq!(spend1.create_coin, spend2.create_coin);
             assert_eq!(spend1.flags, spend2.flags);
         }
-        (Ok(conditions1), Err(ValidationErr(_n2, msg2))) => {
+        (Ok(conditions1), Err(ValidationErr(msg2))) => {
             // if the spend is valid and becomes invalid when
             // rebased/fast-forwarded, it should at least not be considered
             // eligible.
             assert!((conditions1.spends[0].flags & ELIGIBLE_FOR_FF) == 0);
             assert!(discrepancy_errors.contains(&msg2));
         }
-        (Err(ValidationErr(_n1, msg1)), Ok(conditions2)) => {
+        (Err(ValidationErr(msg1)), Ok(conditions2)) => {
             // if the spend is invalid and becomes valid when
             // rebased/fast-forwarded, it should not be considered
             // eligible. This is a bit of a far-fetched scenario, but could

--- a/crates/chia-consensus/fuzz/fuzz_targets/run-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/run-generator.rs
@@ -29,7 +29,7 @@ fuzz_target!(|data: &[u8]| {
 
     #[allow(clippy::match_same_arms)]
     match (r1, r2) {
-        (Err(ValidationErr(_, ErrorCode::CostExceeded)), Ok(_)) => {
+        (Err(ValidationErr(ErrorCode::CostExceeded)), Ok(_)) => {
             // Since run_block_generator2 cost less, it's not a problem if the
             // original generator runs out of cost while the rust implementation
             // succeeds. This is part of its features.

--- a/crates/chia-consensus/fuzz/fuzz_targets/sanitize-uint.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/sanitize-uint.rs
@@ -21,8 +21,7 @@ fuzz_target!(|data: &[u8]| {
         Ok(SanitizedUint::PositiveOverflow) => {
             assert!(data.len() > 8);
         }
-        Err(ValidationErr(n, c)) => {
-            assert!(n == atom);
+        Err(ValidationErr(c)) => {
             assert!(c == ErrorCode::InvalidCoinAmount);
         }
     }
@@ -40,8 +39,7 @@ fuzz_target!(|data: &[u8]| {
         Ok(SanitizedUint::PositiveOverflow) => {
             assert!(data.len() > 4);
         }
-        Err(ValidationErr(n, c)) => {
-            assert!(n == atom);
+        Err(ValidationErr(c)) => {
             assert!(c == ErrorCode::InvalidCoinAmount);
         }
     }

--- a/crates/chia-consensus/src/additions_and_removals.rs
+++ b/crates/chia-consensus/src/additions_and_removals.rs
@@ -43,7 +43,7 @@ where
 
     let Reduction(clvm_cost, all_spends) = run_program(&mut a, &dialect, program, args, cost_left)?;
 
-    subtract_cost(&a, &mut cost_left, clvm_cost)?;
+    subtract_cost(&mut cost_left, clvm_cost)?;
     let all_spends = first(&a, all_spends)?;
 
     let mut cache = TreeCache::default();
@@ -59,7 +59,7 @@ where
         iter = rest;
         let (_parent_id, (puzzle, _rest)) =
             <(NodePtr, (NodePtr, NodePtr))>::from_clvm(&a, spend)
-                .map_err(|_| ValidationErr(spend, ErrorCode::InvalidCondition))?;
+                .map_err(|_| ValidationErr(ErrorCode::InvalidCondition))?;
         cache.visit_tree(&a, puzzle);
     }
 
@@ -69,13 +69,13 @@ where
         // process the spend
         let (parent_id, (puzzle, (amount, (solution, _spend_level_extra)))) =
             <(Bytes32, (NodePtr, (NodePtr, (NodePtr, NodePtr))))>::from_clvm(&a, spend)
-                .map_err(|_| ValidationErr(spend, ErrorCode::InvalidCondition))?;
+                .map_err(|_| ValidationErr(ErrorCode::InvalidCondition))?;
         let amount = parse_amount(&a, amount, ErrorCode::InvalidCoinAmount)?;
 
         let Reduction(clvm_cost, mut iter) =
             run_program(&mut a, &dialect, puzzle, solution, cost_left)?;
 
-        subtract_cost(&a, &mut cost_left, clvm_cost)?;
+        subtract_cost(&mut cost_left, clvm_cost)?;
 
         let puzzle_hash = tree_hash_cached(&a, puzzle, &mut cache);
 
@@ -104,7 +104,7 @@ where
 
             let (puzzle_hash, (amount, hint)) =
                 <(Bytes32, (NodePtr, NodePtr))>::from_clvm(&a, c)
-                    .map_err(|_| ValidationErr(c, ErrorCode::InvalidCondition))?;
+                    .map_err(|_| ValidationErr(ErrorCode::InvalidCondition))?;
             let amount = parse_amount(&a, amount, ErrorCode::InvalidCoinAmount)?;
 
             let coin = Coin {

--- a/crates/chia-consensus/src/condition_sanitizers.rs
+++ b/crates/chia-consensus/src/condition_sanitizers.rs
@@ -13,7 +13,7 @@ pub fn sanitize_hash(
     if buf.as_ref().len() == size {
         Ok(n)
     } else {
-        Err(ValidationErr(n, code))
+        Err(ValidationErr(code))
     }
 }
 
@@ -21,7 +21,7 @@ pub fn parse_amount(a: &Allocator, n: NodePtr, code: ErrorCode) -> Result<u64, V
     // amounts are not allowed to exceed 2^64. i.e. 8 bytes
     match sanitize_uint(a, n, 8, code)? {
         SanitizedUint::NegativeOverflow | SanitizedUint::PositiveOverflow => {
-            Err(ValidationErr(n, code))
+            Err(ValidationErr(code))
         }
         SanitizedUint::Ok(r) => Ok(r),
     }
@@ -35,7 +35,7 @@ pub fn sanitize_announce_msg(
     let buf = atom(a, n, code)?;
 
     if buf.as_ref().len() > 1024 {
-        Err(ValidationErr(n, code))
+        Err(ValidationErr(code))
     } else {
         Ok(n)
     }
@@ -43,11 +43,11 @@ pub fn sanitize_announce_msg(
 
 pub fn sanitize_message_mode(a: &Allocator, node: NodePtr) -> Result<u32, ValidationErr> {
     let Some(mode) = a.small_number(node) else {
-        return Err(ValidationErr(node, ErrorCode::InvalidMessageMode));
+        return Err(ValidationErr(ErrorCode::InvalidMessageMode));
     };
     // only 6 bits are allowed to be set
     if (mode & !0b11_1111) != 0 {
-        return Err(ValidationErr(node, ErrorCode::InvalidMessageMode));
+        return Err(ValidationErr(ErrorCode::InvalidMessageMode));
     }
     Ok(mode)
 }
@@ -82,7 +82,7 @@ fn test_sanitize_mode(#[case] value: i64, #[case] pass: bool) {
     if pass {
         assert_eq!(i64::from(ret.unwrap()), value);
     } else {
-        assert_eq!(ret.unwrap_err().1, ErrorCode::InvalidMessageMode);
+        assert_eq!(ret.unwrap_err().0, ErrorCode::InvalidMessageMode);
     }
 }
 
@@ -105,7 +105,7 @@ fn test_sanitize_hash() {
     let short_n = a.new_atom(&short).unwrap();
     assert_eq!(
         sanitize_hash(&a, short_n, 32, ErrorCode::InvalidCondition),
-        Err(ValidationErr(short_n, ErrorCode::InvalidCondition))
+        Err(ValidationErr(ErrorCode::InvalidCondition))
     );
     let valid_n = a.new_atom(&valid).unwrap();
     assert_eq!(
@@ -115,13 +115,13 @@ fn test_sanitize_hash() {
     let long_n = a.new_atom(&long).unwrap();
     assert_eq!(
         sanitize_hash(&a, long_n, 32, ErrorCode::InvalidCondition),
-        Err(ValidationErr(long_n, ErrorCode::InvalidCondition))
+        Err(ValidationErr(ErrorCode::InvalidCondition))
     );
 
     let pair = a.new_pair(short_n, long_n).unwrap();
     assert_eq!(
         sanitize_hash(&a, pair, 32, ErrorCode::InvalidCondition),
-        Err(ValidationErr(pair, ErrorCode::InvalidCondition))
+        Err(ValidationErr(ErrorCode::InvalidCondition))
     );
 }
 
@@ -139,13 +139,13 @@ fn test_sanitize_announce_msg() {
     let long_n = a.new_atom(&long).unwrap();
     assert_eq!(
         sanitize_announce_msg(&a, long_n, ErrorCode::InvalidCondition),
-        Err(ValidationErr(long_n, ErrorCode::InvalidCondition))
+        Err(ValidationErr(ErrorCode::InvalidCondition))
     );
 
     let pair = a.new_pair(valid_n, long_n).unwrap();
     assert_eq!(
         sanitize_announce_msg(&a, pair, ErrorCode::InvalidCondition),
-        Err(ValidationErr(pair, ErrorCode::InvalidCondition))
+        Err(ValidationErr(ErrorCode::InvalidCondition))
     );
 }
 
@@ -161,15 +161,15 @@ fn amount_tester(buf: &[u8]) -> Result<u64, ValidationErr> {
 fn test_sanitize_amount() {
     // negative amounts are not allowed
     assert_eq!(
-        amount_tester(&[0x80]).unwrap_err().1,
+        amount_tester(&[0x80]).unwrap_err().0,
         ErrorCode::InvalidCoinAmount
     );
     assert_eq!(
-        amount_tester(&[0xff]).unwrap_err().1,
+        amount_tester(&[0xff]).unwrap_err().0,
         ErrorCode::InvalidCoinAmount
     );
     assert_eq!(
-        amount_tester(&[0xff, 0]).unwrap_err().1,
+        amount_tester(&[0xff, 0]).unwrap_err().0,
         ErrorCode::InvalidCoinAmount
     );
 
@@ -177,19 +177,19 @@ fn test_sanitize_amount() {
     assert_eq!(amount_tester(&[0, 0xff]), Ok(0xff));
     // but are disallowed when they are redundant
     assert_eq!(
-        amount_tester(&[0, 0, 0, 0xff]).unwrap_err().1,
+        amount_tester(&[0, 0, 0, 0xff]).unwrap_err().0,
         ErrorCode::InvalidCoinAmount
     );
     assert_eq!(
-        amount_tester(&[0, 0, 0, 0x80]).unwrap_err().1,
+        amount_tester(&[0, 0, 0, 0x80]).unwrap_err().0,
         ErrorCode::InvalidCoinAmount
     );
     assert_eq!(
-        amount_tester(&[0, 0, 0, 0x7f]).unwrap_err().1,
+        amount_tester(&[0, 0, 0, 0x7f]).unwrap_err().0,
         ErrorCode::InvalidCoinAmount
     );
     assert_eq!(
-        amount_tester(&[0, 0, 0]).unwrap_err().1,
+        amount_tester(&[0, 0, 0]).unwrap_err().0,
         ErrorCode::InvalidCoinAmount
     );
 
@@ -197,7 +197,7 @@ fn test_sanitize_amount() {
     assert_eq!(
         amount_tester(&[0x7f, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::InvalidCoinAmount
     );
 

--- a/crates/chia-consensus/src/conditions.rs
+++ b/crates/chia-consensus/src/conditions.rs
@@ -354,7 +354,7 @@ fn check_agg_sig_unsafe_message(
         constants.agg_sig_parent_puzzle_additional_data.as_ref(),
     ] {
         if buf.as_ref().ends_with(additional_data) {
-            return Err(ValidationErr(msg, ErrorCode::InvalidMessage));
+            return Err(ValidationErr(ErrorCode::InvalidMessage));
         }
     }
     Ok(())
@@ -414,10 +414,10 @@ pub fn parse_args(
             let node = first(a, c)?;
             let amount = match sanitize_uint(a, node, 8, ErrorCode::InvalidCoinAmount)? {
                 SanitizedUint::PositiveOverflow => {
-                    return Err(ValidationErr(node, ErrorCode::CoinAmountExceedsMaximum));
+                    return Err(ValidationErr(ErrorCode::CoinAmountExceedsMaximum));
                 }
                 SanitizedUint::NegativeOverflow => {
-                    return Err(ValidationErr(node, ErrorCode::CoinAmountNegative));
+                    return Err(ValidationErr(ErrorCode::CoinAmountNegative));
                 }
                 SanitizedUint::Ok(amount) => amount,
             };
@@ -453,13 +453,13 @@ pub fn parse_args(
             if flags.contains(ConsensusFlags::NO_UNKNOWN_CONDS) {
                 // We don't know of any new softforked-in conditions, so they
                 // are all unknown
-                Err(ValidationErr(c, ErrorCode::InvalidConditionOpcode))
+                Err(ValidationErr(ErrorCode::InvalidConditionOpcode))
             } else {
                 match sanitize_uint(a, first(a, c)?, 4, ErrorCode::InvalidSoftforkCost)? {
                     // the first argument represents the cost of the condition.
                     // We scale it by 10000 to make the argument be a bit smaller
                     SanitizedUint::Ok(cost) => Ok(Condition::Softfork(cost * 10000)),
-                    _ => Err(ValidationErr(c, ErrorCode::InvalidSoftforkCost)),
+                    _ => Err(ValidationErr(ErrorCode::InvalidSoftforkCost)),
                 }
             }
         }
@@ -467,7 +467,7 @@ pub fn parse_args(
             // All of these conditions are unknown
             // but they have costs
             if flags.contains(ConsensusFlags::NO_UNKNOWN_CONDS) {
-                Err(ValidationErr(c, ErrorCode::InvalidConditionOpcode))
+                Err(ValidationErr(ErrorCode::InvalidConditionOpcode))
             } else {
                 Ok(Condition::Softfork(compute_unknown_condition_cost(op)))
             }
@@ -538,7 +538,7 @@ pub fn parse_args(
             let code = ErrorCode::AssertMyBirthSecondsFailed;
             match sanitize_uint(a, node, 8, code)? {
                 SanitizedUint::PositiveOverflow | SanitizedUint::NegativeOverflow => {
-                    Err(ValidationErr(node, code))
+                    Err(ValidationErr(code))
                 }
                 SanitizedUint::Ok(r) => Ok(Condition::AssertMyBirthSeconds(r)),
             }
@@ -549,7 +549,7 @@ pub fn parse_args(
             let code = ErrorCode::AssertMyBirthHeightFailed;
             match sanitize_uint(a, node, 4, code)? {
                 SanitizedUint::PositiveOverflow | SanitizedUint::NegativeOverflow => {
-                    Err(ValidationErr(node, code))
+                    Err(ValidationErr(code))
                 }
                 SanitizedUint::Ok(r) => Ok(Condition::AssertMyBirthHeight(r as u32)),
             }
@@ -566,7 +566,7 @@ pub fn parse_args(
             let node = first(a, c)?;
             let code = ErrorCode::AssertSecondsRelativeFailed;
             match sanitize_uint(a, node, 8, code)? {
-                SanitizedUint::PositiveOverflow => Err(ValidationErr(node, code)),
+                SanitizedUint::PositiveOverflow => Err(ValidationErr(code)),
                 SanitizedUint::NegativeOverflow => Ok(Condition::SkipRelativeCondition),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertSecondsRelative(r)),
             }
@@ -576,7 +576,7 @@ pub fn parse_args(
             let node = first(a, c)?;
             let code = ErrorCode::AssertSecondsAbsoluteFailed;
             match sanitize_uint(a, node, 8, code)? {
-                SanitizedUint::PositiveOverflow => Err(ValidationErr(node, code)),
+                SanitizedUint::PositiveOverflow => Err(ValidationErr(code)),
                 SanitizedUint::NegativeOverflow => Ok(Condition::Skip),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertSecondsAbsolute(r)),
             }
@@ -586,7 +586,7 @@ pub fn parse_args(
             let node = first(a, c)?;
             let code = ErrorCode::AssertHeightRelativeFailed;
             match sanitize_uint(a, node, 4, code)? {
-                SanitizedUint::PositiveOverflow => Err(ValidationErr(node, code)),
+                SanitizedUint::PositiveOverflow => Err(ValidationErr(code)),
                 SanitizedUint::NegativeOverflow => Ok(Condition::SkipRelativeCondition),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertHeightRelative(r as u32)),
             }
@@ -596,7 +596,7 @@ pub fn parse_args(
             let node = first(a, c)?;
             let code = ErrorCode::AssertHeightAbsoluteFailed;
             match sanitize_uint(a, node, 4, code)? {
-                SanitizedUint::PositiveOverflow => Err(ValidationErr(node, code)),
+                SanitizedUint::PositiveOverflow => Err(ValidationErr(code)),
                 SanitizedUint::NegativeOverflow => Ok(Condition::Skip),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertHeightAbsolute(r as u32)),
             }
@@ -607,7 +607,7 @@ pub fn parse_args(
             let code = ErrorCode::AssertBeforeSecondsRelativeFailed;
             match sanitize_uint(a, node, 8, code)? {
                 SanitizedUint::PositiveOverflow => Ok(Condition::SkipRelativeCondition),
-                SanitizedUint::NegativeOverflow => Err(ValidationErr(node, code)),
+                SanitizedUint::NegativeOverflow => Err(ValidationErr(code)),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertBeforeSecondsRelative(r)),
             }
         }
@@ -618,7 +618,7 @@ pub fn parse_args(
             let code = ErrorCode::AssertBeforeSecondsAbsoluteFailed;
             match sanitize_uint(a, node, 8, code)? {
                 SanitizedUint::PositiveOverflow => Ok(Condition::Skip),
-                SanitizedUint::NegativeOverflow => Err(ValidationErr(node, code)),
+                SanitizedUint::NegativeOverflow => Err(ValidationErr(code)),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertBeforeSecondsAbsolute(r)),
             }
         }
@@ -628,7 +628,7 @@ pub fn parse_args(
             let code = ErrorCode::AssertBeforeHeightRelativeFailed;
             match sanitize_uint(a, node, 4, code)? {
                 SanitizedUint::PositiveOverflow => Ok(Condition::SkipRelativeCondition),
-                SanitizedUint::NegativeOverflow => Err(ValidationErr(node, code)),
+                SanitizedUint::NegativeOverflow => Err(ValidationErr(code)),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertBeforeHeightRelative(r as u32)),
             }
         }
@@ -638,7 +638,7 @@ pub fn parse_args(
             let code = ErrorCode::AssertBeforeHeightAbsoluteFailed;
             match sanitize_uint(a, node, 4, code)? {
                 SanitizedUint::PositiveOverflow => Ok(Condition::Skip),
-                SanitizedUint::NegativeOverflow => Err(ValidationErr(node, code)),
+                SanitizedUint::NegativeOverflow => Err(ValidationErr(code)),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertBeforeHeightAbsolute(r as u32)),
             }
         }
@@ -679,7 +679,7 @@ pub fn parse_args(
             // this condition is always true, we always ignore arguments
             Ok(Condition::Skip)
         }
-        _ => Err(ValidationErr(c, ErrorCode::InvalidConditionOpcode)),
+        _ => Err(ValidationErr(ErrorCode::InvalidConditionOpcode)),
     }
 }
 
@@ -956,7 +956,7 @@ pub fn process_single_spend<'a, V: SpendVisitor>(
     {
         // if this coin ID has already been added to this set, it's a double
         // spend
-        return Err(ValidationErr(parent_id, ErrorCode::DoubleSpend));
+        return Err(ValidationErr(ErrorCode::DoubleSpend));
     }
 
     state.spent_puzzles.insert(puzzle_hash);
@@ -967,7 +967,7 @@ pub fn process_single_spend<'a, V: SpendVisitor>(
 
     if flags.contains(ConsensusFlags::COST_CONDITIONS) {
         if *max_cost < SPEND_COST {
-            return Err(ValidationErr(parent_id, ErrorCode::CostExceeded));
+            return Err(ValidationErr(ErrorCode::CostExceeded));
         }
         *max_cost -= SPEND_COST;
         ret.condition_cost += SPEND_COST;
@@ -998,9 +998,9 @@ fn assert_not_ephemeral(spend_flags: &mut u32, state: &mut ParseState, idx: usiz
     *spend_flags |= HAS_RELATIVE_CONDITION;
 }
 
-fn decrement(cnt: &mut u32, n: NodePtr) -> Result<(), ValidationErr> {
+fn decrement(cnt: &mut u32) -> Result<(), ValidationErr> {
     if *cnt == 0 {
-        Err(ValidationErr(n, ErrorCode::TooManyAnnouncements))
+        Err(ValidationErr(ErrorCode::TooManyAnnouncements))
     } else {
         *cnt -= 1;
         Ok(())
@@ -1009,9 +1009,9 @@ fn decrement(cnt: &mut u32, n: NodePtr) -> Result<(), ValidationErr> {
 
 fn to_key(a: &Allocator, pk: NodePtr) -> Result<PublicKey, ValidationErr> {
     let key = PublicKey::from_bytes(a.atom(pk).as_ref().try_into().expect("internal error"))
-        .map_err(|_| ValidationErr(pk, ErrorCode::InvalidPublicKey))?;
+        .map_err(|_| ValidationErr(ErrorCode::InvalidPublicKey))?;
     if key.is_inf() {
-        Err(ValidationErr(pk, ErrorCode::InvalidPublicKey))
+        Err(ValidationErr(ErrorCode::InvalidPublicKey))
     } else {
         Ok(key)
     }
@@ -1037,13 +1037,13 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
         let Some(op) = parse_opcode(a, first(a, c)?, flags) else {
             // in strict mode we don't allow unknown conditions
             if flags.contains(ConsensusFlags::NO_UNKNOWN_CONDS) {
-                return Err(ValidationErr(c, ErrorCode::InvalidConditionOpcode));
+                return Err(ValidationErr(ErrorCode::InvalidConditionOpcode));
             }
             // in consensus-mode, we ignore unknown conditions, but still charge
             // cost for them
             if flags.contains(ConsensusFlags::COST_CONDITIONS) {
                 if *max_cost < GENERIC_CONDITION_COST {
-                    return Err(ValidationErr(c, ErrorCode::CostExceeded));
+                    return Err(ValidationErr(ErrorCode::CostExceeded));
                 }
                 *max_cost -= GENERIC_CONDITION_COST;
                 ret.condition_cost += GENERIC_CONDITION_COST;
@@ -1062,7 +1062,7 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
                     CREATE_COIN_COST
                 };
                 if *max_cost < cost {
-                    return Err(ValidationErr(c, ErrorCode::CostExceeded));
+                    return Err(ValidationErr(ErrorCode::CostExceeded));
                 }
                 *max_cost -= cost;
                 ret.condition_cost += cost;
@@ -1077,7 +1077,7 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
             | AGG_SIG_PARENT_PUZZLE
             | AGG_SIG_PARENT_AMOUNT => {
                 if *max_cost < AGG_SIG_COST {
-                    return Err(ValidationErr(c, ErrorCode::CostExceeded));
+                    return Err(ValidationErr(ErrorCode::CostExceeded));
                 }
                 *max_cost -= AGG_SIG_COST;
                 ret.condition_cost += AGG_SIG_COST;
@@ -1093,7 +1093,7 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
             | RECEIVE_MESSAGE => {
                 if flags.contains(ConsensusFlags::COST_CONDITIONS) {
                     if *max_cost < MESSAGE_CONDITION_COST {
-                        return Err(ValidationErr(c, ErrorCode::CostExceeded));
+                        return Err(ValidationErr(ErrorCode::CostExceeded));
                     }
                     *max_cost -= MESSAGE_CONDITION_COST;
                     ret.condition_cost += MESSAGE_CONDITION_COST;
@@ -1103,7 +1103,7 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
             _ => {
                 if flags.contains(ConsensusFlags::COST_CONDITIONS) {
                     if *max_cost < GENERIC_CONDITION_COST {
-                        return Err(ValidationErr(c, ErrorCode::CostExceeded));
+                        return Err(ValidationErr(ErrorCode::CostExceeded));
                     }
                     *max_cost -= GENERIC_CONDITION_COST;
                     ret.condition_cost += GENERIC_CONDITION_COST;
@@ -1120,7 +1120,7 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
                 ret.reserve_fee = ret
                     .reserve_fee
                     .checked_add(limit)
-                    .ok_or(ValidationErr(c, ErrorCode::ReserveFeeConditionFailed))?;
+                    .ok_or(ValidationErr(ErrorCode::ReserveFeeConditionFailed))?;
             }
             Condition::CreateCoin(ph, amount, hint) => {
                 let new_coin = NewCoin {
@@ -1129,7 +1129,7 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
                     hint,
                 };
                 if !spend.create_coin.insert(new_coin) {
-                    return Err(ValidationErr(c, ErrorCode::DuplicateOutput));
+                    return Err(ValidationErr(ErrorCode::DuplicateOutput));
                 }
                 ret.addition_amount += amount as u128;
             }
@@ -1146,7 +1146,6 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
                         // timestamp and also *after* a timestamp that's the
                         // same or later. that's impossible.
                         return Err(ValidationErr(
-                            c,
                             ErrorCode::ImpossibleSecondsRelativeConstraints,
                         ));
                     }
@@ -1170,7 +1169,6 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
                         // height and also *after* a height that's the
                         // same or later. that's impossible.
                         return Err(ValidationErr(
-                            c,
                             ErrorCode::ImpossibleHeightRelativeConstraints,
                         ));
                     }
@@ -1194,7 +1192,6 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
                         // timestamp and also *after* a timestamp that's the
                         // same or later. that's impossible.
                         return Err(ValidationErr(
-                            c,
                             ErrorCode::ImpossibleSecondsRelativeConstraints,
                         ));
                     }
@@ -1222,7 +1219,6 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
                         // height and also *after* a height that's the
                         // same or later. that's impossible.
                         return Err(ValidationErr(
-                            c,
                             ErrorCode::ImpossibleHeightRelativeConstraints,
                         ));
                     }
@@ -1239,12 +1235,12 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
             }
             Condition::AssertMyCoinId(id) => {
                 if a.atom(id).as_ref() != (*spend.coin_id).as_ref() {
-                    return Err(ValidationErr(c, ErrorCode::AssertMyCoinIdFailed));
+                    return Err(ValidationErr(ErrorCode::AssertMyCoinIdFailed));
                 }
             }
             Condition::AssertMyAmount(amount) => {
                 if amount != spend.coin_amount {
-                    return Err(ValidationErr(c, ErrorCode::AssertMyAmountFailed));
+                    return Err(ValidationErr(ErrorCode::AssertMyAmountFailed));
                 }
             }
             Condition::AssertMyBirthSeconds(s) => {
@@ -1252,7 +1248,7 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
                 // error if it's different from the new birth assertion. One of
                 // them must be false
                 if spend.birth_seconds.is_some_and(|v| v != s) {
-                    return Err(ValidationErr(c, ErrorCode::AssertMyBirthSecondsFailed));
+                    return Err(ValidationErr(ErrorCode::AssertMyBirthSecondsFailed));
                 }
                 spend.birth_seconds = Some(s);
                 assert_not_ephemeral(&mut spend.flags, state, ret.spends.len());
@@ -1262,7 +1258,7 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
                 // error if it's different from the new birth assertion. One of
                 // them must be false
                 if spend.birth_height.is_some_and(|v| v != h) {
-                    return Err(ValidationErr(c, ErrorCode::AssertMyBirthHeightFailed));
+                    return Err(ValidationErr(ErrorCode::AssertMyBirthHeightFailed));
                 }
                 spend.birth_height = Some(h);
                 assert_not_ephemeral(&mut spend.flags, state, ret.spends.len());
@@ -1272,47 +1268,47 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
             }
             Condition::AssertMyParentId(id) => {
                 if a.atom(id).as_ref() != a.atom(spend.parent_id).as_ref() {
-                    return Err(ValidationErr(c, ErrorCode::AssertMyParentIdFailed));
+                    return Err(ValidationErr(ErrorCode::AssertMyParentIdFailed));
                 }
             }
             Condition::AssertMyPuzzlehash(hash) => {
                 if a.atom(hash).as_ref() != a.atom(spend.puzzle_hash).as_ref() {
-                    return Err(ValidationErr(c, ErrorCode::AssertMyPuzzleHashFailed));
+                    return Err(ValidationErr(ErrorCode::AssertMyPuzzleHashFailed));
                 }
             }
             Condition::CreateCoinAnnouncement(msg) => {
                 if !flags.contains(ConsensusFlags::COST_CONDITIONS) {
-                    decrement(&mut announce_countdown, msg)?;
+                    decrement(&mut announce_countdown)?;
                 }
                 state.announce_coin.insert((spend.coin_id.clone(), msg));
             }
             Condition::CreatePuzzleAnnouncement(msg) => {
                 if !flags.contains(ConsensusFlags::COST_CONDITIONS) {
-                    decrement(&mut announce_countdown, msg)?;
+                    decrement(&mut announce_countdown)?;
                 }
                 state.announce_puzzle.insert((spend.puzzle_hash, msg));
             }
             Condition::AssertCoinAnnouncement(msg) => {
                 if !flags.contains(ConsensusFlags::COST_CONDITIONS) {
-                    decrement(&mut announce_countdown, msg)?;
+                    decrement(&mut announce_countdown)?;
                 }
                 state.assert_coin.insert(msg);
             }
             Condition::AssertPuzzleAnnouncement(msg) => {
                 if !flags.contains(ConsensusFlags::COST_CONDITIONS) {
-                    decrement(&mut announce_countdown, msg)?;
+                    decrement(&mut announce_countdown)?;
                 }
                 state.assert_puzzle.insert(msg);
             }
             Condition::AssertConcurrentSpend(id) => {
                 if !flags.contains(ConsensusFlags::COST_CONDITIONS) {
-                    decrement(&mut announce_countdown, id)?;
+                    decrement(&mut announce_countdown)?;
                 }
                 state.assert_concurrent_spend.insert(id);
             }
             Condition::AssertConcurrentPuzzle(id) => {
                 if !flags.contains(ConsensusFlags::COST_CONDITIONS) {
-                    decrement(&mut announce_countdown, id)?;
+                    decrement(&mut announce_countdown)?;
                 }
                 state.assert_concurrent_puzzle.insert(id);
             }
@@ -1395,7 +1391,7 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
             }
             Condition::Softfork(cost) => {
                 if *max_cost < cost {
-                    return Err(ValidationErr(c, ErrorCode::CostExceeded));
+                    return Err(ValidationErr(ErrorCode::CostExceeded));
                 }
                 *max_cost -= cost;
                 ret.condition_cost += cost;
@@ -1403,7 +1399,7 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
             }
             Condition::SendMessage(src_mode, dst, msg) => {
                 if !flags.contains(ConsensusFlags::COST_CONDITIONS) {
-                    decrement(&mut announce_countdown, msg)?;
+                    decrement(&mut announce_countdown)?;
                 }
                 let src = SpendId::from_self(
                     src_mode,
@@ -1421,7 +1417,7 @@ pub fn parse_conditions<'a, V: SpendVisitor>(
             }
             Condition::ReceiveMessage(src, dst_mode, msg) => {
                 if !flags.contains(ConsensusFlags::COST_CONDITIONS) {
-                    decrement(&mut announce_countdown, msg)?;
+                    decrement(&mut announce_countdown)?;
                 }
                 let dst = SpendId::from_self(
                     dst_mode,
@@ -1503,7 +1499,7 @@ pub fn parse_spends<V: SpendVisitor>(
     while let Some((spend, next)) = next(a, iter)? {
         iter = next;
         if spends_left == 0 {
-            return Err(ValidationErr(spend, ErrorCode::TooManySpends));
+            return Err(ValidationErr(ErrorCode::TooManySpends));
         }
         spends_left -= 1;
         // cost_left is passed in as a mutable reference and decremented by the
@@ -1529,7 +1525,7 @@ pub fn parse_spends<V: SpendVisitor>(
     }
 
     V::post_process(a, &state, &mut ret)?;
-    validate_conditions(a, &ret, &state, spends, flags)?;
+    validate_conditions(a, &ret, &state, flags)?;
     validate_signature(&state, aggregate_signature, flags, bls_cache)?;
     ret.validated_signature = !flags.contains(ConsensusFlags::DONT_VALIDATE_SIGNATURE);
 
@@ -1541,18 +1537,17 @@ pub fn validate_conditions(
     a: &Allocator,
     ret: &SpendBundleConditions,
     state: &ParseState,
-    spends: NodePtr,
     _flags: ConsensusFlags,
 ) -> Result<(), ValidationErr> {
     if ret.removal_amount < ret.addition_amount {
         // The sum of removal amounts must not be less than the sum of addition
         // amounts
-        return Err(ValidationErr(spends, ErrorCode::MintingCoin));
+        return Err(ValidationErr(ErrorCode::MintingCoin));
     }
 
     if ret.removal_amount - ret.addition_amount < ret.reserve_fee as u128 {
         // the actual fee is lower than the reserved fee
-        return Err(ValidationErr(spends, ErrorCode::ReserveFeeConditionFailed));
+        return Err(ValidationErr(ErrorCode::ReserveFeeConditionFailed));
     }
 
     if let Some(bh) = ret.before_height_absolute {
@@ -1561,7 +1556,6 @@ pub fn validate_conditions(
             // height and also *after* a height that's the
             // same or later. that's impossible.
             return Err(ValidationErr(
-                spends,
                 ErrorCode::ImpossibleHeightAbsoluteConstraints,
             ));
         }
@@ -1573,7 +1567,6 @@ pub fn validate_conditions(
             // timestamp and also *after* a timestamp that's the
             // same or later. that's impossible.
             return Err(ValidationErr(
-                spends,
                 ErrorCode::ImpossibleSecondsAbsoluteConstraints,
             ));
         }
@@ -1585,10 +1578,7 @@ pub fn validate_conditions(
             .spent_coins
             .contains_key(&Bytes32::try_from(a.atom(*coin_id).as_ref()).unwrap())
         {
-            return Err(ValidationErr(
-                *coin_id,
-                ErrorCode::AssertConcurrentSpendFailed,
-            ));
+            return Err(ValidationErr(ErrorCode::AssertConcurrentSpendFailed));
         }
     }
 
@@ -1603,10 +1593,7 @@ pub fn validate_conditions(
 
         for puzzle_assert in &state.assert_concurrent_puzzle {
             if !spent_phs.contains(&a.atom(*puzzle_assert).as_ref().try_into().unwrap()) {
-                return Err(ValidationErr(
-                    *puzzle_assert,
-                    ErrorCode::AssertConcurrentPuzzleFailed,
-                ));
+                return Err(ValidationErr(ErrorCode::AssertConcurrentPuzzleFailed));
             }
         }
     }
@@ -1626,10 +1613,7 @@ pub fn validate_conditions(
 
         for coin_assert in &state.assert_coin {
             if !announcements.contains(&a.atom(*coin_assert).as_ref().try_into().unwrap()) {
-                return Err(ValidationErr(
-                    *coin_assert,
-                    ErrorCode::AssertCoinAnnouncementFailed,
-                ));
+                return Err(ValidationErr(ErrorCode::AssertCoinAnnouncementFailed));
             }
         }
     }
@@ -1637,10 +1621,7 @@ pub fn validate_conditions(
     for spend_idx in &state.assert_ephemeral {
         // make sure this coin was created in this block
         if !is_ephemeral(a, *spend_idx, &state.spent_coins, &ret.spends) {
-            return Err(ValidationErr(
-                ret.spends[*spend_idx].parent_id,
-                ErrorCode::AssertEphemeralFailed,
-            ));
+            return Err(ValidationErr(ErrorCode::AssertEphemeralFailed));
         }
     }
 
@@ -1649,10 +1630,7 @@ pub fn validate_conditions(
         // because consensus rules do not allow relative conditions on
         // ephemeral spends
         if is_ephemeral(a, *spend_idx, &state.spent_coins, &ret.spends) {
-            return Err(ValidationErr(
-                ret.spends[*spend_idx].parent_id,
-                ErrorCode::EphemeralRelativeCondition,
-            ));
+            return Err(ValidationErr(ErrorCode::EphemeralRelativeCondition));
         }
     }
 
@@ -1669,10 +1647,7 @@ pub fn validate_conditions(
 
         for puzzle_assert in &state.assert_puzzle {
             if !announcements.contains(&a.atom(*puzzle_assert).as_ref().try_into().unwrap()) {
-                return Err(ValidationErr(
-                    *puzzle_assert,
-                    ErrorCode::AssertPuzzleAnnouncementFailed,
-                ));
+                return Err(ValidationErr(ErrorCode::AssertPuzzleAnnouncementFailed));
             }
         }
     }
@@ -1690,10 +1665,7 @@ pub fn validate_conditions(
 
         for count in messages.values() {
             if *count != 0 {
-                return Err(ValidationErr(
-                    NodePtr::NIL,
-                    ErrorCode::MessageNotSentOrReceived,
-                ));
+                return Err(ValidationErr(ErrorCode::MessageNotSentOrReceived));
             }
         }
     }
@@ -1720,19 +1692,13 @@ pub fn validate_signature(
             state.pkm_pairs.iter().map(|(pk, msg)| (pk, msg.as_slice())),
             signature,
         ) {
-            return Err(ValidationErr(
-                NodePtr::NIL,
-                ErrorCode::BadAggregateSignature,
-            ));
+            return Err(ValidationErr(ErrorCode::BadAggregateSignature));
         }
     } else if !aggregate_verify(
         signature,
         state.pkm_pairs.iter().map(|(pk, msg)| (pk, msg.as_slice())),
     ) {
-        return Err(ValidationErr(
-            NodePtr::NIL,
-            ErrorCode::BadAggregateSignature,
-        ));
+        return Err(ValidationErr(ErrorCode::BadAggregateSignature));
     }
     Ok(())
 }
@@ -2039,7 +2005,7 @@ fn cond_test_sig(
 #[test]
 fn test_invalid_condition_list1() {
     assert_eq!(
-        cond_test("((({h1} ({h2} (123 (8 )))").unwrap_err().1,
+        cond_test("((({h1} ({h2} (123 (8 )))").unwrap_err().0,
         ErrorCode::InvalidCondition
     );
 }
@@ -2047,7 +2013,7 @@ fn test_invalid_condition_list1() {
 #[test]
 fn test_invalid_condition_list2() {
     assert_eq!(
-        cond_test("((({h1} ({h2} (123 ((8 ))))").unwrap_err().1,
+        cond_test("((({h1} ({h2} (123 ((8 ))))").unwrap_err().0,
         ErrorCode::InvalidCondition
     );
 }
@@ -2080,7 +2046,7 @@ fn test_invalid_condition_args_terminator_mempool() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((80 (50 8 ))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::InvalidCondition
     );
 }
@@ -2110,7 +2076,7 @@ fn test_invalid_condition_list_terminator_mempool() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((80 (50 8 ))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::InvalidCondition
     );
 }
@@ -2119,7 +2085,7 @@ fn test_invalid_condition_list_terminator_mempool() {
 fn test_invalid_condition_short_list_terminator() {
     // ASSERT_SECONDS_RELATIVE
     assert_eq!(
-        cond_test("((({h1} ({h2} (123 (((80 8 ))))").unwrap_err().1,
+        cond_test("((({h1} ({h2} (123 (((80 8 ))))").unwrap_err().0,
         ErrorCode::InvalidCondition
     );
 }
@@ -2127,7 +2093,7 @@ fn test_invalid_condition_short_list_terminator() {
 #[test]
 fn test_invalid_spend_list1() {
     assert_eq!(
-        cond_test("(8 )").unwrap_err().1,
+        cond_test("(8 )").unwrap_err().0,
         ErrorCode::InvalidCondition
     );
 }
@@ -2135,7 +2101,7 @@ fn test_invalid_spend_list1() {
 #[test]
 fn test_invalid_spend_list2() {
     assert_eq!(
-        cond_test("((8 ))").unwrap_err().1,
+        cond_test("((8 ))").unwrap_err().0,
         ErrorCode::InvalidCondition
     );
 }
@@ -2143,7 +2109,7 @@ fn test_invalid_spend_list2() {
 #[test]
 fn test_invalid_spend_list_terminator() {
     assert_eq!(
-        cond_test("((({h1} ({h2} (123 (()) 8 ))").unwrap_err().1,
+        cond_test("((({h1} ({h2} (123 (()) 8 ))").unwrap_err().0,
         ErrorCode::InvalidCondition
     );
 }
@@ -2196,17 +2162,17 @@ fn test_strict_args_count(
     if flags.is_empty() {
         // two of the cases won't pass, even when garbage at the end is allowed.
         if condition == ASSERT_COIN_ANNOUNCEMENT {
-            assert_eq!(ret.unwrap_err().1, ErrorCode::AssertCoinAnnouncementFailed,);
+            assert_eq!(ret.unwrap_err().0, ErrorCode::AssertCoinAnnouncementFailed,);
         } else if condition == ASSERT_PUZZLE_ANNOUNCEMENT {
             assert_eq!(
-                ret.unwrap_err().1,
+                ret.unwrap_err().0,
                 ErrorCode::AssertPuzzleAnnouncementFailed,
             );
         } else {
             assert!(ret.is_ok());
         }
     } else {
-        assert_eq!(ret.unwrap_err().1, ErrorCode::InvalidCondition);
+        assert_eq!(ret.unwrap_err().0, ErrorCode::InvalidCondition);
     }
 }
 
@@ -2241,7 +2207,7 @@ fn test_message_strict_args_count(
     if flags.is_empty() {
         ret.unwrap();
     } else {
-        assert_eq!(ret.unwrap_err().1, ErrorCode::InvalidCondition);
+        assert_eq!(ret.unwrap_err().0, ErrorCode::InvalidCondition);
     }
 }
 
@@ -2303,7 +2269,7 @@ fn test_extra_arg(
             MEMPOOL_MODE,
         )
         .unwrap_err()
-        .1,
+        .0,
         ErrorCode::InvalidCondition
     );
 
@@ -2496,7 +2462,7 @@ fn test_single_condition_failure(
         condition as u8, arg
     ))
     .unwrap_err()
-    .1;
+    .0;
 
     assert_eq!(err, expected_error);
 }
@@ -2574,7 +2540,7 @@ fn test_missing_arg(#[case] condition: ConditionOpcode) {
             ConsensusFlags::empty()
         )
         .unwrap_err()
-        .1,
+        .0,
         ErrorCode::InvalidCondition
     );
 }
@@ -2604,7 +2570,7 @@ fn test_reserve_fee_exceed_max() {
     assert_eq!(
         cond_test("((({h1} ({h2} (0x00ffffffffffffffff (((52 (0x00fffffffffffffff0 ))) (({h2} ({h1} (0x00ffffff (((52 (0x10 )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::ReserveFeeConditionFailed
     );
 }
@@ -2616,7 +2582,7 @@ fn test_reserve_fee_insufficient_spends() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((52 (124 ) ))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::ReserveFeeConditionFailed
     );
 }
@@ -2629,7 +2595,7 @@ fn test_reserve_fee_insufficient_fee() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((52 (100 ) ((51 ({h2} (24 )) )))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::ReserveFeeConditionFailed
     );
 }
@@ -2672,7 +2638,7 @@ fn test_failing_coin_consume() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((61 ({c11} )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::AssertCoinAnnouncementFailed
     );
 }
@@ -2684,7 +2650,7 @@ fn test_coin_announce_mismatch() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((60 ({msg1} ) ((61 ({c12} )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::AssertCoinAnnouncementFailed
     );
 }
@@ -2725,7 +2691,7 @@ fn test_failing_puzzle_consume() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((63 ({p21} )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::AssertPuzzleAnnouncementFailed
     );
 }
@@ -2737,7 +2703,7 @@ fn test_puzzle_announce_mismatch() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((62 ({msg1} ) ((63 ({p11} )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::AssertPuzzleAnnouncementFailed
     );
 }
@@ -2748,7 +2714,7 @@ fn test_single_assert_my_amount_exceed_max() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((73 (0x010000000000000000 )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::AssertMyAmountFailed
     );
 }
@@ -2763,7 +2729,7 @@ fn test_single_assert_my_amount_overlong() {
             ConsensusFlags::empty()
         )
         .unwrap_err()
-        .1,
+        .0,
         ErrorCode::AssertMyAmountFailed
     );
 }
@@ -2775,7 +2741,7 @@ fn test_single_assert_my_amount_overlong_mempool() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((73 (0x0000007b )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::AssertMyAmountFailed
     );
 }
@@ -2799,7 +2765,7 @@ fn test_multiple_failing_assert_my_amount() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((73 (123 ) ((73 (122 ) ))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::AssertMyAmountFailed
     );
 }
@@ -2810,7 +2776,7 @@ fn test_single_failing_assert_my_amount() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((73 (124 ) ))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::AssertMyAmountFailed
     );
 }
@@ -2825,7 +2791,7 @@ fn test_single_assert_my_coin_id_overlong() {
             ConsensusFlags::empty()
         )
         .unwrap_err()
-        .1,
+        .0,
         ErrorCode::InvalidCoinAmount
     );
 }
@@ -2850,7 +2816,7 @@ fn test_single_assert_my_coin_id_mismatch() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((70 ({coin11} )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::AssertMyCoinIdFailed
     );
 }
@@ -2863,7 +2829,7 @@ fn test_multiple_assert_my_coin_id_mismatch() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((60 (123 ))) (({h1} ({h1} (123 (((70 ({coin12} )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::AssertMyCoinIdFailed
     );
 }
@@ -2887,7 +2853,7 @@ fn test_single_assert_my_parent_coin_id_mismatch() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((71 ({h2} )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::AssertMyParentIdFailed
     );
 }
@@ -2899,7 +2865,7 @@ fn test_single_invalid_assert_my_parent_coin_id() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((71 ({long} )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::AssertMyParentIdFailed
     );
 }
@@ -2925,7 +2891,7 @@ fn test_single_assert_my_puzzle_hash_mismatch() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((72 ({h1} )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::AssertMyPuzzleHashFailed
     );
 }
@@ -2937,7 +2903,7 @@ fn test_single_invalid_assert_my_puzzle_hash() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((72 ({long} )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::AssertMyPuzzleHashFailed
     );
 }
@@ -2993,7 +2959,7 @@ fn test_minting_coin() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((51 ({h2} (124 )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::MintingCoin
     );
 }
@@ -3004,7 +2970,7 @@ fn test_create_coin_amount_exceeds_max() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((51 ({h2} (0x010000000000000000 )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::CoinAmountExceedsMaximum
     );
 }
@@ -3015,7 +2981,7 @@ fn test_create_coin_negative_amount() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((51 ({h2} (-1 )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::CoinAmountNegative
     );
 }
@@ -3026,7 +2992,7 @@ fn test_create_coin_invalid_puzzlehash() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((51 ({long} (42 )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::InvalidPuzzleHash
     );
 }
@@ -3153,7 +3119,7 @@ fn test_create_coin_with_invalid_hint_as_terminator_mempool() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((51 ({h2} (42 {h1}))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::InvalidCondition
     );
 }
@@ -3301,7 +3267,7 @@ fn test_create_coin_exceed_cost() {
             None,
         )
         .unwrap_err()
-        .1,
+        .0,
         ErrorCode::CostExceeded
     );
 }
@@ -3312,7 +3278,7 @@ fn test_duplicate_create_coin() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((51 ({h2} (42 ) ((51 ({h2} (42 ) ))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::DuplicateOutput
     );
 }
@@ -3323,7 +3289,7 @@ fn test_duplicate_create_coin_with_hint() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((51 ({h2} (42 (({h1})) ((51 ({h2} (42 ) ))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::DuplicateOutput
     );
 }
@@ -3443,7 +3409,7 @@ fn test_agg_sig_invalid_pubkey(
             mempool | ConsensusFlags::DONT_VALIDATE_SIGNATURE
         )
         .unwrap_err()
-        .1,
+        .0,
         ErrorCode::InvalidPublicKey
     );
 }
@@ -3470,7 +3436,7 @@ fn test_agg_sig_infinity_pubkey(
         mempool,
     );
 
-    assert_eq!(ret.unwrap_err().1, ErrorCode::InvalidPublicKey);
+    assert_eq!(ret.unwrap_err().0, ErrorCode::InvalidPublicKey);
 }
 
 #[cfg(test)]
@@ -3495,7 +3461,7 @@ fn test_agg_sig_invalid_msg(
             mempool
         )
         .unwrap_err()
-        .1,
+        .0,
         ErrorCode::InvalidMessage
     );
 }
@@ -3536,7 +3502,7 @@ fn test_agg_sig_exceed_cost(#[case] condition: ConditionOpcode) {
             None,
         )
         .unwrap_err()
-        .1,
+        .0,
         ErrorCode::CostExceeded
     );
 }
@@ -3612,7 +3578,7 @@ fn test_agg_sig_extra_arg(#[case] condition: ConditionOpcode) {
             MEMPOOL_MODE,
         )
         .unwrap_err()
-        .1,
+        .0,
         ErrorCode::InvalidCondition
     );
 }
@@ -3709,7 +3675,7 @@ fn test_agg_sig_unsafe_invalid_pubkey() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((49 ({h2} ({msg1} )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::InvalidPublicKey
     );
 }
@@ -3720,7 +3686,7 @@ fn test_agg_sig_unsafe_long_msg() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 (((49 ({pubkey} ({longmsg} )))))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::InvalidMessage
     );
 }
@@ -3808,7 +3774,7 @@ fn test_agg_sig_unsafe_invalid_msg(
         ConsensusFlags::empty(),
     );
     if opcode == AGG_SIG_UNSAFE {
-        assert_eq!(ret.unwrap_err().1, ErrorCode::InvalidMessage);
+        assert_eq!(ret.unwrap_err().0, ErrorCode::InvalidMessage);
     } else {
         assert!(ret.is_ok());
     }
@@ -3843,7 +3809,7 @@ fn test_agg_sig_unsafe_exceed_cost() {
             None,
         )
         .unwrap_err()
-        .1,
+        .0,
         ErrorCode::CostExceeded
     );
 }
@@ -3854,7 +3820,7 @@ fn test_spend_amount_exceeds_max() {
     assert_eq!(
         cond_test("((({h1} ({h2} (0x010000000000000000 ())))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::InvalidCoinAmount
     );
 }
@@ -3863,7 +3829,7 @@ fn test_spend_amount_exceeds_max() {
 fn test_single_spend_negative_amount() {
     // the coin we're trying to spend has a negative amount (i.e. it's invalid)
     assert_eq!(
-        cond_test("((({h1} ({h2} (-123 ())))").unwrap_err().1,
+        cond_test("((({h1} ({h2} (-123 ())))").unwrap_err().0,
         ErrorCode::InvalidCoinAmount
     );
 }
@@ -3872,7 +3838,7 @@ fn test_single_spend_negative_amount() {
 fn test_single_spend_invalid_puzle_hash() {
     // the puzzle hash in the spend is 33 bytes
     assert_eq!(
-        cond_test("((({h1} ({long} (123 ())))").unwrap_err().1,
+        cond_test("((({h1} ({long} (123 ())))").unwrap_err().0,
         ErrorCode::InvalidPuzzleHash
     );
 }
@@ -3881,7 +3847,7 @@ fn test_single_spend_invalid_puzle_hash() {
 fn test_single_spend_invalid_parent_id() {
     // the parent coin ID is 33 bytes long
     assert_eq!(
-        cond_test("((({long} ({h2} (123 ())))").unwrap_err().1,
+        cond_test("((({long} ({h2} (123 ())))").unwrap_err().0,
         ErrorCode::InvalidParentId
     );
 }
@@ -3892,7 +3858,7 @@ fn test_double_spend() {
     assert_eq!(
         cond_test("((({h1} ({h2} (123 ()) (({h1} ({h2} (123 ())))")
             .unwrap_err()
-            .1,
+            .0,
         ErrorCode::DoubleSpend
     );
 }
@@ -4035,7 +4001,7 @@ fn test_concurrent_spend_fail() {
 
     for test in test_cases {
         assert_eq!(
-            cond_test(test).unwrap_err().1,
+            cond_test(test).unwrap_err().0,
             ErrorCode::AssertConcurrentSpendFailed
         );
     }
@@ -4161,7 +4127,7 @@ fn test_concurrent_puzzle_fail() {
 
     for test in test_cases {
         assert_eq!(
-            cond_test(test).unwrap_err().1,
+            cond_test(test).unwrap_err().0,
             ErrorCode::AssertConcurrentPuzzleFailed
         );
     }
@@ -4396,7 +4362,7 @@ fn test_impossible_constraints_single_spend(
         cond1 as u8, value1, cond2 as u8, value2
     );
     if let Some(e) = expected_err {
-        assert_eq!(cond_test(test).unwrap_err().1, e);
+        assert_eq!(cond_test(test).unwrap_err().0, e);
     } else {
         // we don't expect any error
         let (a, conds) = cond_test(test).unwrap();
@@ -4493,7 +4459,7 @@ fn test_impossible_constraints_separate_spends(
         cond1 as u8, value1, cond2 as u8, value2
     );
     if let Some(e) = expected_err {
-        assert_eq!(cond_test(test).unwrap_err().1, e);
+        assert_eq!(cond_test(test).unwrap_err().0, e);
     } else {
         // we don't expect any error
         let (a, conds) = cond_test(test).unwrap();
@@ -4533,7 +4499,7 @@ fn test_conflicting_my_birth_assertions(
             "((({{h1}} ({{h2}} (1234 ((({val} (100 ) (({val} (503 ) (({val} (90 )))))"
         ))
         .unwrap_err()
-        .1,
+        .0,
         expected
     );
 }
@@ -4713,7 +4679,7 @@ fn test_assert_ephemeral_wrong_ph() {
 
     // this is an invalid ASSERT_EPHEMERAL
     assert_eq!(
-        cond_test(test).unwrap_err().1,
+        cond_test(test).unwrap_err().0,
         ErrorCode::AssertEphemeralFailed
     );
 }
@@ -4737,7 +4703,7 @@ fn test_assert_ephemeral_wrong_amount() {
 
     // this is an invalid ASSERT_EPHEMERAL
     assert_eq!(
-        cond_test(test).unwrap_err().1,
+        cond_test(test).unwrap_err().0,
         ErrorCode::AssertEphemeralFailed
     );
 }
@@ -4761,7 +4727,7 @@ fn test_assert_ephemeral_wrong_parent() {
 
     // this is an invalid ASSERT_EPHEMERAL
     assert_eq!(
-        cond_test(test).unwrap_err().1,
+        cond_test(test).unwrap_err().0,
         ErrorCode::AssertEphemeralFailed
     );
 }
@@ -4813,7 +4779,7 @@ fn test_relative_condition_on_ephemeral(
     );
 
     if let Some(err) = expect_error {
-        assert_eq!(cond_test(&test).unwrap_err().1, err);
+        assert_eq!(cond_test(&test).unwrap_err().0, err);
     } else {
         // we don't expect any error
         let (a, conds) = cond_test(&test).unwrap();
@@ -4904,7 +4870,7 @@ fn test_softfork_condition_failures(#[case] conditions: &str, #[case] expected_e
             ConsensusFlags::empty()
         )
         .unwrap_err()
-        .1,
+        .0,
         expected_err
     );
 }
@@ -5032,7 +4998,7 @@ fn test_limit_announcements(
     );
 
     if expect_err.is_some() {
-        assert_eq!(r.unwrap_err().1, expect_err.unwrap());
+        assert_eq!(r.unwrap_err().0, expect_err.unwrap());
     } else {
         r.unwrap();
     }
@@ -5498,9 +5464,9 @@ fn test_message_conditions_single_spend(#[case] test_case: &str, #[case] expect:
         assert_eq!(a.atom(spend.puzzle_hash).as_ref(), H2);
         assert_eq!(spend.flags, 0);
     } else if expect_pass {
-        panic!("failed: {:?}", ret.unwrap_err().1);
+        panic!("failed: {:?}", ret.unwrap_err().0);
     } else {
-        let actual_err = ret.unwrap_err().1;
+        let actual_err = ret.unwrap_err().0;
         println!("Error: {actual_err:?}");
         assert_eq!(ErrorCode::MessageNotSentOrReceived, actual_err);
     }
@@ -5557,7 +5523,7 @@ fn test_limit_messages(
     );
 
     if expect_err.is_some() {
-        assert_eq!(r.unwrap_err().1, expect_err.unwrap());
+        assert_eq!(r.unwrap_err().0, expect_err.unwrap());
     } else {
         r.unwrap();
     }
@@ -5676,7 +5642,7 @@ fn test_message_conditions_failures(#[case] test_case: &str, #[case] expect: Err
     let flags = MEMPOOL_MODE;
     let ret = cond_test_flag(&format!("((({{h1}} ({{h2}} (123 (({test_case}))))"), flags);
 
-    let Err(ValidationErr(_, code)) = ret else {
+    let Err(ValidationErr(code)) = ret else {
         panic!("expected failure: {expect:?}");
     };
     assert_eq!(code, expect);
@@ -5922,9 +5888,9 @@ fn test_message_conditions_two_spends(
         assert_eq!(a.atom(spend.puzzle_hash).as_ref(), H1);
         assert_eq!(spend.flags, 0);
     } else if expect_pass {
-        panic!("failed: {:?}", ret.unwrap_err().1);
+        panic!("failed: {:?}", ret.unwrap_err().0);
     } else {
-        let actual_err = ret.unwrap_err().1;
+        let actual_err = ret.unwrap_err().0;
         println!("Error: {actual_err:?}");
         assert_eq!(ErrorCode::MessageNotSentOrReceived, actual_err);
     }
@@ -6251,7 +6217,7 @@ fn test_limit_spends_parse_spends(
     );
     match (expected_err, result) {
         (Some(err), Err(e)) => {
-            assert_eq!(e.1, err);
+            assert_eq!(e.0, err);
         }
         (None, Ok(conds)) => {
             assert_eq!(conds.spends.len(), num_spends);

--- a/crates/chia-consensus/src/get_puzzle_and_solution.rs
+++ b/crates/chia-consensus/src/get_puzzle_and_solution.rs
@@ -51,7 +51,7 @@ pub fn get_puzzle_and_solution_for_coin(
         // we found the coin!
         return Ok((puzzle, solution));
     }
-    Err(ValidationErr(generator_result, ErrorCode::InvalidCondition))
+    Err(ValidationErr(ErrorCode::InvalidCondition))
 }
 
 #[cfg(test)]
@@ -146,7 +146,7 @@ mod test {
                 &Coin::new(make_dummy_id(2), tree_hash(&a, puzzle1).into(), 1337),
             )
             .unwrap_err()
-            .1,
+            .0,
             ErrorCode::InvalidCondition
         );
 
@@ -158,7 +158,7 @@ mod test {
                 &Coin::new(parent, tree_hash(&a, puzzle1).into(), 42),
             )
             .unwrap_err()
-            .1,
+            .0,
             ErrorCode::InvalidCondition
         );
 
@@ -170,7 +170,7 @@ mod test {
                 &Coin::new(parent, make_dummy_id(4), 1337),
             )
             .unwrap_err()
-            .1,
+            .0,
             ErrorCode::InvalidCondition
         );
     }
@@ -194,14 +194,14 @@ mod test {
         // this is a spend where the parent is not an atom
         let spend2 = make_invalid_coin_spend(&mut a, puzzle2, amount_atom, puzzle1, solution1);
         assert_eq!(
-            parse_coin_spend(&a, spend2).unwrap_err().1,
+            parse_coin_spend(&a, spend2).unwrap_err().0,
             ErrorCode::InvalidParentId
         );
 
         // this is a spend where the amount is not an atom
         let spend3 = make_invalid_coin_spend(&mut a, parent_atom, puzzle2, puzzle1, solution1);
         assert_eq!(
-            parse_coin_spend(&a, spend3).unwrap_err().1,
+            parse_coin_spend(&a, spend3).unwrap_err().0,
             ErrorCode::InvalidCoinAmount
         );
     }

--- a/crates/chia-consensus/src/messages.rs
+++ b/crates/chia-consensus/src/messages.rs
@@ -61,10 +61,10 @@ impl SpendId {
             let amount = match sanitize_uint(a, first(a, *args)?, 8, ErrorCode::InvalidCoinAmount)?
             {
                 SanitizedUint::PositiveOverflow => {
-                    return Err(ValidationErr(*args, ErrorCode::CoinAmountExceedsMaximum));
+                    return Err(ValidationErr(ErrorCode::CoinAmountExceedsMaximum));
                 }
                 SanitizedUint::NegativeOverflow => {
-                    return Err(ValidationErr(*args, ErrorCode::CoinAmountNegative));
+                    return Err(ValidationErr(ErrorCode::CoinAmountNegative));
                 }
                 SanitizedUint::Ok(amount) => amount,
             };
@@ -82,7 +82,7 @@ impl SpendId {
             PARENTAMOUNT => Ok(Self::ParentAmount(parent, amount)),
             PUZZLEAMOUNT => Ok(Self::PuzzleAmount(puzzle, amount)),
             0 => Ok(Self::None),
-            _ => Err(ValidationErr(*args, ErrorCode::InvalidMessageMode)),
+            _ => Err(ValidationErr(ErrorCode::InvalidMessageMode)),
         }
     }
 
@@ -105,7 +105,7 @@ impl SpendId {
             PARENTAMOUNT => Ok(Self::ParentAmount(parent, amount)),
             PUZZLEAMOUNT => Ok(Self::PuzzleAmount(puzzle, amount)),
             0 => Ok(Self::None),
-            _ => Err(ValidationErr(NodePtr::NIL, ErrorCode::InvalidMessageMode)),
+            _ => Err(ValidationErr(ErrorCode::InvalidMessageMode)),
         }
     }
 

--- a/crates/chia-consensus/src/puzzle_fingerprint.rs
+++ b/crates/chia-consensus/src/puzzle_fingerprint.rs
@@ -23,12 +23,12 @@ fn hash_atom_list(
 ) -> Result<NodePtr, ValidationErr> {
     while count > 0 {
         let Some((arg, next)) = a.next(args) else {
-            return Err(ValidationErr(args, ErrorCode::InvalidCondition));
+            return Err(ValidationErr(ErrorCode::InvalidCondition));
         };
         args = next;
         count -= 1;
         if !matches!(a.sexp(arg), SExp::Atom) {
-            return Err(ValidationErr(arg, ErrorCode::InvalidCondition));
+            return Err(ValidationErr(ErrorCode::InvalidCondition));
         }
         let buf = a.atom(arg);
 
@@ -135,7 +135,7 @@ pub fn compute_puzzle_fingerprint(
                 hash_atom_list(&mut fingerprint, a, c, 1)?;
             }
             _ => {
-                return Err(ValidationErr(c, ErrorCode::InvalidConditionOpcode));
+                return Err(ValidationErr(ErrorCode::InvalidConditionOpcode));
             }
         }
     }
@@ -215,7 +215,7 @@ mod tests {
 
         // we expect 2 elements, but there's only 1
         assert_eq!(
-            hash_atom_list(&mut ctx1, &a, list, 2).unwrap_err().1,
+            hash_atom_list(&mut ctx1, &a, list, 2).unwrap_err().0,
             ErrorCode::InvalidCondition
         );
     }
@@ -230,7 +230,7 @@ mod tests {
 
         // we expect all elements to be atoms, but we encountered a pair
         assert_eq!(
-            hash_atom_list(&mut ctx1, &a, list, 1).unwrap_err().1,
+            hash_atom_list(&mut ctx1, &a, list, 1).unwrap_err().0,
             ErrorCode::InvalidCondition
         );
     }

--- a/crates/chia-consensus/src/run_block_generator.rs
+++ b/crates/chia-consensus/src/run_block_generator.rs
@@ -26,13 +26,9 @@ use clvmr::reduction::Reduction;
 use clvmr::run_program::run_program;
 use clvmr::serde::{InternedTree, intern_tree_limited, node_from_bytes, node_from_bytes_backrefs};
 
-pub fn subtract_cost(
-    a: &Allocator,
-    cost_left: &mut Cost,
-    subtract: Cost,
-) -> Result<(), ValidationErr> {
+pub fn subtract_cost(cost_left: &mut Cost, subtract: Cost) -> Result<(), ValidationErr> {
     if subtract > *cost_left {
-        Err(ValidationErr(a.nil(), ErrorCode::CostExceeded))
+        Err(ValidationErr(ErrorCode::CostExceeded))
     } else {
         *cost_left -= subtract;
         Ok(())
@@ -53,7 +49,7 @@ where
     // need to pass in the deserialization program
     if flags.contains(ConsensusFlags::SIMPLE_GENERATOR) {
         if block_refs.into_iter().next().is_some() {
-            return Err(ValidationErr(a.nil(), ErrorCode::TooManyGeneratorRefs));
+            return Err(ValidationErr(ErrorCode::TooManyGeneratorRefs));
         }
         return Ok(a.nil());
     }
@@ -105,7 +101,7 @@ where
     let mut cost_left = max_cost;
     let byte_cost = program.len() as u64 * constants.cost_per_byte;
 
-    subtract_cost(&a, &mut cost_left, byte_cost)?;
+    subtract_cost(&mut cost_left, byte_cost)?;
 
     let rom_generator = node_from_bytes(&mut a, &ROM_BOOTSTRAP_GENERATOR)?;
     let program = node_from_bytes_backrefs(&mut a, program)?;
@@ -129,7 +125,7 @@ where
     let Reduction(clvm_cost, generator_output) =
         run_program(&mut a, &dialect, rom_generator, args, cost_left)?;
 
-    subtract_cost(&a, &mut cost_left, clvm_cost)?;
+    subtract_cost(&mut cost_left, clvm_cost)?;
 
     // we pass in what's left of max_cost here, to fail early in case the
     // cost of a condition brings us over the cost limit
@@ -165,7 +161,7 @@ fn extract_n<const N: usize>(
         counter += 1;
     }
     if counter != N - 1 {
-        return Err(ValidationErr(n, e));
+        return Err(ValidationErr(e));
     }
     ret[counter] = n;
     Ok(ret)
@@ -178,10 +174,7 @@ pub fn check_generator_quote(program: &[u8], flags: ConsensusFlags) -> Result<()
     if !flags.contains(ConsensusFlags::SIMPLE_GENERATOR) || program.starts_with(&[0xff, 0x01]) {
         Ok(())
     } else {
-        Err(ValidationErr(
-            NodePtr::NIL,
-            ErrorCode::ComplexGeneratorReceived,
-        ))
+        Err(ValidationErr(ErrorCode::ComplexGeneratorReceived))
     }
 }
 
@@ -198,10 +191,7 @@ pub fn check_generator_node(
     }
     // this expects an atom with a single byte value of 1 as the first value in the list
     match <(MatchByte<1>, NodePtr)>::from_clvm(a, program) {
-        Err(..) => Err(ValidationErr(
-            NodePtr::NIL,
-            ErrorCode::ComplexGeneratorReceived,
-        )),
+        Err(..) => Err(ValidationErr(ErrorCode::ComplexGeneratorReceived)),
         _ => Ok(()),
     }
 }
@@ -235,7 +225,7 @@ where
         let mut decode_allocator = Allocator::new();
         let program_node = node_from_bytes_backrefs(&mut decode_allocator, program)?;
         let interned = intern_tree_limited(&decode_allocator, program_node, u32::MAX as usize)
-            .map_err(|_| ValidationErr(NodePtr::NIL, ErrorCode::GeneratorRuntimeError))?;
+            .map_err(|_| ValidationErr(ErrorCode::GeneratorRuntimeError))?;
         let cost = total_cost_from_tree(&interned);
         let InternedTree {
             allocator, root, ..
@@ -250,7 +240,7 @@ where
     };
 
     let mut cost_left = max_cost;
-    subtract_cost(&a, &mut cost_left, base_cost)?;
+    subtract_cost(&mut cost_left, base_cost)?;
 
     check_generator_node(&a, program, flags)?;
 
@@ -259,7 +249,7 @@ where
 
     let Reduction(clvm_cost, all_spends) = run_program(&mut a, &dialect, program, args, cost_left)?;
 
-    subtract_cost(&a, &mut cost_left, clvm_cost)?;
+    subtract_cost(&mut cost_left, clvm_cost)?;
 
     let mut ret = SpendBundleConditions::default();
 
@@ -293,7 +283,7 @@ where
     while let Some((spend, rest)) = a.next(iter) {
         iter = rest;
         if spends_left == 0 {
-            return Err(ValidationErr(spend, ErrorCode::TooManySpends));
+            return Err(ValidationErr(ErrorCode::TooManySpends));
         }
         spends_left -= 1;
         // process the spend
@@ -303,7 +293,7 @@ where
         let Reduction(clvm_cost, conditions) =
             run_program(&mut a, &dialect, puzzle, solution, cost_left)?;
 
-        subtract_cost(&a, &mut cost_left, clvm_cost)?;
+        subtract_cost(&mut cost_left, clvm_cost)?;
         ret.execution_cost += clvm_cost;
 
         let buf = tree_hash_cached(&a, puzzle, &mut cache);
@@ -324,10 +314,10 @@ where
         )?;
     }
     if a.atom_len(iter) != 0 {
-        return Err(ValidationErr(iter, ErrorCode::GeneratorRuntimeError));
+        return Err(ValidationErr(ErrorCode::GeneratorRuntimeError));
     }
 
-    validate_conditions(&a, &ret, &state, a.nil(), flags)?;
+    validate_conditions(&a, &ret, &state, flags)?;
     validate_signature(&state, signature, flags, bls_cache)?;
     ret.validated_signature = !flags.contains(ConsensusFlags::DONT_VALIDATE_SIGNATURE);
 
@@ -365,7 +355,7 @@ where
 
     let (first, _rest) = a
         .next(res)
-        .ok_or(ValidationErr(res, ErrorCode::GeneratorRuntimeError))?;
+        .ok_or(ValidationErr(ErrorCode::GeneratorRuntimeError))?;
     let mut cache = TreeCache::default();
     let mut iter = first;
     while let Some((spend, rest)) = a.next(iter) {
@@ -385,7 +375,7 @@ where
         };
         let puzhash = tree_hash_cached(&a, puzzle, &mut cache);
         let parent_id = BytesImpl::<32>::from_clvm(&a, parent_id)
-            .map_err(|_| ValidationErr(first, ErrorCode::InvalidParentId))?;
+            .map_err(|_| ValidationErr(ErrorCode::InvalidParentId))?;
         let coin = Coin::new(
             parent_id,
             puzhash.into(),
@@ -461,11 +451,11 @@ where
         args,
         constants.max_block_cost_clvm,
     )
-    .map_err(|_| ValidationErr(program, ErrorCode::GeneratorRuntimeError))?;
+    .map_err(|_| ValidationErr(ErrorCode::GeneratorRuntimeError))?;
 
     let (first, _rest) = a
         .next(res)
-        .ok_or(ValidationErr(res, ErrorCode::GeneratorRuntimeError))?;
+        .ok_or(ValidationErr(ErrorCode::GeneratorRuntimeError))?;
     let mut cache = TreeCache::default();
     let mut iter = first;
     while let Some((spend, rest)) = a.next(iter) {
@@ -484,7 +474,7 @@ where
         };
         let puzhash = tree_hash_cached(&a, puzzle, &mut cache);
         let parent_id = BytesImpl::<32>::from_clvm(&a, parent_id)
-            .map_err(|_| ValidationErr(first, ErrorCode::InvalidParentId))?;
+            .map_err(|_| ValidationErr(ErrorCode::InvalidParentId))?;
         let coin = Coin::new(
             parent_id,
             puzhash.into(),
@@ -500,7 +490,7 @@ where
             solution,
             constants.max_block_cost_clvm,
         )
-        .map_err(|_| ValidationErr(program, ErrorCode::GeneratorRuntimeError))?;
+        .map_err(|_| ValidationErr(ErrorCode::GeneratorRuntimeError))?;
         // conditions_list is the full returned output of puzzle ran with solution
         // ((51 0xcafef00d 100) (51 0x1234 200) ...)
 
@@ -633,7 +623,7 @@ mod tests {
         );
         match (expected_err, result) {
             (Some(err), Err(e)) => {
-                assert_eq!(e.1, err);
+                assert_eq!(e.0, err);
             }
             (None, Ok(conds)) => {
                 assert_eq!(conds.1.spends.len(), num_spends);

--- a/crates/chia-consensus/src/sanitize_int.rs
+++ b/crates/chia-consensus/src/sanitize_int.rs
@@ -34,7 +34,7 @@ pub fn sanitize_uint(
     // be interpreted as a negative integer. i.e. if the next top bit is set
     // all other leading zeros are invalid
     if buf == [0_u8] || (buf.len() > 1 && buf[0] == 0 && (buf[1] & 0x80) == 0) {
-        return Err(ValidationErr(n, code));
+        return Err(ValidationErr(code));
     }
 
     // strip the leading zero byte if there is one
@@ -75,26 +75,26 @@ fn test_sanitize_uint() {
     let just_zeros = a.new_substr(atom, 10, 70).unwrap();
     // a zero value must be represented by an empty atom
     assert_eq!(
-        sanitize_uint(&a, just_zeros, 8, e).unwrap_err().1,
+        sanitize_uint(&a, just_zeros, 8, e).unwrap_err().0,
         ErrorCode::InvalidCoinAmount
     );
 
     let a1 = a.new_substr(atom, 1, 101).unwrap();
     assert_eq!(
-        sanitize_uint(&a, a1, 8, e).unwrap_err().1,
+        sanitize_uint(&a, a1, 8, e).unwrap_err().0,
         ErrorCode::InvalidCoinAmount
     );
 
     let a1 = a.new_substr(atom, 1, 101).unwrap();
     assert_eq!(
-        sanitize_uint(&a, a1, 8, e).unwrap_err().1,
+        sanitize_uint(&a, a1, 8, e).unwrap_err().0,
         ErrorCode::InvalidCoinAmount
     );
 
     // a new all-zeros range
     let a1 = a.new_substr(atom, 1000, 1024).unwrap();
     assert_eq!(
-        sanitize_uint(&a, a1, 8, e).unwrap_err().1,
+        sanitize_uint(&a, a1, 8, e).unwrap_err().0,
         ErrorCode::InvalidCoinAmount
     );
 

--- a/crates/chia-consensus/src/spendbundle_conditions.rs
+++ b/crates/chia-consensus/src/spendbundle_conditions.rs
@@ -16,7 +16,6 @@ use chia_bls::PublicKey;
 use chia_protocol::{Bytes, SpendBundle};
 
 use clvm_utils::tree_hash;
-use clvmr::NodePtr;
 use clvmr::allocator::Allocator;
 use clvmr::chia_dialect::ChiaDialect;
 use clvmr::reduction::Reduction;
@@ -49,7 +48,6 @@ pub fn get_conditions_from_spendbundle(
 /// based on the interned structure. Otherwise charges cost_per_byte on the raw
 /// generator length (excluding the quote wrapper).
 fn calculate_base_cost(
-    a: &mut Allocator,
     spend_bundle: &SpendBundle,
     flags: ConsensusFlags,
     constants: &ConsensusConstants,
@@ -63,9 +61,9 @@ fn calculate_base_cost(
                 .iter()
                 .map(|cs| (cs.coin, cs.puzzle_reveal.as_slice(), cs.solution.as_slice())),
         )
-        .map_err(|_| ValidationErr(a.nil(), ErrorCode::GeneratorRuntimeError))?;
+        .map_err(|_| ValidationErr(ErrorCode::GeneratorRuntimeError))?;
         let interned = intern_tree_limited(&gen_allocator, generator, u32::MAX as usize)
-            .map_err(|_| ValidationErr(NodePtr::NIL, ErrorCode::GeneratorRuntimeError))?;
+            .map_err(|_| ValidationErr(ErrorCode::GeneratorRuntimeError))?;
         Ok(total_cost_from_tree(&interned))
     } else {
         // We don't pay the size cost (nor execution cost) of being wrapped by a
@@ -92,13 +90,13 @@ pub fn run_spendbundle(
     let dialect = ChiaDialect::new(flags.to_clvm_flags());
     let mut ret = SpendBundleConditions::default();
     let mut state = ParseState::default();
-    let base_cost = calculate_base_cost(a, spend_bundle, flags, constants)?;
-    subtract_cost(a, &mut cost_left, base_cost)?;
+    let base_cost = calculate_base_cost(spend_bundle, flags, constants)?;
+    subtract_cost(&mut cost_left, base_cost)?;
 
     if flags.contains(ConsensusFlags::LIMIT_SPENDS)
         && spend_bundle.coin_spends.len() > MAX_SPENDS_PER_BLOCK
     {
-        return Err(ValidationErr(a.nil(), ErrorCode::TooManySpends));
+        return Err(ValidationErr(ErrorCode::TooManySpends));
     }
 
     for coin_spend in &spend_bundle.coin_spends {
@@ -110,11 +108,11 @@ pub fn run_spendbundle(
         let Reduction(clvm_cost, conditions) = run_program(a, &dialect, puz, sol, cost_left)?;
 
         ret.execution_cost += clvm_cost;
-        subtract_cost(a, &mut cost_left, clvm_cost)?;
+        subtract_cost(&mut cost_left, clvm_cost)?;
 
         let buf = tree_hash(a, puz);
         if coin_spend.coin.puzzle_hash != buf.into() {
-            return Err(ValidationErr(puz, ErrorCode::WrongPuzzleHash));
+            return Err(ValidationErr(ErrorCode::WrongPuzzleHash));
         }
         let puzzle_hash = a.new_atom(&buf)?;
         let spend = process_single_spend::<MempoolVisitor>(
@@ -139,7 +137,7 @@ pub fn run_spendbundle(
     }
 
     MempoolVisitor::post_process(a, &state, &mut ret)?;
-    validate_conditions(a, &ret, &state, a.nil(), flags)?;
+    validate_conditions(a, &ret, &state, flags)?;
 
     assert!(max_cost >= cost_left);
     ret.cost = max_cost - cost_left;
@@ -636,7 +634,7 @@ mod tests {
                     (
                         0,
                         0,
-                        format!("FAILED: {:?} ({})\n", code.1, u32::from(code.1)),
+                        format!("FAILED: {:?} ({})\n", code.0, u32::from(code.0)),
                         block_conds,
                     )
                 }
@@ -696,7 +694,7 @@ mod tests {
             }
             Err(code) => {
                 println!("error: {code:?}");
-                format!("FAILED: {:?} ({})\n", code.1, u32::from(code.1))
+                format!("FAILED: {:?} ({})\n", code.0, u32::from(code.0))
             }
         };
 
@@ -750,7 +748,7 @@ mod tests {
         let result = run_spendbundle(&mut alloc, &bundle, u64::MAX, flags, &TEST_CONSTANTS);
         match (expected_err, result) {
             (Some(err), Err(e)) => {
-                assert_eq!(e.1, err);
+                assert_eq!(e.0, err);
             }
             (None, Ok((conds, _))) => {
                 assert_eq!(conds.spends.len(), num_spends);

--- a/crates/chia-consensus/src/spendbundle_validation.rs
+++ b/crates/chia-consensus/src/spendbundle_validation.rs
@@ -8,7 +8,6 @@ use chia_bls::GTElement;
 use chia_bls::{aggregate_verify_gt, hash_to_g2};
 use chia_protocol::SpendBundle;
 use chia_sha2::Sha256;
-use clvmr::NodePtr;
 
 // type definition makes clippy happy
 pub type ValidationPair = ([u8; 32], GTElement);
@@ -48,10 +47,7 @@ pub fn validate_clvm_and_signature(
         pairs.iter().map(|tuple| &tuple.1),
     );
     if !result {
-        return Err(ValidationErr(
-            NodePtr::NIL,
-            ErrorCode::BadAggregateSignature,
-        ));
+        return Err(ValidationErr(ErrorCode::BadAggregateSignature));
     }
 
     // Collect results
@@ -260,7 +256,7 @@ ff01\
                 MEMPOOL_MODE,
             )
             .unwrap_err()
-            .1,
+            .0,
             ErrorCode::WrongPuzzleHash
         );
     }
@@ -341,7 +337,7 @@ ff843B9ACA00\
             validate_clvm_and_signature(&spend_bundle, max_cost - 1, &TEST_CONSTANTS, MEMPOOL_MODE);
         assert!(matches!(
             result,
-            Err(ValidationErr(_, ErrorCode::CostExceeded))
+            Err(ValidationErr(ErrorCode::CostExceeded))
         ));
     }
 
@@ -426,7 +422,7 @@ ff843B9ACA00\
         );
         assert!(matches!(
             result,
-            Err(ValidationErr(_, ErrorCode::BadAggregateSignature))
+            Err(ValidationErr(ErrorCode::BadAggregateSignature))
         ));
     }
 }

--- a/crates/chia-consensus/src/test_generators.rs
+++ b/crates/chia-consensus/src/test_generators.rs
@@ -329,7 +329,7 @@ fn run_generator(#[case] name: &str) {
                 &TEST_CONSTANTS,
             );
             assert_eq!(
-                test_conds.unwrap_err().1,
+                test_conds.unwrap_err().0,
                 ErrorCode::ComplexGeneratorReceived
             );
 
@@ -338,7 +338,7 @@ fn run_generator(#[case] name: &str) {
             let program = node_from_bytes_backrefs(&mut a, generator.as_ref())
                 .expect("node_from_bytes_backref");
             let res = check_generator_node(&a, program, flags | ConsensusFlags::SIMPLE_GENERATOR);
-            assert_eq!(res.unwrap_err().1, ErrorCode::ComplexGeneratorReceived);
+            assert_eq!(res.unwrap_err().0, ErrorCode::ComplexGeneratorReceived);
         } else {
             flags |= ConsensusFlags::SIMPLE_GENERATOR;
             // ensure SIMPLE_GENERATOR fails if there are any block references
@@ -352,7 +352,7 @@ fn run_generator(#[case] name: &str) {
                 None,
                 &TEST_CONSTANTS,
             );
-            assert_eq!(test_conds.unwrap_err().1, ErrorCode::TooManyGeneratorRefs);
+            assert_eq!(test_conds.unwrap_err().0, ErrorCode::TooManyGeneratorRefs);
 
             // now lets specifically check the node generator check
             let mut a = make_allocator(flags);
@@ -396,7 +396,7 @@ fn run_generator(#[case] name: &str) {
                 }
                 (conditions.cost, print_conditions(a2, conditions, a2))
             }
-            Err(code) => (0, format!("FAILED: {:?} ({})\n", code.1, u32::from(code.1))),
+            Err(code) => (0, format!("FAILED: {:?} ({})\n", code.0, u32::from(code.0))),
         };
 
         if UPDATE_TESTS {
@@ -452,7 +452,7 @@ fn run_generator(#[case] name: &str) {
                     print_conditions(&a1, &conditions, a2)
                 }
                 Err(code) => {
-                    format!("FAILED: {:?} ({})\n", code.1, u32::from(code.1))
+                    format!("FAILED: {:?} ({})\n", code.0, u32::from(code.0))
                 }
             };
             if output != output_pre_hard_fork {

--- a/crates/chia-consensus/src/validation_error.rs
+++ b/crates/chia-consensus/src/validation_error.rs
@@ -168,21 +168,21 @@ pub enum ErrorCode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
-#[error("validation error: {1:?}")]
-pub struct ValidationErr(pub NodePtr, pub ErrorCode);
+#[error("validation error: {0:?}")]
+pub struct ValidationErr(pub ErrorCode);
 
 impl From<EvalErr> for ValidationErr {
     fn from(v: EvalErr) -> Self {
         match v {
-            EvalErr::CostExceeded => ValidationErr(v.node_ptr(), ErrorCode::CostExceeded),
-            _ => ValidationErr(v.node_ptr(), ErrorCode::GeneratorRuntimeError),
+            EvalErr::CostExceeded => ValidationErr(ErrorCode::CostExceeded),
+            _ => ValidationErr(ErrorCode::GeneratorRuntimeError),
         }
     }
 }
 
 impl From<std::io::Error> for ValidationErr {
     fn from(_: std::io::Error) -> Self {
-        ValidationErr(NodePtr::NIL, ErrorCode::GeneratorRuntimeError)
+        ValidationErr(ErrorCode::GeneratorRuntimeError)
     }
 }
 
@@ -191,8 +191,8 @@ impl From<ValidationErr> for PyErr {
     fn from(err: ValidationErr) -> PyErr {
         pyo3::exceptions::PyValueError::new_err((
             "ValidationError",
-            u32::from(err.1),
-            format!("{:?}", err.1),
+            u32::from(err.0),
+            format!("{:?}", err.0),
         ))
     }
 }
@@ -201,7 +201,7 @@ impl From<ValidationErr> for PyErr {
 pub fn first(a: &Allocator, n: NodePtr) -> Result<NodePtr, ValidationErr> {
     match a.sexp(n) {
         SExp::Pair(left, _) => Ok(left),
-        SExp::Atom => Err(ValidationErr(n, ErrorCode::InvalidCondition)),
+        SExp::Atom => Err(ValidationErr(ErrorCode::InvalidCondition)),
     }
 }
 
@@ -373,7 +373,7 @@ impl From<ErrorCode> for u32 {
 pub fn rest(a: &Allocator, n: NodePtr) -> Result<NodePtr, ValidationErr> {
     match a.sexp(n) {
         SExp::Pair(_, right) => Ok(right),
-        SExp::Atom => Err(ValidationErr(n, ErrorCode::InvalidCondition)),
+        SExp::Atom => Err(ValidationErr(ErrorCode::InvalidCondition)),
     }
 }
 
@@ -385,7 +385,7 @@ pub fn next(a: &Allocator, n: NodePtr) -> Result<Option<(NodePtr, NodePtr)>, Val
             if a.atom_len(n) == 0 {
                 Ok(None)
             } else {
-                Err(ValidationErr(n, ErrorCode::InvalidCondition))
+                Err(ValidationErr(ErrorCode::InvalidCondition))
             }
         }
     }
@@ -394,7 +394,7 @@ pub fn next(a: &Allocator, n: NodePtr) -> Result<Option<(NodePtr, NodePtr)>, Val
 pub fn atom(a: &Allocator, n: NodePtr, code: ErrorCode) -> Result<Atom<'_>, ValidationErr> {
     match a.sexp(n) {
         SExp::Atom => Ok(a.atom(n)),
-        SExp::Pair(..) => Err(ValidationErr(n, code)),
+        SExp::Pair(..) => Err(ValidationErr(code)),
     }
 }
 
@@ -402,6 +402,6 @@ pub fn check_nil(a: &Allocator, n: NodePtr) -> Result<(), ValidationErr> {
     if atom(a, n, ErrorCode::InvalidCondition)?.as_ref().is_empty() {
         Ok(())
     } else {
-        Err(ValidationErr(n, ErrorCode::InvalidCondition))
+        Err(ValidationErr(ErrorCode::InvalidCondition))
     }
 }

--- a/crates/chia-tools/src/visit_spends.rs
+++ b/crates/chia-tools/src/visit_spends.rs
@@ -128,7 +128,7 @@ pub fn visit_spends<
         // process the spend
         let destructure_list!(parent_id, puzzle, amount, solution, _spend_level_extra) =
             <match_list!(Bytes32, NodePtr, u64, NodePtr, NodePtr)>::from_clvm(a, spend)
-                .map_err(|_| ValidationErr(spend, ErrorCode::InvalidCondition))?;
+                .map_err(|_| ValidationErr(ErrorCode::InvalidCondition))?;
         callback(a, parent_id, amount, puzzle, solution);
     }
     Ok(())

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -189,9 +189,10 @@ pub fn get_puzzle_and_solution_for_coin<'a>(
                 result,
                 &Coin::new(find_parent, find_ph, find_amount),
             ) {
-                Err(ValidationErr(n, _)) => {
-                    Err(EvalErr::InvalidOpArg(n, "coin not found".to_string()))
-                }
+                Err(ValidationErr(_)) => Err(EvalErr::InvalidOpArg(
+                    NodePtr::NIL,
+                    "coin not found".to_string(),
+                )),
                 Ok(pair) => Ok(pair),
             }
         })
@@ -238,9 +239,10 @@ pub fn get_puzzle_and_solution_for_coin2<'a>(
             let Reduction(_cost, result) =
                 run_program(&mut allocator, dialect, generator, args, max_cost)?;
             match parse_puzzle_solution(&allocator, result, find_coin) {
-                Err(ValidationErr(n, _)) => {
-                    Err(EvalErr::InvalidOpArg(n, "coin not found".to_string()))
-                }
+                Err(ValidationErr(_)) => Err(EvalErr::InvalidOpArg(
+                    NodePtr::NIL,
+                    "coin not found".to_string(),
+                )),
                 Ok(pair) => Ok(pair),
             }
         })

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -62,7 +62,7 @@ pub fn run_block_generator<'a>(
                     spend_bundle_conds,
                 )),
             ),
-            Err(ValidationErr(_, error_code)) => (
+            Err(ValidationErr(error_code)) => (
                 Some(error_code.into()),
                 Some(format!("{error_code:?}")),
                 None,
@@ -114,7 +114,7 @@ pub fn run_block_generator2<'a>(
                     spend_bundle_conds,
                 )),
             ),
-            Err(ValidationErr(_, error_code)) => (
+            Err(ValidationErr(error_code)) => (
                 Some(error_code.into()),
                 Some(format!("{error_code:?}")),
                 None,


### PR DESCRIPTION
The `NodePtr` is never used in production (only some tests). The main issue is that by the time you catch the error, you may no longer have access to the `Allocator`, so the node is meaningless.

This simplifies the error type, as a step towards a more regular error type. If there are errors that need to pass along more metadata, we can add that to the respective enum value in the future.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide, cross-cutting refactor across consensus parsing/validation and bindings; low behavioral intent but easy to miss a call-site mapping or subtly change error propagation in edge cases.
> 
> **Overview**
> **Removes the `NodePtr` payload from `ValidationErr`**, making it a thin wrapper around `ErrorCode` and updating its `Display`/conversion behavior.
> 
> Propagates the new error shape throughout consensus codepaths (condition sanitizers/parsing, generator execution, additions/removals, message parsing) and updates all tests/fuzz targets to match; this also simplifies a couple of APIs that only used the allocator/node for error construction (e.g., `subtract_cost`, `validate_conditions`).
> 
> Updates Rust↔Python glue (`wheel`) to handle the new error type, mapping “coin not found” paths to a generic `EvalErr::InvalidOpArg` with `NodePtr::NIL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a2e9aae23ad78e5f42027bc0ba8663fa02f2ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->