### PR TITLE
fix mypy issue

### DIFF
--- a/wheel/generate_type_stubs.py
+++ b/wheel/generate_type_stubs.py
@@ -331,15 +331,15 @@ def supports_fast_forward(spend: CoinSpend) -> bool : ...
 def fast_forward_singleton(spend: CoinSpend, new_coin: Coin, new_parent: Coin) -> bytes: ...
 
 def run_block_generator(
-    program: ReadableBuffer, block_refs: list[ReadableBuffer], max_cost: int, flags: int, signature: G2Element, bls_cache: Optional[BLSCache], constants: ConsensusConstants
+    program: ReadableBuffer, block_refs: Sequence[ReadableBuffer], max_cost: int, flags: int, signature: G2Element, bls_cache: Optional[BLSCache], constants: ConsensusConstants
 ) -> tuple[Optional[int], Optional[str], Optional[SpendBundleConditions]]: ...
 
 def run_block_generator2(
-    program: ReadableBuffer, block_refs: list[ReadableBuffer], max_cost: int, flags: int, signature: G2Element, bls_cache: Optional[BLSCache], constants: ConsensusConstants
+    program: ReadableBuffer, block_refs: Sequence[ReadableBuffer], max_cost: int, flags: int, signature: G2Element, bls_cache: Optional[BLSCache], constants: ConsensusConstants
 ) -> tuple[Optional[int], Optional[str], Optional[SpendBundleConditions]]: ...
 
 def additions_and_removals(
-    program: ReadableBuffer, block_refs: list[ReadableBuffer], flags: int, constants: ConsensusConstants
+    program: ReadableBuffer, block_refs: Sequence[ReadableBuffer], flags: int, constants: ConsensusConstants
 ) -> tuple[list[tuple[Coin, Optional[bytes]]], list[tuple[bytes32, Coin]]]: ...
 
 def check_time_locks(
@@ -379,14 +379,14 @@ def get_conditions_from_spendbundle(
 def get_spends_for_trusted_block(
     constants: ConsensusConstants,
     generator: Program,
-    block_refs: list[ReadableBuffer],
+    block_refs: Sequence[ReadableBuffer],
     flags: int,
 ) -> dict[str, Any]: ...
 
 def get_spends_for_trusted_block_with_conditions(
     constants: ConsensusConstants,
     generator: Program,
-    block_refs: list[ReadableBuffer],
+    block_refs: Sequence[ReadableBuffer],
     flags: int,
 ) -> list[dict[str, Any]]: ...
 
@@ -462,7 +462,7 @@ def serialized_length(program: ReadableBuffer) -> int: ...
 def serialized_length_trusted(program: ReadableBuffer) -> int: ...
 def tree_hash(blob: ReadableBuffer) -> bytes32: ...
 def get_puzzle_and_solution_for_coin(program: ReadableBuffer, args: ReadableBuffer, max_cost: int, find_parent: bytes32, find_amount: int, find_ph: bytes32, flags: int) -> tuple[bytes, bytes]: ...
-def get_puzzle_and_solution_for_coin2(generator: Program, block_refs: list[ReadableBuffer], max_cost: int, find_coin: Coin, flags: int) -> tuple[Program, Program]: ...
+def get_puzzle_and_solution_for_coin2(generator: Program, block_refs: Sequence[ReadableBuffer], max_cost: int, find_coin: Coin, flags: int) -> tuple[Program, Program]: ...
 
 @final
 class BLSCache:

--- a/wheel/python/chia_rs/chia_rs.pyi
+++ b/wheel/python/chia_rs/chia_rs.pyi
@@ -24,15 +24,15 @@ def supports_fast_forward(spend: CoinSpend) -> bool : ...
 def fast_forward_singleton(spend: CoinSpend, new_coin: Coin, new_parent: Coin) -> bytes: ...
 
 def run_block_generator(
-    program: ReadableBuffer, block_refs: list[ReadableBuffer], max_cost: int, flags: int, signature: G2Element, bls_cache: Optional[BLSCache], constants: ConsensusConstants
+    program: ReadableBuffer, block_refs: Sequence[ReadableBuffer], max_cost: int, flags: int, signature: G2Element, bls_cache: Optional[BLSCache], constants: ConsensusConstants
 ) -> tuple[Optional[int], Optional[str], Optional[SpendBundleConditions]]: ...
 
 def run_block_generator2(
-    program: ReadableBuffer, block_refs: list[ReadableBuffer], max_cost: int, flags: int, signature: G2Element, bls_cache: Optional[BLSCache], constants: ConsensusConstants
+    program: ReadableBuffer, block_refs: Sequence[ReadableBuffer], max_cost: int, flags: int, signature: G2Element, bls_cache: Optional[BLSCache], constants: ConsensusConstants
 ) -> tuple[Optional[int], Optional[str], Optional[SpendBundleConditions]]: ...
 
 def additions_and_removals(
-    program: ReadableBuffer, block_refs: list[ReadableBuffer], flags: int, constants: ConsensusConstants
+    program: ReadableBuffer, block_refs: Sequence[ReadableBuffer], flags: int, constants: ConsensusConstants
 ) -> tuple[list[tuple[Coin, Optional[bytes]]], list[tuple[bytes32, Coin]]]: ...
 
 def check_time_locks(
@@ -72,14 +72,14 @@ def get_conditions_from_spendbundle(
 def get_spends_for_trusted_block(
     constants: ConsensusConstants,
     generator: Program,
-    block_refs: list[ReadableBuffer],
+    block_refs: Sequence[ReadableBuffer],
     flags: int,
 ) -> dict[str, Any]: ...
 
 def get_spends_for_trusted_block_with_conditions(
     constants: ConsensusConstants,
     generator: Program,
-    block_refs: list[ReadableBuffer],
+    block_refs: Sequence[ReadableBuffer],
     flags: int,
 ) -> list[dict[str, Any]]: ...
 
@@ -155,7 +155,7 @@ def serialized_length(program: ReadableBuffer) -> int: ...
 def serialized_length_trusted(program: ReadableBuffer) -> int: ...
 def tree_hash(blob: ReadableBuffer) -> bytes32: ...
 def get_puzzle_and_solution_for_coin(program: ReadableBuffer, args: ReadableBuffer, max_cost: int, find_parent: bytes32, find_amount: int, find_ph: bytes32, flags: int) -> tuple[bytes, bytes]: ...
-def get_puzzle_and_solution_for_coin2(generator: Program, block_refs: list[ReadableBuffer], max_cost: int, find_coin: Coin, flags: int) -> tuple[Program, Program]: ...
+def get_puzzle_and_solution_for_coin2(generator: Program, block_refs: Sequence[ReadableBuffer], max_cost: int, find_coin: Coin, flags: int) -> tuple[Program, Program]: ...
 
 @final
 class BLSCache:

--- a/wheel/python/chia_rs/datalayer.pyi
+++ b/wheel/python/chia_rs/datalayer.pyi
@@ -303,7 +303,7 @@ class MerkleBlob:
 
     def __new__(
         cls,
-        blob: bytes,
+        blob: ReadableBuffer,
     ) -> MerkleBlob: ...
 
     @classmethod

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -59,9 +59,9 @@ use pyo3::buffer::PyBuffer;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::pybacked::PyBackedBytes;
-use pyo3::types::PyList;
 use pyo3::types::PyTuple;
 use pyo3::types::{PyBytes, PyDict};
+use pyo3::types::{PyList, PySequence, PySequenceMethods};
 use pyo3::wrap_pyfunction;
 use std::path::Path;
 
@@ -214,17 +214,17 @@ pub fn get_puzzle_and_solution_for_coin<'a>(
 pub fn get_puzzle_and_solution_for_coin2<'a>(
     py: Python<'a>,
     generator: &Program,
-    block_refs: &Bound<'a, PyList>,
+    block_refs: &Bound<'a, PySequence>,
     max_cost: Cost,
     find_coin: &Coin,
     flags: ConsensusFlags,
 ) -> PyResult<(Program, Program)> {
     let mut allocator = make_allocator(ConsensusFlags::LIMIT_HEAP);
 
-    let refs = block_refs.into_iter().map(|b| {
+    let refs = block_refs.to_list()?.into_iter().map(|b| {
         let buf = b
             .extract::<PyBuffer<u8>>()
-            .expect("block_refs should be a list of buffers");
+            .expect("block_refs should be a sequence of buffers");
         py_to_slice::<'a>(buf)
     });
 
@@ -534,15 +534,16 @@ pub fn get_spends_for_trusted_block<'a>(
     py: Python<'a>,
     constants: &ConsensusConstants,
     generator: Program,
-    block_refs: &Bound<'_, PyList>,
+    block_refs: &Bound<'_, PySequence>,
     flags: ConsensusFlags,
 ) -> pyo3::PyResult<Py<PyAny>> {
     let refs = block_refs
+        .to_list()?
         .into_iter()
         .map(|b| {
             let buf = b
                 .extract::<PyBuffer<u8>>()
-                .expect("block_refs must be list of buffers");
+                .expect("block_refs must be sequence of buffers");
             py_to_slice::<'a>(buf)
         })
         .collect::<Vec<&'a [u8]>>();
@@ -560,15 +561,16 @@ pub fn get_spends_for_trusted_block_with_conditions<'a>(
     py: Python<'a>,
     constants: &ConsensusConstants,
     generator: Program,
-    block_refs: &Bound<'a, PyList>,
+    block_refs: &Bound<'a, PySequence>,
     flags: ConsensusFlags,
 ) -> pyo3::PyResult<Py<PyAny>> {
     let refs = block_refs
+        .to_list()?
         .into_iter()
         .map(|b| {
             let buf = b
                 .extract::<PyBuffer<u8>>()
-                .expect("block_refs must be list of buffers");
+                .expect("block_refs must be sequence of buffers");
             py_to_slice::<'a>(buf)
         })
         .collect::<Vec<&'a [u8]>>();

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -13,7 +13,7 @@ use clvmr::cost::Cost;
 use pyo3::PyResult;
 use pyo3::buffer::PyBuffer;
 use pyo3::prelude::*;
-use pyo3::types::PyList;
+use pyo3::types::{PySequence, PySequenceMethods};
 
 pub fn py_to_slice<'a>(buf: PyBuffer<u8>) -> &'a [u8] {
     assert!(buf.is_c_contiguous(), "buffer must be contiguous");
@@ -26,7 +26,7 @@ pub fn py_to_slice<'a>(buf: PyBuffer<u8>) -> &'a [u8] {
 pub fn run_block_generator<'a>(
     py: Python<'a>,
     program: PyBuffer<u8>,
-    block_refs: &Bound<'_, PyList>,
+    block_refs: &Bound<'_, PySequence>,
     max_cost: Cost,
     flags: ConsensusFlags,
     signature: &Signature,
@@ -38,11 +38,13 @@ pub fn run_block_generator<'a>(
     Option<OwnedSpendBundleConditions>,
 ) {
     let refs = block_refs
+        .to_list()
+        .expect("block_refs should be a sequence")
         .into_iter()
         .map(|b| {
             let buf = b
                 .extract::<PyBuffer<u8>>()
-                .expect("block_refs should be a list of buffers");
+                .expect("block_refs should be a sequence of buffers");
             py_to_slice::<'a>(buf)
         })
         .collect::<Vec<&'a [u8]>>();
@@ -75,7 +77,7 @@ pub fn run_block_generator<'a>(
 pub fn run_block_generator2<'a>(
     py: Python<'a>,
     program: PyBuffer<u8>,
-    block_refs: &Bound<'_, PyList>,
+    block_refs: &Bound<'_, PySequence>,
     max_cost: Cost,
     flags: ConsensusFlags,
     signature: &Signature,
@@ -87,11 +89,13 @@ pub fn run_block_generator2<'a>(
     Option<OwnedSpendBundleConditions>,
 ) {
     let refs = block_refs
+        .to_list()
+        .expect("block_refs should be a sequence")
         .into_iter()
         .map(|b| {
             let buf = b
                 .extract::<PyBuffer<u8>>()
-                .expect("block_refs must be list of buffers");
+                .expect("block_refs must be sequence of buffers");
             py_to_slice::<'a>(buf)
         })
         .collect::<Vec<&'a [u8]>>();
@@ -124,16 +128,17 @@ pub fn run_block_generator2<'a>(
 pub fn additions_and_removals<'a>(
     py: Python<'a>,
     program: PyBuffer<u8>,
-    block_refs: &Bound<'_, PyList>,
+    block_refs: &Bound<'_, PySequence>,
     flags: ConsensusFlags,
     constants: &ConsensusConstants,
 ) -> PyResult<(Vec<(Coin, Option<Bytes>)>, Vec<(Bytes32, Coin)>)> {
     let refs = block_refs
+        .to_list()?
         .into_iter()
         .map(|b| {
             let buf = b
                 .extract::<PyBuffer<u8>>()
-                .expect("block_refs must be list of buffers");
+                .expect("block_refs must be sequence of buffers");
             py_to_slice::<'a>(buf)
         })
         .collect::<Vec<&'a [u8]>>();


### PR DESCRIPTION
the intention of this typestub was to accept `bytes`, `bytearray`s and `memoryviews`, but it seems `list` doesn't support an unknown type as the element type. Sequence does however.

It's meant to address some python mypy errors that started popping up on CI:

```
tests/run_gen.py:123: error: Argument 2 has incompatible type "list[bytes]"; expected "list[bytes | bytearray | memoryview[int]]"  [arg-type]
tests/run_gen.py:123: note: "list" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
tests/run_gen.py:123: note: Consider using "Sequence" instead, which is covariant
tests/test_get_spends_for_block.py:15: error: Argument 3 to "get_spends_for_trusted_block_with_conditions" has incompatible type "list[bytes]"; expected "list[bytes | bytearray | memoryview[int]]"  [arg-type]
tests/test_get_spends_for_block.py:15: note: "list" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
tests/test_get_spends_for_block.py:15: note: Consider using "Sequence" instead, which is covariant
tests/test_get_spends_for_block.py:39: error: Argument 3 to "get_spends_for_trusted_block" has incompatible type "list[bytes]"; expected "list[bytes | bytearray | memoryview[int]]"  [arg-type]
tests/test_get_spends_for_block.py:39: note: "list" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
tests/test_get_spends_for_block.py:39: note: Consider using "Sequence" instead, which is covariant
tests/test_get_spends_for_block.py:53: error: Argument 3 to "get_spends_for_trusted_block_with_conditions" has incompatible type "list[bytes]"; expected "list[bytes | bytearray | memoryview[int]]"  [arg-type]

```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily broadens Python/Rust function argument types from `list`/`bytes` to more general buffer/sequence types; runtime behavior should remain compatible, with low risk aside from potential edge cases in PyO3 sequence conversion.
> 
> **Overview**
> Updates the Python type stubs and PyO3 bindings to accept `Sequence[ReadableBuffer]` (instead of `list[...]`) for `block_refs` across generator-related APIs (`run_block_generator*`, `additions_and_removals`, `get_spends_for_trusted_block*`, `get_puzzle_and_solution_for_coin2`), fixing mypy invariance issues while allowing `list`, `tuple`, etc.
> 
> Also broadens the `datalayer.MerkleBlob` constructor stub to accept `ReadableBuffer` rather than only `bytes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 090d854afbfda38e1b54bf2921fe8d6635a26bfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->