### PR TITLE
[CHIA-3823] Add INTERNED_GENERATOR consensus path + serde_2026 prefix guard

### DIFF
--- a/crates/chia-consensus/fuzz/fuzz_targets/interned-block-builder.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/interned-block-builder.rs
@@ -93,12 +93,13 @@ fuzz_target!(|spends: Vec<CoinSpend>| -> Corpus {
     );
 
     // Round-trip: generator bytes must decode back to the same spends (cf. generator.rs).
+    // finalize() emits serde_2026, so INTERNED_GENERATOR is needed to parse it.
     let gen_prog = Program::new(generator.into());
     let Ok(mut result) = get_coinspends_for_trusted_block(
         &TEST_CONSTANTS,
         &gen_prog,
         vec![&[]],
-        ConsensusFlags::empty(),
+        ConsensusFlags::INTERNED_GENERATOR,
     ) else {
         return Corpus::Reject;
     };

--- a/crates/chia-consensus/src/build_interned_block.rs
+++ b/crates/chia-consensus/src/build_interned_block.rs
@@ -1,10 +1,11 @@
 use crate::consensus_constants::ConsensusConstants;
 use crate::error::Result;
 use crate::generator_cost::interned_vbytes;
+use crate::serde_2026::SERDE_2026_COMPRESSION_LEVEL;
 use chia_bls::Signature;
 use chia_protocol::SpendBundle;
 use clvmr::allocator::{Allocator, NodePtr};
-use clvmr::serde::{intern_tree, node_from_bytes_backrefs, node_to_bytes_backrefs};
+use clvmr::serde::{intern_tree, node_from_bytes_backrefs, serialize_2026};
 use std::borrow::Borrow;
 
 #[cfg(feature = "py-bindings")]
@@ -219,7 +220,7 @@ impl InternedBlockBuilder {
             .allocator
             .new_pair(self.spend_list, self.allocator.nil())?;
         let root = self.allocator.new_pair(self.allocator.one(), inner)?;
-        let serialized = node_to_bytes_backrefs(&self.allocator, root)?;
+        let serialized = serialize_2026(&self.allocator, root, SERDE_2026_COMPRESSION_LEVEL)?;
 
         let interned = intern_tree(&self.allocator, root)?;
         let total_cost = interned_vbytes(&interned) * self.cost_per_byte + self.block_cost;

--- a/crates/chia-consensus/src/run_block_generator.rs
+++ b/crates/chia-consensus/src/run_block_generator.rs
@@ -25,10 +25,7 @@ use clvmr::chia_dialect::ChiaDialect;
 use clvmr::cost::Cost;
 use clvmr::reduction::Reduction;
 use clvmr::run_program::run_program;
-use clvmr::serde::{
-    InternedTree, SERDE_2026_MAGIC_PREFIX, intern_tree_limited, node_from_bytes,
-    node_from_bytes_backrefs,
-};
+use clvmr::serde::{InternedTree, intern_tree_limited, node_from_bytes, node_from_bytes_backrefs};
 
 pub fn subtract_cost(cost_left: &mut Cost, subtract: Cost) -> Result<(), ValidationErr> {
     if subtract > *cost_left {
@@ -175,17 +172,6 @@ fn extract_n<const N: usize>(
 // this is required after the SIMPLE_GENERATOR fork is active
 #[inline]
 pub fn check_generator_quote(program: &[u8], flags: ConsensusFlags) -> Result<(), ValidationErr> {
-    // CRITICAL: Reject serde_2026 format before INTERNED_GENERATOR activates.
-    // Without this explicit guard, a serde_2026-prefixed generator would be
-    // accepted on the pre-HF2 chain during the window between code shipping
-    // and SIMPLE_GENERATOR (soft_fork9) activation.
-    if !flags.contains(ConsensusFlags::INTERNED_GENERATOR)
-        && program.starts_with(&SERDE_2026_MAGIC_PREFIX)
-    {
-        return Err(ValidationErr::Err(
-            ErrorCode::InvalidTransactionsGeneratorEncoding,
-        ));
-    }
     if flags.contains(ConsensusFlags::INTERNED_GENERATOR) {
         // serde_2026 blocks have a different serialization header
         return Ok(());
@@ -363,9 +349,13 @@ where
     check_generator_quote(generator.as_ref(), flags)?;
     let mut output = Vec::<CoinSpend>::new();
 
-    let max_blob_size =
-        max_canonical_blob_size(constants.max_block_cost_clvm, constants.cost_per_byte);
-    let program = node_from_bytes_auto(&mut a, generator, max_blob_size)?;
+    let program = if flags.contains(ConsensusFlags::INTERNED_GENERATOR) {
+        let max_blob_size =
+            max_canonical_blob_size(constants.max_block_cost_clvm, constants.cost_per_byte);
+        node_from_bytes_auto(&mut a, generator, max_blob_size)?
+    } else {
+        node_from_bytes_backrefs(&mut a, generator)?
+    };
     check_generator_node(&a, program, flags)?;
     let args = setup_generator_args(&mut a, refs, flags)?;
     let dialect = ChiaDialect::new(flags.to_clvm_flags());
@@ -464,9 +454,13 @@ where
     check_generator_quote(generator.as_ref(), flags)?;
     let mut output = Vec::<(CoinSpend, Vec<(u32, Vec<Vec<u8>>)>)>::new();
 
-    let max_blob_size =
-        max_canonical_blob_size(constants.max_block_cost_clvm, constants.cost_per_byte);
-    let program = node_from_bytes_auto(&mut a, generator, max_blob_size)?;
+    let program = if flags.contains(ConsensusFlags::INTERNED_GENERATOR) {
+        let max_blob_size =
+            max_canonical_blob_size(constants.max_block_cost_clvm, constants.cost_per_byte);
+        node_from_bytes_auto(&mut a, generator, max_blob_size)?
+    } else {
+        node_from_bytes_backrefs(&mut a, generator)?
+    };
     check_generator_node(&a, program, flags)?;
     let args = setup_generator_args(&mut a, refs, flags)?;
     let dialect = ChiaDialect::new(flags.to_clvm_flags());
@@ -578,7 +572,7 @@ mod tests {
     use chia_protocol::Bytes32;
     use clvm_traits::ToClvm;
     use clvm_utils::tree_hash_atom;
-    use clvmr::serde::node_to_bytes;
+    use clvmr::serde::{SERDE_2026_MAGIC_PREFIX, node_to_bytes};
     use rstest::rstest;
 
     const IDENTITY_PUZZLE: &[u8] = &[1];
@@ -733,31 +727,51 @@ mod tests {
     #[test]
     fn test_check_generator_quote_pre_simple_always_passes() {
         let flags = ConsensusFlags::empty();
-        // Before SIMPLE_GENERATOR, non-serde_2026 bytes are accepted
+        // Before SIMPLE_GENERATOR, the quote check accepts any bytes
         assert!(check_generator_quote(&[0x80], flags).is_ok());
         assert!(check_generator_quote(&[0xff, 0x01, 0x80], flags).is_ok());
     }
 
     #[test]
-    fn test_check_generator_quote_rejects_serde_2026_without_interned_flag() {
-        // CRITICAL guard: serde_2026 prefix must be rejected whenever
-        // INTERNED_GENERATOR is NOT set, regardless of SIMPLE_GENERATOR.
-        let prefix = SERDE_2026_MAGIC_PREFIX;
+    fn test_serde_2026_blob_rejected_without_interned_flag() {
+        // Without INTERNED_GENERATOR, a serde_2026-prefixed blob must fail the
+        // same way as on deployed nodes: the magic prefix starts with 0xfd,
+        // which is an invalid header byte in classic CLVM serialization, so
+        // node_from_bytes_backrefs() fails and maps to GeneratorRuntimeError.
+        let mut blob = SERDE_2026_MAGIC_PREFIX.to_vec();
+        blob.push(0x80);
+        let blocks: &[&[u8]] = &[];
+
         // Pre-fork (no flags at all)
-        let flags = ConsensusFlags::empty();
-        assert_eq!(
-            check_generator_quote(&prefix, flags)
-                .unwrap_err()
-                .error_code(),
-            ErrorCode::InvalidTransactionsGeneratorEncoding,
+        let result = run_block_generator2(
+            &blob,
+            blocks,
+            u64::MAX,
+            ConsensusFlags::DONT_VALIDATE_SIGNATURE,
+            &Signature::default(),
+            None,
+            &TEST_CONSTANTS,
         );
-        // SIMPLE_GENERATOR active but INTERNED_GENERATOR not yet
-        let flags = ConsensusFlags::SIMPLE_GENERATOR;
         assert_eq!(
-            check_generator_quote(&prefix, flags)
-                .unwrap_err()
-                .error_code(),
-            ErrorCode::InvalidTransactionsGeneratorEncoding,
+            result.unwrap_err().error_code(),
+            ErrorCode::GeneratorRuntimeError,
+        );
+
+        // SIMPLE_GENERATOR active but INTERNED_GENERATOR not yet: the blob
+        // fails the quote check first (it doesn't start with [0xff, 0x01]),
+        // exactly as on deployed nodes.
+        let result = run_block_generator2(
+            &blob,
+            blocks,
+            u64::MAX,
+            ConsensusFlags::DONT_VALIDATE_SIGNATURE | ConsensusFlags::SIMPLE_GENERATOR,
+            &Signature::default(),
+            None,
+            &TEST_CONSTANTS,
+        );
+        assert_eq!(
+            result.unwrap_err().error_code(),
+            ErrorCode::ComplexGeneratorReceived,
         );
     }
 

--- a/crates/chia-consensus/src/run_block_generator.rs
+++ b/crates/chia-consensus/src/run_block_generator.rs
@@ -11,6 +11,7 @@ use crate::opcodes::{
     AGG_SIG_AMOUNT, AGG_SIG_ME, AGG_SIG_PARENT, AGG_SIG_PARENT_AMOUNT, AGG_SIG_PARENT_PUZZLE,
     AGG_SIG_PUZZLE, AGG_SIG_PUZZLE_AMOUNT, AGG_SIG_UNSAFE, CREATE_COIN,
 };
+use crate::serde_2026::{max_canonical_blob_size, node_from_bytes_auto};
 use crate::validation_error::{ErrorCode, ValidationErr, first};
 use chia_bls::{BlsCache, Signature};
 use chia_protocol::{BytesImpl, Coin, CoinSpend, Program};
@@ -24,7 +25,10 @@ use clvmr::chia_dialect::ChiaDialect;
 use clvmr::cost::Cost;
 use clvmr::reduction::Reduction;
 use clvmr::run_program::run_program;
-use clvmr::serde::{InternedTree, intern_tree_limited, node_from_bytes, node_from_bytes_backrefs};
+use clvmr::serde::{
+    InternedTree, SERDE_2026_MAGIC_PREFIX, intern_tree_limited, node_from_bytes,
+    node_from_bytes_backrefs,
+};
 
 pub fn subtract_cost(cost_left: &mut Cost, subtract: Cost) -> Result<(), ValidationErr> {
     if subtract > *cost_left {
@@ -171,6 +175,21 @@ fn extract_n<const N: usize>(
 // this is required after the SIMPLE_GENERATOR fork is active
 #[inline]
 pub fn check_generator_quote(program: &[u8], flags: ConsensusFlags) -> Result<(), ValidationErr> {
+    // CRITICAL: Reject serde_2026 format before INTERNED_GENERATOR activates.
+    // Without this explicit guard, a serde_2026-prefixed generator would be
+    // accepted on the pre-HF2 chain during the window between code shipping
+    // and SIMPLE_GENERATOR (soft_fork9) activation.
+    if !flags.contains(ConsensusFlags::INTERNED_GENERATOR)
+        && program.starts_with(&SERDE_2026_MAGIC_PREFIX)
+    {
+        return Err(ValidationErr::Err(
+            ErrorCode::InvalidTransactionsGeneratorEncoding,
+        ));
+    }
+    if flags.contains(ConsensusFlags::INTERNED_GENERATOR) {
+        // serde_2026 blocks have a different serialization header
+        return Ok(());
+    }
     if !flags.contains(ConsensusFlags::SIMPLE_GENERATOR) || program.starts_with(&[0xff, 0x01]) {
         Ok(())
     } else {
@@ -186,7 +205,9 @@ pub fn check_generator_node(
     program: NodePtr,
     flags: ConsensusFlags,
 ) -> Result<(), ValidationErr> {
-    if !flags.contains(ConsensusFlags::SIMPLE_GENERATOR) {
+    if !flags.contains(ConsensusFlags::SIMPLE_GENERATOR)
+        || flags.contains(ConsensusFlags::INTERNED_GENERATOR)
+    {
         return Ok(());
     }
     // this expects an atom with a single byte value of 1 as the first value in the list
@@ -223,7 +244,9 @@ where
 
     let (mut a, base_cost, program) = if flags.contains(ConsensusFlags::INTERNED_GENERATOR) {
         let mut decode_allocator = Allocator::new();
-        let program_node = node_from_bytes_backrefs(&mut decode_allocator, program)?;
+        let max_blob_size = max_canonical_blob_size(max_cost, constants.cost_per_byte);
+        let program_node = node_from_bytes_auto(&mut decode_allocator, program, max_blob_size)
+            .map_err(|_| ValidationErr::Err(ErrorCode::GeneratorRuntimeError))?;
         let interned = intern_tree_limited(&decode_allocator, program_node, u32::MAX as usize)
             .map_err(|_| ValidationErr::Err(ErrorCode::GeneratorRuntimeError))?;
         let cost = interned_vbytes(&interned) * constants.cost_per_byte;
@@ -340,7 +363,9 @@ where
     check_generator_quote(generator.as_ref(), flags)?;
     let mut output = Vec::<CoinSpend>::new();
 
-    let program = node_from_bytes_backrefs(&mut a, generator)?;
+    let max_blob_size =
+        max_canonical_blob_size(constants.max_block_cost_clvm, constants.cost_per_byte);
+    let program = node_from_bytes_auto(&mut a, generator, max_blob_size)?;
     check_generator_node(&a, program, flags)?;
     let args = setup_generator_args(&mut a, refs, flags)?;
     let dialect = ChiaDialect::new(flags.to_clvm_flags());
@@ -439,7 +464,9 @@ where
     check_generator_quote(generator.as_ref(), flags)?;
     let mut output = Vec::<(CoinSpend, Vec<(u32, Vec<Vec<u8>>)>)>::new();
 
-    let program = node_from_bytes_backrefs(&mut a, generator)?;
+    let max_blob_size =
+        max_canonical_blob_size(constants.max_block_cost_clvm, constants.cost_per_byte);
+    let program = node_from_bytes_auto(&mut a, generator, max_blob_size)?;
     check_generator_node(&a, program, flags)?;
     let args = setup_generator_args(&mut a, refs, flags)?;
     let dialect = ChiaDialect::new(flags.to_clvm_flags());
@@ -679,5 +706,95 @@ mod tests {
         );
 
         assert_eq!(without.execution_cost, with.execution_cost);
+    }
+
+    #[test]
+    fn test_check_generator_quote_simple_only_rejects_non_quote() {
+        let flags = ConsensusFlags::SIMPLE_GENERATOR;
+        // Non-quote generator: starts with 0x80 (nil atom), not [0xff, 0x01]
+        assert_eq!(
+            check_generator_quote(&[0x80], flags)
+                .unwrap_err()
+                .error_code(),
+            ErrorCode::ComplexGeneratorReceived,
+        );
+        // Valid quote generator: starts with [0xff, 0x01]
+        assert!(check_generator_quote(&[0xff, 0x01, 0x80], flags).is_ok());
+    }
+
+    #[test]
+    fn test_check_generator_quote_interned_bypasses_check() {
+        let flags = ConsensusFlags::SIMPLE_GENERATOR | ConsensusFlags::INTERNED_GENERATOR;
+        // With INTERNED_GENERATOR, even non-quote bytes are accepted
+        assert!(check_generator_quote(&[0x80], flags).is_ok());
+        assert!(check_generator_quote(&[0x00, 0x42], flags).is_ok());
+    }
+
+    #[test]
+    fn test_check_generator_quote_pre_simple_always_passes() {
+        let flags = ConsensusFlags::empty();
+        // Before SIMPLE_GENERATOR, non-serde_2026 bytes are accepted
+        assert!(check_generator_quote(&[0x80], flags).is_ok());
+        assert!(check_generator_quote(&[0xff, 0x01, 0x80], flags).is_ok());
+    }
+
+    #[test]
+    fn test_check_generator_quote_rejects_serde_2026_without_interned_flag() {
+        // CRITICAL guard: serde_2026 prefix must be rejected whenever
+        // INTERNED_GENERATOR is NOT set, regardless of SIMPLE_GENERATOR.
+        let prefix = SERDE_2026_MAGIC_PREFIX;
+        // Pre-fork (no flags at all)
+        let flags = ConsensusFlags::empty();
+        assert_eq!(
+            check_generator_quote(&prefix, flags)
+                .unwrap_err()
+                .error_code(),
+            ErrorCode::InvalidTransactionsGeneratorEncoding,
+        );
+        // SIMPLE_GENERATOR active but INTERNED_GENERATOR not yet
+        let flags = ConsensusFlags::SIMPLE_GENERATOR;
+        assert_eq!(
+            check_generator_quote(&prefix, flags)
+                .unwrap_err()
+                .error_code(),
+            ErrorCode::InvalidTransactionsGeneratorEncoding,
+        );
+    }
+
+    #[test]
+    fn test_check_generator_quote_accepts_serde_2026_with_interned_flag() {
+        let prefix = SERDE_2026_MAGIC_PREFIX;
+        let flags = ConsensusFlags::INTERNED_GENERATOR;
+        assert!(check_generator_quote(&prefix, flags).is_ok());
+        let flags = ConsensusFlags::SIMPLE_GENERATOR | ConsensusFlags::INTERNED_GENERATOR;
+        assert!(check_generator_quote(&prefix, flags).is_ok());
+    }
+
+    #[test]
+    fn test_check_generator_node_simple_only_rejects_non_quote() {
+        let flags = ConsensusFlags::SIMPLE_GENERATOR;
+        let mut a = Allocator::new();
+        // Build a non-quote tree: just an atom (not (1 . rest))
+        let atom = a.new_atom(&[42]).unwrap();
+        assert_eq!(
+            check_generator_node(&a, atom, flags)
+                .unwrap_err()
+                .error_code(),
+            ErrorCode::ComplexGeneratorReceived,
+        );
+        // Build a valid (1 . nil) tree
+        let one = a.new_atom(&[1]).unwrap();
+        let nil = a.nil();
+        let pair = a.new_pair(one, nil).unwrap();
+        assert!(check_generator_node(&a, pair, flags).is_ok());
+    }
+
+    #[test]
+    fn test_check_generator_node_interned_bypasses_check() {
+        let flags = ConsensusFlags::SIMPLE_GENERATOR | ConsensusFlags::INTERNED_GENERATOR;
+        let mut a = Allocator::new();
+        let atom = a.new_atom(&[42]).unwrap();
+        // INTERNED_GENERATOR bypasses the node check even for non-quote trees
+        assert!(check_generator_node(&a, atom, flags).is_ok());
     }
 }

--- a/crates/chia-consensus/src/run_block_generator.rs
+++ b/crates/chia-consensus/src/run_block_generator.rs
@@ -232,8 +232,7 @@ where
     let (mut a, base_cost, program) = if flags.contains(ConsensusFlags::INTERNED_GENERATOR) {
         let mut decode_allocator = Allocator::new();
         let max_blob_size = max_canonical_blob_size(max_cost, constants.cost_per_byte);
-        let program_node = node_from_bytes_2026(&mut decode_allocator, program, max_blob_size)
-            .map_err(|_| ValidationErr::Err(ErrorCode::GeneratorRuntimeError))?;
+        let program_node = node_from_bytes_2026(&mut decode_allocator, program, max_blob_size)?;
         let interned = intern_tree_limited(&decode_allocator, program_node, u32::MAX as usize)
             .map_err(|_| ValidationErr::Err(ErrorCode::GeneratorRuntimeError))?;
         let cost = interned_vbytes(&interned) * constants.cost_per_byte;
@@ -861,8 +860,8 @@ mod tests {
             &TEST_CONSTANTS,
         );
         assert_eq!(
-            result.unwrap_err().error_code(),
-            ErrorCode::GeneratorRuntimeError,
+            result.unwrap_err(),
+            ValidationErr::Eval(clvmr::error::EvalErr::SerializationError),
         );
     }
 }

--- a/crates/chia-consensus/src/run_block_generator.rs
+++ b/crates/chia-consensus/src/run_block_generator.rs
@@ -11,7 +11,7 @@ use crate::opcodes::{
     AGG_SIG_AMOUNT, AGG_SIG_ME, AGG_SIG_PARENT, AGG_SIG_PARENT_AMOUNT, AGG_SIG_PARENT_PUZZLE,
     AGG_SIG_PUZZLE, AGG_SIG_PUZZLE_AMOUNT, AGG_SIG_UNSAFE, CREATE_COIN,
 };
-use crate::serde_2026::{max_canonical_blob_size, node_from_bytes_auto};
+use crate::serde_2026::{max_canonical_blob_size, node_from_bytes_2026};
 use crate::validation_error::{ErrorCode, ValidationErr, first};
 use chia_bls::{BlsCache, Signature};
 use chia_protocol::{BytesImpl, Coin, CoinSpend, Program};
@@ -25,10 +25,7 @@ use clvmr::chia_dialect::ChiaDialect;
 use clvmr::cost::Cost;
 use clvmr::reduction::Reduction;
 use clvmr::run_program::run_program;
-use clvmr::serde::{
-    InternedTree, SERDE_2026_MAGIC_PREFIX, intern_tree_limited, node_from_bytes,
-    node_from_bytes_backrefs,
-};
+use clvmr::serde::{InternedTree, intern_tree_limited, node_from_bytes, node_from_bytes_backrefs};
 
 pub fn subtract_cost(cost_left: &mut Cost, subtract: Cost) -> Result<(), ValidationErr> {
     if subtract > *cost_left {
@@ -175,12 +172,11 @@ fn extract_n<const N: usize>(
 // this is required after the SIMPLE_GENERATOR fork is active
 #[inline]
 pub fn check_generator_quote(program: &[u8], flags: ConsensusFlags) -> Result<(), ValidationErr> {
-    if flags.contains(ConsensusFlags::INTERNED_GENERATOR)
-        && program.starts_with(&SERDE_2026_MAGIC_PREFIX)
-    {
-        // the serde_2026 header can't match the [0xff, 0x01] quote shape;
-        // quote enforcement happens post-deserialization in
-        // check_generator_node() instead
+    if flags.contains(ConsensusFlags::INTERNED_GENERATOR) {
+        // nothing to check at the byte level: serde_2026 (the only legal
+        // encoding, enforced by node_from_bytes_2026 at parse time) can't be
+        // examined for the quote shape; quote enforcement happens
+        // post-deserialization in check_generator_node() instead
         return Ok(());
     }
     if !flags.contains(ConsensusFlags::SIMPLE_GENERATOR) || program.starts_with(&[0xff, 0x01]) {
@@ -236,7 +232,7 @@ where
     let (mut a, base_cost, program) = if flags.contains(ConsensusFlags::INTERNED_GENERATOR) {
         let mut decode_allocator = Allocator::new();
         let max_blob_size = max_canonical_blob_size(max_cost, constants.cost_per_byte);
-        let program_node = node_from_bytes_auto(&mut decode_allocator, program, max_blob_size)
+        let program_node = node_from_bytes_2026(&mut decode_allocator, program, max_blob_size)
             .map_err(|_| ValidationErr::Err(ErrorCode::GeneratorRuntimeError))?;
         let interned = intern_tree_limited(&decode_allocator, program_node, u32::MAX as usize)
             .map_err(|_| ValidationErr::Err(ErrorCode::GeneratorRuntimeError))?;
@@ -357,7 +353,7 @@ where
     let program = if flags.contains(ConsensusFlags::INTERNED_GENERATOR) {
         let max_blob_size =
             max_canonical_blob_size(constants.max_block_cost_clvm, constants.cost_per_byte);
-        node_from_bytes_auto(&mut a, generator, max_blob_size)?
+        node_from_bytes_2026(&mut a, generator, max_blob_size)?
     } else {
         node_from_bytes_backrefs(&mut a, generator)?
     };
@@ -462,7 +458,7 @@ where
     let program = if flags.contains(ConsensusFlags::INTERNED_GENERATOR) {
         let max_blob_size =
             max_canonical_blob_size(constants.max_block_cost_clvm, constants.cost_per_byte);
-        node_from_bytes_auto(&mut a, generator, max_blob_size)?
+        node_from_bytes_2026(&mut a, generator, max_blob_size)?
     } else {
         node_from_bytes_backrefs(&mut a, generator)?
     };
@@ -577,7 +573,7 @@ mod tests {
     use chia_protocol::Bytes32;
     use clvm_traits::ToClvm;
     use clvm_utils::tree_hash_atom;
-    use clvmr::serde::node_to_bytes;
+    use clvmr::serde::{SERDE_2026_MAGIC_PREFIX, node_to_bytes};
     use rstest::rstest;
 
     const IDENTITY_PUZZLE: &[u8] = &[1];
@@ -708,49 +704,14 @@ mod tests {
     }
 
     #[test]
-    fn test_check_generator_quote_simple_only_rejects_non_quote() {
-        let flags = ConsensusFlags::SIMPLE_GENERATOR;
-        // Non-quote generator: starts with 0x80 (nil atom), not [0xff, 0x01]
-        assert_eq!(
-            check_generator_quote(&[0x80], flags)
-                .unwrap_err()
-                .error_code(),
-            ErrorCode::ComplexGeneratorReceived,
-        );
-        // Valid quote generator: starts with [0xff, 0x01]
-        assert!(check_generator_quote(&[0xff, 0x01, 0x80], flags).is_ok());
-    }
-
-    #[test]
-    fn test_check_generator_quote_interned_only_bypasses_serde_2026() {
+    fn test_check_generator_quote_interned_defers_to_parse_and_node_checks() {
+        // with INTERNED_GENERATOR set, there is nothing to check at the byte
+        // level: encoding is enforced by node_from_bytes_2026 at parse time
+        // and the quote shape by check_generator_node() after decode
         let flags = ConsensusFlags::SIMPLE_GENERATOR | ConsensusFlags::INTERNED_GENERATOR;
-        // serde_2026-prefixed blobs skip the byte-level quote check (their
-        // header can't match [0xff, 0x01]); enforcement happens at the node
-        // level instead
         assert!(check_generator_quote(&SERDE_2026_MAGIC_PREFIX, flags).is_ok());
-        // classic encodings keep the post-SIMPLE_GENERATOR quote enforcement
-        // even after INTERNED_GENERATOR activates
         assert!(check_generator_quote(&[0xff, 0x01, 0x80], flags).is_ok());
-        assert_eq!(
-            check_generator_quote(&[0x80], flags)
-                .unwrap_err()
-                .error_code(),
-            ErrorCode::ComplexGeneratorReceived,
-        );
-        assert_eq!(
-            check_generator_quote(&[0x00, 0x42], flags)
-                .unwrap_err()
-                .error_code(),
-            ErrorCode::ComplexGeneratorReceived,
-        );
-    }
-
-    #[test]
-    fn test_check_generator_quote_pre_simple_always_passes() {
-        let flags = ConsensusFlags::empty();
-        // Before SIMPLE_GENERATOR, the quote check accepts any bytes
         assert!(check_generator_quote(&[0x80], flags).is_ok());
-        assert!(check_generator_quote(&[0xff, 0x01, 0x80], flags).is_ok());
     }
 
     #[test]
@@ -794,34 +755,6 @@ mod tests {
             result.unwrap_err().error_code(),
             ErrorCode::ComplexGeneratorReceived,
         );
-    }
-
-    #[test]
-    fn test_check_generator_quote_accepts_serde_2026_with_interned_flag() {
-        let prefix = SERDE_2026_MAGIC_PREFIX;
-        let flags = ConsensusFlags::INTERNED_GENERATOR;
-        assert!(check_generator_quote(&prefix, flags).is_ok());
-        let flags = ConsensusFlags::SIMPLE_GENERATOR | ConsensusFlags::INTERNED_GENERATOR;
-        assert!(check_generator_quote(&prefix, flags).is_ok());
-    }
-
-    #[test]
-    fn test_check_generator_node_simple_only_rejects_non_quote() {
-        let flags = ConsensusFlags::SIMPLE_GENERATOR;
-        let mut a = Allocator::new();
-        // Build a non-quote tree: just an atom (not (1 . rest))
-        let atom = a.new_atom(&[42]).unwrap();
-        assert_eq!(
-            check_generator_node(&a, atom, flags)
-                .unwrap_err()
-                .error_code(),
-            ErrorCode::ComplexGeneratorReceived,
-        );
-        // Build a valid (1 . nil) tree
-        let one = a.new_atom(&[1]).unwrap();
-        let nil = a.nil();
-        let pair = a.new_pair(one, nil).unwrap();
-        assert!(check_generator_node(&a, pair, flags).is_ok());
     }
 
     #[test]
@@ -894,6 +827,42 @@ mod tests {
         assert_eq!(
             result.unwrap_err().error_code(),
             ErrorCode::ComplexGeneratorReceived,
+        );
+    }
+
+    #[test]
+    fn test_old_serialization_rejected_with_interned_flag() {
+        // with INTERNED_GENERATOR active, an otherwise-valid generator in the
+        // old (classic/backrefs) serialization is a consensus failure
+        let program = make_generator(1);
+        assert!(program.starts_with(&[0xff, 0x01]));
+        let blocks: &[&[u8]] = &[];
+
+        let flags = ConsensusFlags::DONT_VALIDATE_SIGNATURE | ConsensusFlags::SIMPLE_GENERATOR;
+        let result = run_block_generator2(
+            &program,
+            blocks,
+            u64::MAX,
+            flags,
+            &Signature::default(),
+            None,
+            &TEST_CONSTANTS,
+        );
+        assert!(result.is_ok(), "sanity: valid without INTERNED_GENERATOR");
+
+        let flags = flags | ConsensusFlags::INTERNED_GENERATOR;
+        let result = run_block_generator2(
+            &program,
+            blocks,
+            u64::MAX,
+            flags,
+            &Signature::default(),
+            None,
+            &TEST_CONSTANTS,
+        );
+        assert_eq!(
+            result.unwrap_err().error_code(),
+            ErrorCode::GeneratorRuntimeError,
         );
     }
 }

--- a/crates/chia-consensus/src/run_block_generator.rs
+++ b/crates/chia-consensus/src/run_block_generator.rs
@@ -25,7 +25,10 @@ use clvmr::chia_dialect::ChiaDialect;
 use clvmr::cost::Cost;
 use clvmr::reduction::Reduction;
 use clvmr::run_program::run_program;
-use clvmr::serde::{InternedTree, intern_tree_limited, node_from_bytes, node_from_bytes_backrefs};
+use clvmr::serde::{
+    InternedTree, SERDE_2026_MAGIC_PREFIX, intern_tree_limited, node_from_bytes,
+    node_from_bytes_backrefs,
+};
 
 pub fn subtract_cost(cost_left: &mut Cost, subtract: Cost) -> Result<(), ValidationErr> {
     if subtract > *cost_left {
@@ -172,8 +175,12 @@ fn extract_n<const N: usize>(
 // this is required after the SIMPLE_GENERATOR fork is active
 #[inline]
 pub fn check_generator_quote(program: &[u8], flags: ConsensusFlags) -> Result<(), ValidationErr> {
-    if flags.contains(ConsensusFlags::INTERNED_GENERATOR) {
-        // serde_2026 blocks have a different serialization header
+    if flags.contains(ConsensusFlags::INTERNED_GENERATOR)
+        && program.starts_with(&SERDE_2026_MAGIC_PREFIX)
+    {
+        // the serde_2026 header can't match the [0xff, 0x01] quote shape;
+        // quote enforcement happens post-deserialization in
+        // check_generator_node() instead
         return Ok(());
     }
     if !flags.contains(ConsensusFlags::SIMPLE_GENERATOR) || program.starts_with(&[0xff, 0x01]) {
@@ -191,9 +198,7 @@ pub fn check_generator_node(
     program: NodePtr,
     flags: ConsensusFlags,
 ) -> Result<(), ValidationErr> {
-    if !flags.contains(ConsensusFlags::SIMPLE_GENERATOR)
-        || flags.contains(ConsensusFlags::INTERNED_GENERATOR)
-    {
+    if !flags.contains(ConsensusFlags::SIMPLE_GENERATOR) {
         return Ok(());
     }
     // this expects an atom with a single byte value of 1 as the first value in the list
@@ -572,7 +577,7 @@ mod tests {
     use chia_protocol::Bytes32;
     use clvm_traits::ToClvm;
     use clvm_utils::tree_hash_atom;
-    use clvmr::serde::{SERDE_2026_MAGIC_PREFIX, node_to_bytes};
+    use clvmr::serde::node_to_bytes;
     use rstest::rstest;
 
     const IDENTITY_PUZZLE: &[u8] = &[1];
@@ -717,11 +722,27 @@ mod tests {
     }
 
     #[test]
-    fn test_check_generator_quote_interned_bypasses_check() {
+    fn test_check_generator_quote_interned_only_bypasses_serde_2026() {
         let flags = ConsensusFlags::SIMPLE_GENERATOR | ConsensusFlags::INTERNED_GENERATOR;
-        // With INTERNED_GENERATOR, even non-quote bytes are accepted
-        assert!(check_generator_quote(&[0x80], flags).is_ok());
-        assert!(check_generator_quote(&[0x00, 0x42], flags).is_ok());
+        // serde_2026-prefixed blobs skip the byte-level quote check (their
+        // header can't match [0xff, 0x01]); enforcement happens at the node
+        // level instead
+        assert!(check_generator_quote(&SERDE_2026_MAGIC_PREFIX, flags).is_ok());
+        // classic encodings keep the post-SIMPLE_GENERATOR quote enforcement
+        // even after INTERNED_GENERATOR activates
+        assert!(check_generator_quote(&[0xff, 0x01, 0x80], flags).is_ok());
+        assert_eq!(
+            check_generator_quote(&[0x80], flags)
+                .unwrap_err()
+                .error_code(),
+            ErrorCode::ComplexGeneratorReceived,
+        );
+        assert_eq!(
+            check_generator_quote(&[0x00, 0x42], flags)
+                .unwrap_err()
+                .error_code(),
+            ErrorCode::ComplexGeneratorReceived,
+        );
     }
 
     #[test]
@@ -804,11 +825,75 @@ mod tests {
     }
 
     #[test]
-    fn test_check_generator_node_interned_bypasses_check() {
+    fn test_check_generator_node_enforced_with_interned_flag() {
+        // The node-level check is the quote enforcement point for serde_2026
+        // blobs (whose byte encoding can't be checked for the quote shape),
+        // so it must NOT be bypassed when INTERNED_GENERATOR is set.
         let flags = ConsensusFlags::SIMPLE_GENERATOR | ConsensusFlags::INTERNED_GENERATOR;
         let mut a = Allocator::new();
         let atom = a.new_atom(&[42]).unwrap();
-        // INTERNED_GENERATOR bypasses the node check even for non-quote trees
-        assert!(check_generator_node(&a, atom, flags).is_ok());
+        assert_eq!(
+            check_generator_node(&a, atom, flags)
+                .unwrap_err()
+                .error_code(),
+            ErrorCode::ComplexGeneratorReceived,
+        );
+        let one = a.new_atom(&[1]).unwrap();
+        let nil = a.nil();
+        let pair = a.new_pair(one, nil).unwrap();
+        assert!(check_generator_node(&a, pair, flags).is_ok());
+    }
+
+    #[test]
+    fn test_serde_2026_quote_enforcement_end_to_end() {
+        use crate::solution_generator::solution_generator_2026;
+        use clvmr::serde::serialize_2026;
+
+        let flags = ConsensusFlags::DONT_VALIDATE_SIGNATURE
+            | ConsensusFlags::SIMPLE_GENERATOR
+            | ConsensusFlags::INTERNED_GENERATOR;
+        let blocks: &[&[u8]] = &[];
+
+        // a quoted spend list in serde_2026 encoding is accepted
+        let puzzle_hash = tree_hash_atom(&[1]).to_bytes();
+        let empty_solution: &[u8] = &[0x80];
+        let spends = [(
+            Coin::new([0u8; 32].into(), puzzle_hash.into(), 0),
+            IDENTITY_PUZZLE,
+            empty_solution,
+        )];
+        let program = solution_generator_2026(spends).expect("solution_generator_2026");
+        assert!(program.starts_with(&SERDE_2026_MAGIC_PREFIX));
+        let (_, conds) = run_block_generator2(
+            &program,
+            blocks,
+            u64::MAX,
+            flags,
+            &Signature::default(),
+            None,
+            &TEST_CONSTANTS,
+        )
+        .expect("run_block_generator2");
+        assert_eq!(conds.spends.len(), 1);
+
+        // a non-quoted serde_2026 generator is rejected by the node-level
+        // quote check
+        let mut a = Allocator::new();
+        let atom = a.new_atom(&[42]).unwrap();
+        let blob = serialize_2026(&a, atom, 0).expect("serialize_2026");
+        assert!(blob.starts_with(&SERDE_2026_MAGIC_PREFIX));
+        let result = run_block_generator2(
+            &blob,
+            blocks,
+            u64::MAX,
+            flags,
+            &Signature::default(),
+            None,
+            &TEST_CONSTANTS,
+        );
+        assert_eq!(
+            result.unwrap_err().error_code(),
+            ErrorCode::ComplexGeneratorReceived,
+        );
     }
 }

--- a/crates/chia-consensus/src/serde_2026.rs
+++ b/crates/chia-consensus/src/serde_2026.rs
@@ -10,6 +10,22 @@ use clvmr::allocator::{Allocator, NodePtr};
 use clvmr::error::{EvalErr, Result};
 use clvmr::serde::{SERDE_2026_MAGIC_PREFIX, deserialize_2026, node_from_bytes_backrefs};
 
+/// Deserialize a generator on the consensus path: the blob must be a
+/// magic-prefixed serde_2026 encoding, with no fallback to classic/backrefs
+/// parsing — with `INTERNED_GENERATOR` active, serde_2026 is the only legal
+/// generator encoding. `max_blob_size` and `strict = false` have the same
+/// meaning (and rationale) as in [`node_from_bytes_auto`].
+pub fn node_from_bytes_2026(
+    allocator: &mut Allocator,
+    bytes: &[u8],
+    max_blob_size: usize,
+) -> Result<NodePtr> {
+    if bytes.len() > max_blob_size {
+        return Err(EvalErr::SerializationError);
+    }
+    deserialize_2026(allocator, bytes, max_blob_size, false)
+}
+
 /// Compression level passed to [`clvmr::serde::serialize_2026`] when chia
 /// produces serde_2026 blobs.
 ///

--- a/crates/chia-consensus/src/validation_error.rs
+++ b/crates/chia-consensus/src/validation_error.rs
@@ -165,6 +165,7 @@ pub enum ErrorCode {
     MessageNotSentOrReceived,
     ComplexGeneratorReceived,
     TooManySpends,
+    InvalidTransactionsGeneratorEncoding,
 }
 
 #[derive(Debug, PartialEq, Error)]
@@ -380,6 +381,7 @@ impl From<ErrorCode> for u32 {
             ErrorCode::MessageNotSentOrReceived => 147,
             ErrorCode::ComplexGeneratorReceived => 148,
             ErrorCode::TooManySpends => 149,
+            ErrorCode::InvalidTransactionsGeneratorEncoding => 150,
         }
     }
 }

--- a/crates/chia-consensus/src/validation_error.rs
+++ b/crates/chia-consensus/src/validation_error.rs
@@ -165,7 +165,6 @@ pub enum ErrorCode {
     MessageNotSentOrReceived,
     ComplexGeneratorReceived,
     TooManySpends,
-    InvalidTransactionsGeneratorEncoding,
 }
 
 #[derive(Debug, PartialEq, Error)]
@@ -381,7 +380,6 @@ impl From<ErrorCode> for u32 {
             ErrorCode::MessageNotSentOrReceived => 147,
             ErrorCode::ComplexGeneratorReceived => 148,
             ErrorCode::TooManySpends => 149,
-            ErrorCode::InvalidTransactionsGeneratorEncoding => 150,
         }
     }
 }


### PR DESCRIPTION
## Summary

Implement the `INTERNED_GENERATOR` consensus path in `run_block_generator2`.

We also tweak `check_generator_quote` to skip checking serde_2026-serialized generators because it's more difficult to tell if they start with a `q`. We still check in `check_generator_node`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is consensus-critical generator serialization and validation; a mismatch with network rules would fork or reject valid blocks.
> 
> **Overview**
> With **`INTERNED_GENERATOR`**, block generators are **serde_2026-only**: **`InternedBlockBuilder::finalize`** now writes **`serialize_2026`** instead of backrefs, and **`run_block_generator2`** / trusted-block coinspend helpers decode via **`node_from_bytes_2026`** with a **`max_canonical_blob_size`** cap, then charge byte cost from the **interned** tree instead of raw wire length.
> 
> **`check_generator_quote`** no longer inspects the `[0xff, 0x01]` prefix when the interned flag is set (serde_2026 bytes are not quote-shaped on the wire); **simple-generator “quoted” shape** is still enforced in **`check_generator_node`** after decode. Pre-fork behavior is unchanged: serde_2026 blobs fail parse or quote checks without the flag, and classic generators fail once **`INTERNED_GENERATOR`** is on.
> 
> Adds **`node_from_bytes_2026`** in **`serde_2026`**, fuzz round-trip coverage with **`INTERNED_GENERATOR`**, and unit tests for cross-encoding acceptance/rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 616e4863bf9d0933bff364912b6e303f55dba844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->