### PR TITLE
bump version to 0.43.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chia"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
- "chia-bls 0.42.1",
+ "chia-bls 0.43.0",
  "chia-client",
  "chia-consensus",
  "chia-datalayer",
@@ -312,9 +312,9 @@ dependencies = [
  "chia-puzzle-types",
  "chia-secp",
  "chia-serde",
- "chia-sha2 0.42.1",
+ "chia-sha2 0.43.0",
  "chia-ssl",
- "chia-traits 0.42.1",
+ "chia-traits 0.43.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -338,13 +338,13 @@ dependencies = [
 
 [[package]]
 name = "chia-bls"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "arbitrary",
  "blst",
  "chia-serde",
- "chia-sha2 0.42.1",
- "chia-traits 0.42.1",
+ "chia-sha2 0.43.0",
+ "chia-traits 0.43.0",
  "chia_py_streamable_macro",
  "criterion",
  "hex",
@@ -360,18 +360,18 @@ dependencies = [
 
 [[package]]
 name = "chia-bls-fuzz"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
- "chia-bls 0.42.1",
+ "chia-bls 0.43.0",
  "libfuzzer-sys",
 ]
 
 [[package]]
 name = "chia-client"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "chia-protocol",
- "chia-traits 0.42.1",
+ "chia-traits 0.43.0",
  "futures-util",
  "thiserror 2.0.18",
  "tokio",
@@ -381,18 +381,18 @@ dependencies = [
 
 [[package]]
 name = "chia-consensus"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "bitflags",
  "blocking-threadpool",
- "chia-bls 0.42.1",
+ "chia-bls 0.43.0",
  "chia-protocol",
  "chia-puzzle-types",
  "chia-puzzles",
- "chia-sha2 0.42.1",
- "chia-traits 0.42.1",
+ "chia-sha2 0.43.0",
+ "chia-traits 0.43.0",
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.42.1",
+ "chia_streamable_macro 0.43.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -409,13 +409,13 @@ dependencies = [
 
 [[package]]
 name = "chia-consensus-fuzz"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
- "chia-bls 0.42.1",
+ "chia-bls 0.43.0",
  "chia-consensus",
  "chia-protocol",
- "chia-sha2 0.42.1",
- "chia-traits 0.42.1",
+ "chia-sha2 0.43.0",
+ "chia-traits 0.43.0",
  "clvm-fuzzing",
  "clvm-traits",
  "clvm-utils",
@@ -426,16 +426,16 @@ dependencies = [
 
 [[package]]
 name = "chia-datalayer"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "arbitrary",
  "bitvec",
  "chia-datalayer-macro",
  "chia-protocol",
- "chia-sha2 0.42.1",
- "chia-traits 0.42.1",
+ "chia-sha2 0.43.0",
+ "chia-traits 0.43.0",
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.42.1",
+ "chia_streamable_macro 0.43.0",
  "clvm-utils",
  "expect-test",
  "hex",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "chia-datalayer-fuzz"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "chia-datalayer",
  "libfuzzer-sys",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "chia-datalayer-macro"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -483,17 +483,17 @@ dependencies = [
 
 [[package]]
 name = "chia-protocol"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "chia-bls 0.42.1",
+ "chia-bls 0.43.0",
  "chia-pos2",
  "chia-serde",
- "chia-sha2 0.42.1",
- "chia-traits 0.42.1",
+ "chia-sha2 0.43.0",
+ "chia-traits 0.43.0",
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.42.1",
+ "chia_streamable_macro 0.43.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -509,12 +509,12 @@ dependencies = [
 
 [[package]]
 name = "chia-protocol-fuzz"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "arbitrary",
  "chia-protocol",
- "chia-sha2 0.42.1",
- "chia-traits 0.42.1",
+ "chia-sha2 0.43.0",
+ "chia-traits 0.43.0",
  "clvm-traits",
  "clvmr",
  "hex",
@@ -523,14 +523,14 @@ dependencies = [
 
 [[package]]
 name = "chia-puzzle-types"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "chia-bls 0.42.1",
+ "chia-bls 0.43.0",
  "chia-protocol",
  "chia-puzzles",
- "chia-sha2 0.42.1",
+ "chia-sha2 0.43.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "chia-puzzle-types-fuzz"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "chia-puzzle-types",
  "clvm-traits",
@@ -562,11 +562,11 @@ dependencies = [
 
 [[package]]
 name = "chia-secp"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "chia-sha2 0.42.1",
+ "chia-sha2 0.43.0",
  "hex",
  "k256",
  "p256",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "chia-serde"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sha2"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "openssl",
  "sha2 0.10.9",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "chia-ssl"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "getrandom 0.4.2",
  "rcgen",
@@ -625,17 +625,17 @@ dependencies = [
 
 [[package]]
 name = "chia-tools"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "bitflags",
  "blocking-threadpool",
- "chia-bls 0.42.1",
+ "chia-bls 0.43.0",
  "chia-consensus",
  "chia-protocol",
  "chia-puzzle-types",
  "chia-puzzles",
- "chia-sha2 0.42.1",
- "chia-traits 0.42.1",
+ "chia-sha2 0.43.0",
+ "chia-traits 0.43.0",
  "clap",
  "clvm-traits",
  "clvm-utils",
@@ -659,17 +659,17 @@ dependencies = [
 
 [[package]]
 name = "chia-traits"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
- "chia-sha2 0.42.1",
- "chia_streamable_macro 0.42.1",
+ "chia-sha2 0.43.0",
+ "chia_streamable_macro 0.43.0",
  "pyo3",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "chia_py_streamable_macro"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -679,18 +679,18 @@ dependencies = [
 
 [[package]]
 name = "chia_rs"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "bincode",
- "chia-bls 0.42.1",
+ "chia-bls 0.43.0",
  "chia-client",
  "chia-consensus",
  "chia-datalayer",
  "chia-pos2",
  "chia-protocol",
- "chia-sha2 0.42.1",
+ "chia-sha2 0.43.0",
  "chia-ssl",
- "chia-traits 0.42.1",
+ "chia-traits 0.43.0",
  "clvm-utils",
  "clvmr",
  "pyo3",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "chia_streamable_macro"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "chia_wasm"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -794,7 +794,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clvm-derive"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "clvm-traits"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
- "chia-bls 0.42.1",
+ "chia-bls 0.43.0",
  "chia-secp",
  "clvm-derive",
  "clvmr",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-traits-fuzz"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "clvm-traits",
  "clvmr",
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "clvm-utils"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
- "chia-sha2 0.42.1",
+ "chia-sha2 0.43.0",
  "clvm-traits",
  "clvmr",
  "hex",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-utils-fuzz"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "clvm-fuzzing",
  "clvm-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/Chia-Network/chia_rs"
 members = ["crates/*", "crates/*/fuzz", "wasm", "wheel"]
 
 [workspace.package]
-version = "0.42.1"
+version = "0.43.0"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "deny", priority = -1 }
@@ -117,31 +117,31 @@ lto = "thin"
 bench = false
 
 [workspace.dependencies]
-chia_py_streamable_macro = { path = "./crates/chia_py_streamable_macro", version = "0.42.0" }
-chia_streamable_macro = { path = "./crates/chia_streamable_macro", version = "0.42.0" }
-chia-bls = { path = "./crates/chia-bls", version = "0.42.0" }
-chia-client = { path = "./crates/chia-client", version = "0.42.0" }
-chia-consensus = { path = "./crates/chia-consensus", version = "0.42.0" }
-chia-datalayer = { path = "./crates/chia-datalayer", version = "0.42.0" }
-chia-datalayer-macro = { path = "./crates/chia-datalayer/macro", version = "0.42.0" }
-chia-protocol = { path = "./crates/chia-protocol", version = "0.42.0" }
-chia-secp = { path = "./crates/chia-secp", version = "0.42.0" }
-chia-ssl = { path = "./crates/chia-ssl", version = "0.42.0" }
-chia-traits = { path = "./crates/chia-traits", version = "0.42.0" }
-chia-puzzle-types = { path = "./crates/chia-puzzle-types", version = "0.42.0" }
-chia-sha2 = { path = "./crates/chia-sha2", version = "0.42.0" }
-chia-serde = { path = "./crates/chia-serde", version = "0.42.0" }
-clvm-traits = { path = "./crates/clvm-traits", version = "0.42.0" }
-clvm-utils = { path = "./crates/clvm-utils", version = "0.42.0" }
-clvm-derive = { path = "./crates/clvm-derive", version = "0.42.0" }
+chia_py_streamable_macro = { path = "./crates/chia_py_streamable_macro", version = "0.43.0" }
+chia_streamable_macro = { path = "./crates/chia_streamable_macro", version = "0.43.0" }
+chia-bls = { path = "./crates/chia-bls", version = "0.43.0" }
+chia-client = { path = "./crates/chia-client", version = "0.43.0" }
+chia-consensus = { path = "./crates/chia-consensus", version = "0.43.0" }
+chia-datalayer = { path = "./crates/chia-datalayer", version = "0.43.0" }
+chia-datalayer-macro = { path = "./crates/chia-datalayer/macro", version = "0.43.0" }
+chia-protocol = { path = "./crates/chia-protocol", version = "0.43.0" }
+chia-secp = { path = "./crates/chia-secp", version = "0.43.0" }
+chia-ssl = { path = "./crates/chia-ssl", version = "0.43.0" }
+chia-traits = { path = "./crates/chia-traits", version = "0.43.0" }
+chia-puzzle-types = { path = "./crates/chia-puzzle-types", version = "0.43.0" }
+chia-sha2 = { path = "./crates/chia-sha2", version = "0.43.0" }
+chia-serde = { path = "./crates/chia-serde", version = "0.43.0" }
+clvm-traits = { path = "./crates/clvm-traits", version = "0.43.0" }
+clvm-utils = { path = "./crates/clvm-utils", version = "0.43.0" }
+clvm-derive = { path = "./crates/clvm-derive", version = "0.43.0" }
 chia-pos2 = "0.6.0"
-chia-consensus-fuzz = { path = "./crates/chia-consensus/fuzz", version = "0.42.0" }
-chia-bls-fuzz = { path = "./crates/chia-bls/fuzz", version = "0.42.0" }
-chia-datalayer-fuzz = { path = "./crates/chia-datalayer/fuzz", version = "0.42.0" }
-chia-protocol-fuzz = { path = "./crates/chia-protocol/fuzz", version = "0.42.0" }
-chia-puzzle-types-fuzz = { path = "./crates/chia-puzzle-types/fuzz", version = "0.42.0" }
-clvm-traits-fuzz = { path = "./crates/clvm-traits/fuzz", version = "0.42.0" }
-clvm-utils-fuzz = { path = "./crates/clvm-utils/fuzz", version = "0.42.0" }
+chia-consensus-fuzz = { path = "./crates/chia-consensus/fuzz", version = "0.43.0" }
+chia-bls-fuzz = { path = "./crates/chia-bls/fuzz", version = "0.43.0" }
+chia-datalayer-fuzz = { path = "./crates/chia-datalayer/fuzz", version = "0.43.0" }
+chia-protocol-fuzz = { path = "./crates/chia-protocol/fuzz", version = "0.43.0" }
+chia-puzzle-types-fuzz = { path = "./crates/chia-puzzle-types/fuzz", version = "0.43.0" }
+clvm-traits-fuzz = { path = "./crates/clvm-traits/fuzz", version = "0.43.0" }
+clvm-utils-fuzz = { path = "./crates/clvm-utils/fuzz", version = "0.43.0" }
 blst = { version = "0.3.16", features = ["portable"] }
 clvmr = "0.17.7"
 clvm-fuzzing = "0.17.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily a workspace-wide version bump and lockfile regen; risk is limited to downstream build/compatibility issues from the updated crate versions.
> 
> **Overview**
> Updates the workspace/package version to `0.43.0` and bumps all in-repo Chia crates (including fuzz/macro crates) to `0.43.0` via `Cargo.toml`.
> 
> Regenerates `Cargo.lock` to reflect the new `0.43.0` versions across the workspace dependency graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 904d1eb00aea4e17d82c48310581a932505d7bb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->