### PR TITLE
Add min-release-age to prevent supply chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=1


### PR DESCRIPTION
See https://chia-network.atlassian.net/browse/SEC-1019 and #security_chat for context

## Summary
- Adds `min-release-age=1` to `.npmrc`, telling npm to only resolve package versions published more than 1 day ago
- Lightweight supply-chain-attack mitigation: malicious packages are typically flagged and removed within hours, so a 1-day quarantine avoids installing freshly-published compromised versions

## Test plan
- [ ] `npm install` still works correctly
- [ ] `npm ci` still works correctly

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects dependency resolution timing; could cause installs to fail if a required package version was published within the last day.
> 
> **Overview**
> Adds `.npmrc` setting `min-release-age=1` so npm will avoid resolving dependencies published within the last day, providing a lightweight supply-chain hardening measure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5cf18337a0cd76963033713f2d03b014b34c7a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->