### PR TITLE
support a new version of FullBlock serialization

### DIFF
--- a/crates/chia-protocol/src/fullblock.rs
+++ b/crates/chia-protocol/src/fullblock.rs
@@ -1,5 +1,7 @@
+use chia_sha2::Sha256;
 use chia_streamable_macro::streamable;
 
+use crate::Bytes;
 use crate::Bytes32;
 use crate::Coin;
 use crate::EndOfSubSlotBundle;
@@ -8,8 +10,15 @@ use crate::RewardChainBlock;
 use crate::VDFProof;
 use crate::{Foliage, FoliageTransactionBlock, TransactionsInfo};
 use chia_traits::Streamable;
+use chia_traits::chia_error::Result;
+use std::io::Cursor;
 
-#[streamable]
+// Similar to ProofOfSpace, we use unused bits in the Optional<> prefix byte
+// for transactions_generator to encode a version flag. Bit 1 (0b10) indicates
+// the "raw bytes" format where the generator is serialized as length-prefixed
+// bytes (like Bytes) instead of a self-describing CLVM Program, and
+// transactions_generator_ref_list is omitted entirely.
+#[streamable(no_streamable)]
 pub struct FullBlock {
     finished_sub_slots: Vec<EndOfSubSlotBundle>,
     reward_chain_block: RewardChainBlock,
@@ -23,6 +32,145 @@ pub struct FullBlock {
     transactions_info: Option<TransactionsInfo>, // Reward chain foliage data (tx block additional)
     transactions_generator: Option<Program>,     // Program that generates transactions
     transactions_generator_ref_list: Vec<u32>, // List of block heights of previous generators referenced in this block
+
+    // Raw generator bytes, only used when version == 1. Mutually exclusive
+    // with transactions_generator and transactions_generator_ref_list.
+    transactions_generator_buffer: Option<Vec<u8>>,
+
+    // 0 = legacy format (Program serialization + ref_list)
+    // 1 = raw bytes format (length-prefixed bytes, ref_list omitted)
+    version: u8,
+}
+
+impl Streamable for FullBlock {
+    fn update_digest(&self, digest: &mut Sha256) {
+        self.finished_sub_slots.update_digest(digest);
+        self.reward_chain_block.update_digest(digest);
+        self.challenge_chain_sp_proof.update_digest(digest);
+        self.challenge_chain_ip_proof.update_digest(digest);
+        self.reward_chain_sp_proof.update_digest(digest);
+        self.reward_chain_ip_proof.update_digest(digest);
+        self.infused_challenge_chain_ip_proof.update_digest(digest);
+        self.foliage.update_digest(digest);
+        self.foliage_transaction_block.update_digest(digest);
+        self.transactions_info.update_digest(digest);
+
+        if self.version == 0 {
+            self.transactions_generator.update_digest(digest);
+            self.transactions_generator_ref_list.update_digest(digest);
+        } else {
+            match &self.transactions_generator_buffer {
+                None => {
+                    0b10_u8.update_digest(digest);
+                }
+                Some(buf) => {
+                    0b11_u8.update_digest(digest);
+                    (buf.len() as u32).update_digest(digest);
+                    digest.update(buf);
+                }
+            }
+        }
+    }
+
+    fn stream(&self, out: &mut Vec<u8>) -> Result<()> {
+        self.finished_sub_slots.stream(out)?;
+        self.reward_chain_block.stream(out)?;
+        self.challenge_chain_sp_proof.stream(out)?;
+        self.challenge_chain_ip_proof.stream(out)?;
+        self.reward_chain_sp_proof.stream(out)?;
+        self.reward_chain_ip_proof.stream(out)?;
+        self.infused_challenge_chain_ip_proof.stream(out)?;
+        self.foliage.stream(out)?;
+        self.foliage_transaction_block.stream(out)?;
+        self.transactions_info.stream(out)?;
+
+        if self.version == 0 {
+            self.transactions_generator.stream(out)?;
+            self.transactions_generator_ref_list.stream(out)?;
+        } else {
+            match &self.transactions_generator_buffer {
+                None => {
+                    0b10_u8.stream(out)?;
+                }
+                Some(buf) => {
+                    0b11_u8.stream(out)?;
+                    (buf.len() as u32).stream(out)?;
+                    out.extend_from_slice(buf);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn parse<const TRUSTED: bool>(input: &mut Cursor<&[u8]>) -> Result<Self> {
+        let finished_sub_slots = <Vec<EndOfSubSlotBundle> as Streamable>::parse::<TRUSTED>(input)?;
+        let reward_chain_block = <RewardChainBlock as Streamable>::parse::<TRUSTED>(input)?;
+        let challenge_chain_sp_proof = <Option<VDFProof> as Streamable>::parse::<TRUSTED>(input)?;
+        let challenge_chain_ip_proof = <VDFProof as Streamable>::parse::<TRUSTED>(input)?;
+        let reward_chain_sp_proof = <Option<VDFProof> as Streamable>::parse::<TRUSTED>(input)?;
+        let reward_chain_ip_proof = <VDFProof as Streamable>::parse::<TRUSTED>(input)?;
+        let infused_challenge_chain_ip_proof =
+            <Option<VDFProof> as Streamable>::parse::<TRUSTED>(input)?;
+        let foliage = <Foliage as Streamable>::parse::<TRUSTED>(input)?;
+        let foliage_transaction_block =
+            <Option<FoliageTransactionBlock> as Streamable>::parse::<TRUSTED>(input)?;
+        let transactions_info = <Option<TransactionsInfo> as Streamable>::parse::<TRUSTED>(input)?;
+
+        let prefix = <u8 as Streamable>::parse::<TRUSTED>(input)?;
+        let version = u8::from((prefix & 0b10) != 0);
+        let has_generator = (prefix & 1) != 0;
+
+        if version == 0 {
+            let transactions_generator = if has_generator {
+                Some(<Program as Streamable>::parse::<TRUSTED>(input)?)
+            } else {
+                None
+            };
+            let transactions_generator_ref_list =
+                <Vec<u32> as Streamable>::parse::<TRUSTED>(input)?;
+
+            Ok(FullBlock {
+                finished_sub_slots,
+                reward_chain_block,
+                challenge_chain_sp_proof,
+                challenge_chain_ip_proof,
+                reward_chain_sp_proof,
+                reward_chain_ip_proof,
+                infused_challenge_chain_ip_proof,
+                foliage,
+                foliage_transaction_block,
+                transactions_info,
+                transactions_generator,
+                transactions_generator_ref_list,
+                transactions_generator_buffer: None,
+                version,
+            })
+        } else {
+            let transactions_generator_buffer = if has_generator {
+                let bytes = <Bytes as Streamable>::parse::<TRUSTED>(input)?;
+                Some(bytes.into_inner())
+            } else {
+                None
+            };
+
+            Ok(FullBlock {
+                finished_sub_slots,
+                reward_chain_block,
+                challenge_chain_sp_proof,
+                challenge_chain_ip_proof,
+                reward_chain_sp_proof,
+                reward_chain_ip_proof,
+                infused_challenge_chain_ip_proof,
+                foliage,
+                foliage_transaction_block,
+                transactions_info,
+                transactions_generator: None,
+                transactions_generator_ref_list: vec![],
+                transactions_generator_buffer,
+                version,
+            })
+        }
+    }
 }
 
 impl FullBlock {
@@ -136,5 +284,261 @@ impl FullBlock {
     #[pyo3(name = "is_fully_compactified")]
     fn py_is_fully_compactified(&self) -> bool {
         self.is_fully_compactified()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ClassgroupElement, FoliageBlockData, PoolTarget, ProofOfSpace, VDFInfo};
+    use chia_bls::{G1Element, G2Element};
+
+    fn make_vdf_proof() -> VDFProof {
+        VDFProof::new(0, Bytes::default(), false)
+    }
+
+    fn make_vdf_info() -> VDFInfo {
+        VDFInfo::new(Bytes32::default(), 1, ClassgroupElement::default())
+    }
+
+    fn make_proof_of_space() -> ProofOfSpace {
+        ProofOfSpace::new(
+            Bytes32::default(),
+            Some(G1Element::default()),
+            None,
+            G1Element::default(),
+            0,
+            0,
+            0,
+            0,
+            32,
+            Bytes::from(vec![0x80]),
+        )
+    }
+
+    fn make_reward_chain_block() -> RewardChainBlock {
+        RewardChainBlock::new(
+            1,
+            0,
+            1,
+            0,
+            Bytes32::default(),
+            make_proof_of_space(),
+            None,
+            G2Element::default(),
+            make_vdf_info(),
+            None,
+            G2Element::default(),
+            make_vdf_info(),
+            None,
+            None,
+            false,
+        )
+    }
+
+    fn make_foliage() -> Foliage {
+        let pool_target = PoolTarget::new(Bytes32::default(), 0);
+        let foliage_block_data = FoliageBlockData::new(
+            Bytes32::default(),
+            pool_target,
+            Some(G2Element::default()),
+            Bytes32::default(),
+            Bytes32::default(),
+        );
+        Foliage::new(
+            Bytes32::default(),
+            Bytes32::default(),
+            foliage_block_data,
+            G2Element::default(),
+            None,
+            None,
+        )
+    }
+
+    fn make_v0_block(generator: Option<Program>, ref_list: Vec<u32>) -> FullBlock {
+        FullBlock::new(
+            vec![],
+            make_reward_chain_block(),
+            None,
+            make_vdf_proof(),
+            None,
+            make_vdf_proof(),
+            None,
+            make_foliage(),
+            None,
+            None,
+            generator,
+            ref_list,
+            None,
+            0,
+        )
+    }
+
+    fn make_v1_block(buffer: Option<Vec<u8>>) -> FullBlock {
+        FullBlock::new(
+            vec![],
+            make_reward_chain_block(),
+            None,
+            make_vdf_proof(),
+            None,
+            make_vdf_proof(),
+            None,
+            make_foliage(),
+            None,
+            None,
+            None,
+            vec![],
+            buffer,
+            1,
+        )
+    }
+
+    #[test]
+    fn v0_no_generator_roundtrip() {
+        let block = make_v0_block(None, vec![]);
+        let buf = block.to_bytes().unwrap();
+        let block2 = FullBlock::parse::<false>(&mut Cursor::new(&buf)).unwrap();
+
+        assert_eq!(block2.version, 0);
+        assert!(block2.transactions_generator.is_none());
+        assert!(block2.transactions_generator_ref_list.is_empty());
+        assert!(block2.transactions_generator_buffer.is_none());
+        assert_eq!(block2.to_bytes().unwrap(), buf);
+    }
+
+    #[test]
+    fn v0_with_generator_roundtrip() {
+        let generator = Program::from(vec![0xff, 0x01, 0x80]);
+        let block = make_v0_block(Some(generator.clone()), vec![100, 200]);
+        let buf = block.to_bytes().unwrap();
+        let block2 = FullBlock::parse::<false>(&mut Cursor::new(&buf)).unwrap();
+
+        assert_eq!(block2.version, 0);
+        assert_eq!(
+            block2.transactions_generator.as_ref().unwrap().as_ref(),
+            generator.as_ref()
+        );
+        assert_eq!(block2.transactions_generator_ref_list, vec![100, 200]);
+        assert!(block2.transactions_generator_buffer.is_none());
+        assert_eq!(block2.to_bytes().unwrap(), buf);
+    }
+
+    #[test]
+    fn v1_no_generator_roundtrip() {
+        let block = make_v1_block(None);
+        let buf = block.to_bytes().unwrap();
+        let block2 = FullBlock::parse::<false>(&mut Cursor::new(&buf)).unwrap();
+
+        assert_eq!(block2.version, 1);
+        assert!(block2.transactions_generator.is_none());
+        assert!(block2.transactions_generator_ref_list.is_empty());
+        assert!(block2.transactions_generator_buffer.is_none());
+        assert_eq!(block2.to_bytes().unwrap(), buf);
+    }
+
+    #[test]
+    fn v1_with_buffer_roundtrip() {
+        let raw = vec![0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe];
+        let block = make_v1_block(Some(raw.clone()));
+        let buf = block.to_bytes().unwrap();
+        let block2 = FullBlock::parse::<false>(&mut Cursor::new(&buf)).unwrap();
+
+        assert_eq!(block2.version, 1);
+        assert!(block2.transactions_generator.is_none());
+        assert!(block2.transactions_generator_ref_list.is_empty());
+        assert_eq!(block2.transactions_generator_buffer.as_ref().unwrap(), &raw);
+        assert_eq!(block2.to_bytes().unwrap(), buf);
+    }
+
+    #[test]
+    fn v0_prefix_byte_encoding() {
+        let block_none = make_v0_block(None, vec![]);
+        let buf_none = block_none.to_bytes().unwrap();
+
+        let block_some = make_v0_block(Some(Program::from(vec![0x80])), vec![]);
+        let buf_some = block_some.to_bytes().unwrap();
+
+        let prefix_offset = buf_none
+            .iter()
+            .zip(buf_some.iter())
+            .position(|(a, b)| a != b)
+            .unwrap();
+
+        assert_eq!(buf_none[prefix_offset], 0b00);
+        assert_eq!(buf_some[prefix_offset], 0b01);
+    }
+
+    #[test]
+    fn v1_prefix_byte_encoding() {
+        let block_none = make_v1_block(None);
+        let buf_none = block_none.to_bytes().unwrap();
+
+        let block_some = make_v1_block(Some(vec![0x80]));
+        let buf_some = block_some.to_bytes().unwrap();
+
+        let prefix_offset = buf_none
+            .iter()
+            .zip(buf_some.iter())
+            .position(|(a, b)| a != b)
+            .unwrap();
+
+        assert_eq!(buf_none[prefix_offset], 0b10);
+        assert_eq!(buf_some[prefix_offset], 0b11);
+    }
+
+    #[test]
+    fn v1_generator_has_length_prefix() {
+        let raw = vec![0xca, 0xfe, 0xba, 0xbe];
+        let block = make_v1_block(Some(raw.clone()));
+        let buf = block.to_bytes().unwrap();
+
+        let block_empty = make_v1_block(None);
+        let buf_empty = block_empty.to_bytes().unwrap();
+
+        let prefix_offset = buf
+            .iter()
+            .zip(buf_empty.iter())
+            .position(|(a, b)| a != b)
+            .unwrap();
+
+        assert_eq!(buf[prefix_offset], 0b11);
+        let len = u32::from_be_bytes(
+            buf[prefix_offset + 1..prefix_offset + 5]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(len as usize, raw.len());
+        assert_eq!(&buf[prefix_offset + 5..prefix_offset + 5 + raw.len()], &raw);
+        assert_eq!(prefix_offset + 5 + raw.len(), buf.len());
+    }
+
+    #[test]
+    fn v1_omits_ref_list() {
+        let block_v0 = make_v0_block(Some(Program::from(vec![0x80])), vec![42]);
+        let buf_v0 = block_v0.to_bytes().unwrap();
+
+        let block_v1 = make_v1_block(Some(vec![0x80]));
+        let buf_v1 = block_v1.to_bytes().unwrap();
+
+        // v0: 1 (prefix) + 1 (program "80") + 4 (ref_list count) + 4 (one u32) = 10 tail bytes
+        // v1: 1 (prefix) + 4 (length) + 1 (data) = 6 tail bytes
+        assert!(buf_v1.len() < buf_v0.len());
+    }
+
+    #[test]
+    fn v0_and_v1_same_hash_fields_before_generator() {
+        let block_v0 = make_v0_block(None, vec![]);
+        let block_v1 = make_v1_block(None);
+
+        assert_eq!(block_v0.header_hash(), block_v1.header_hash());
+    }
+
+    #[test]
+    fn v1_unvalidated_buffer_roundtrips() {
+        let garbage = vec![0xff; 1000];
+        let block = make_v1_block(Some(garbage.clone()));
+        let buf = block.to_bytes().unwrap();
+        let block2 = FullBlock::parse::<false>(&mut Cursor::new(&buf)).unwrap();
+        assert_eq!(block2.transactions_generator_buffer.unwrap(), garbage);
     }
 }

--- a/crates/chia-protocol/src/fullblock.rs
+++ b/crates/chia-protocol/src/fullblock.rs
@@ -10,7 +10,7 @@ use crate::RewardChainBlock;
 use crate::VDFProof;
 use crate::{Foliage, FoliageTransactionBlock, TransactionsInfo};
 use chia_traits::Streamable;
-use chia_traits::chia_error::Result;
+use chia_traits::chia_error::{Error, Result};
 use std::io::Cursor;
 
 // Similar to ProofOfSpace, we use unused bits in the Optional<> prefix byte
@@ -58,7 +58,7 @@ impl Streamable for FullBlock {
         if self.version == 0 {
             self.transactions_generator.update_digest(digest);
             self.transactions_generator_ref_list.update_digest(digest);
-        } else {
+        } else if self.version == 1 {
             match &self.transactions_generator_buffer {
                 None => {
                     0b10_u8.update_digest(digest);
@@ -69,6 +69,8 @@ impl Streamable for FullBlock {
                     digest.update(buf);
                 }
             }
+        } else {
+            panic!("version field must be 0 or 1, but it's {}", self.version);
         }
     }
 
@@ -87,7 +89,7 @@ impl Streamable for FullBlock {
         if self.version == 0 {
             self.transactions_generator.stream(out)?;
             self.transactions_generator_ref_list.stream(out)?;
-        } else {
+        } else if self.version == 1 {
             match &self.transactions_generator_buffer {
                 None => {
                     0b10_u8.stream(out)?;
@@ -98,6 +100,8 @@ impl Streamable for FullBlock {
                     out.extend_from_slice(buf);
                 }
             }
+        } else {
+            return Err(Error::InvalidFullBlock);
         }
         Ok(())
     }
@@ -145,7 +149,7 @@ impl Streamable for FullBlock {
                 transactions_generator_buffer: None,
                 version,
             })
-        } else {
+        } else if version == 1 {
             let transactions_generator_buffer = if has_generator {
                 let bytes = <Bytes as Streamable>::parse::<TRUSTED>(input)?;
                 Some(bytes.into_inner())
@@ -169,6 +173,8 @@ impl Streamable for FullBlock {
                 transactions_generator_buffer,
                 version,
             })
+        } else {
+            Err(Error::InvalidFullBlock)
         }
     }
 }

--- a/crates/chia-traits/src/chia_error.rs
+++ b/crates/chia-traits/src/chia_error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     InvalidPotIteration,
     #[error("Invalid ProofOfSpace")]
     InvalidPoS,
+    #[error("Invalid FullBlock")]
+    InvalidFullBlock,
     #[error("{0}")]
     Custom(String),
 }

--- a/tests/test_full_block.py
+++ b/tests/test_full_block.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import struct
+from typing import Optional
+
+from chia_rs.sized_ints import uint8, uint16, uint32, uint64, uint128
+from chia_rs.sized_bytes import bytes32
+
+from chia_rs import (
+    ClassgroupElement,
+    Foliage,
+    FoliageBlockData,
+    FullBlock,
+    G1Element,
+    G2Element,
+    PoolTarget,
+    ProofOfSpace,
+    Program,
+    RewardChainBlock,
+    VDFInfo,
+    VDFProof,
+)
+
+ZERO_32 = bytes(32)
+
+
+def make_vdf_proof() -> VDFProof:
+    return VDFProof(uint8(0), b"\x00", False)
+
+
+def make_vdf_info() -> VDFInfo:
+    return VDFInfo(ZERO_32, uint64(1), ClassgroupElement.get_default_element())
+
+
+def make_proof_of_space() -> ProofOfSpace:
+    return ProofOfSpace(
+        ZERO_32,
+        G1Element(),
+        None,
+        G1Element(),
+        uint8(0),
+        uint16(0),
+        uint8(0),
+        uint8(0),
+        uint8(32),
+        bytes.fromhex("80"),
+    )
+
+
+def make_reward_chain_block() -> RewardChainBlock:
+    return RewardChainBlock(
+        uint128(1),
+        uint32(0),
+        uint128(1),
+        uint8(0),
+        ZERO_32,
+        make_proof_of_space(),
+        None,
+        G2Element(),
+        make_vdf_info(),
+        None,
+        G2Element(),
+        make_vdf_info(),
+        None,
+        None,
+        False,
+    )
+
+
+def make_foliage() -> Foliage:
+    pool_target = PoolTarget(ZERO_32, uint32(0))
+    foliage_block_data = FoliageBlockData(
+        ZERO_32, pool_target, G2Element(), ZERO_32, ZERO_32
+    )
+    return Foliage(ZERO_32, ZERO_32, foliage_block_data, G2Element(), None, None)
+
+
+def make_full_block_v0(
+    generator: Optional[Program] = None,
+    ref_list: Optional[list[uint32]] = None,
+) -> FullBlock:
+    return FullBlock(
+        [],
+        make_reward_chain_block(),
+        None,
+        make_vdf_proof(),
+        None,
+        make_vdf_proof(),
+        None,
+        make_foliage(),
+        None,
+        None,
+        generator,
+        ref_list or [],
+        None,
+        uint8(0),
+    )
+
+
+def make_full_block_v1(
+    generator_buffer: Optional[bytes] = None,
+) -> FullBlock:
+    return FullBlock(
+        [],
+        make_reward_chain_block(),
+        None,
+        make_vdf_proof(),
+        None,
+        make_vdf_proof(),
+        None,
+        make_foliage(),
+        None,
+        None,
+        None,
+        [],
+        [uint8(b) for b in generator_buffer] if generator_buffer is not None else None,
+        uint8(1),
+    )
+
+
+def test_v0_no_generator_roundtrip() -> None:
+    block = make_full_block_v0()
+    buf = bytes(block)
+    block2, consumed = FullBlock.parse_rust(buf)
+
+    assert consumed == len(buf)
+    assert block2.version == 0
+    assert block2.transactions_generator is None
+    assert block2.transactions_generator_ref_list == []
+    assert block2.transactions_generator_buffer is None
+    assert bytes(block2) == buf
+
+
+def test_v0_with_generator_roundtrip() -> None:
+    generator = Program.fromhex("ff0180")
+    block = make_full_block_v0(generator=generator, ref_list=[uint32(100), uint32(200)])
+    buf = bytes(block)
+    block2, consumed = FullBlock.parse_rust(buf)
+
+    assert consumed == len(buf)
+    assert block2.version == 0
+    assert block2.transactions_generator is not None
+    assert bytes(block2.transactions_generator) == bytes(generator)
+    assert block2.transactions_generator_ref_list == [100, 200]
+    assert block2.transactions_generator_buffer is None
+    assert bytes(block2) == buf
+
+
+def test_v1_no_generator_roundtrip() -> None:
+    block = make_full_block_v1()
+    buf = bytes(block)
+    block2, consumed = FullBlock.parse_rust(buf)
+
+    assert consumed == len(buf)
+    assert block2.version == 1
+    assert block2.transactions_generator is None
+    assert block2.transactions_generator_ref_list == []
+    assert block2.transactions_generator_buffer is None
+    assert bytes(block2) == buf
+
+
+def test_v1_with_generator_buffer_roundtrip() -> None:
+    raw_bytes = b"\xde\xad\xbe\xef" * 10
+    block = make_full_block_v1(generator_buffer=raw_bytes)
+    buf = bytes(block)
+    block2, consumed = FullBlock.parse_rust(buf)
+
+    assert consumed == len(buf)
+    assert block2.version == 1
+    assert block2.transactions_generator is None
+    assert block2.transactions_generator_ref_list == []
+    assert block2.transactions_generator_buffer is not None
+    assert bytes(block2.transactions_generator_buffer) == raw_bytes
+    assert bytes(block2) == buf
+
+
+def test_v0_prefix_byte_is_standard_optional() -> None:
+    """v0 blocks use standard Optional encoding: prefix byte is 0 or 1."""
+    block_none = make_full_block_v0()
+    buf_none = bytes(block_none)
+
+    block_some = make_full_block_v0(generator=Program.fromhex("80"))
+    buf_some = bytes(block_some)
+
+    # Find the prefix byte for transactions_generator by serializing with and
+    # without a generator. Everything before the generator field is identical.
+    common_prefix_len = 0
+    for i in range(min(len(buf_none), len(buf_some))):
+        if buf_none[i] != buf_some[i]:
+            common_prefix_len = i
+            break
+
+    assert buf_none[common_prefix_len] == 0
+    assert buf_some[common_prefix_len] == 1
+
+
+def test_v1_prefix_byte_has_version_bit() -> None:
+    """v1 blocks set bit 1 (0b10) in the Optional prefix byte."""
+    block_none = make_full_block_v1()
+    buf_none = bytes(block_none)
+
+    block_some = make_full_block_v1(generator_buffer=b"\x80")
+    buf_some = bytes(block_some)
+
+    common_prefix_len = 0
+    for i in range(min(len(buf_none), len(buf_some))):
+        if buf_none[i] != buf_some[i]:
+            common_prefix_len = i
+            break
+
+    assert buf_none[common_prefix_len] == 0b10
+    assert buf_some[common_prefix_len] == 0b11
+
+
+def test_v1_generator_buffer_has_length_prefix() -> None:
+    """v1 generator is serialized as a 4-byte length prefix + raw bytes."""
+    raw_bytes = b"\xca\xfe\xba\xbe"
+    block = make_full_block_v1(generator_buffer=raw_bytes)
+    buf = bytes(block)
+
+    # Find the prefix byte (0b11) by comparing against empty generator
+    block_empty = make_full_block_v1()
+    buf_empty = bytes(block_empty)
+
+    prefix_offset = 0
+    for i in range(min(len(buf), len(buf_empty))):
+        if buf[i] != buf_empty[i]:
+            prefix_offset = i
+            break
+
+    assert buf[prefix_offset] == 0b11
+    length_bytes = buf[prefix_offset + 1 : prefix_offset + 5]
+    assert struct.unpack("!I", length_bytes)[0] == len(raw_bytes)
+    assert buf[prefix_offset + 5 : prefix_offset + 5 + len(raw_bytes)] == raw_bytes
+
+
+def test_v0_no_trailing_data() -> None:
+    """v0 serialization includes the ref_list; no data is lost."""
+    block = make_full_block_v0(generator=Program.fromhex("80"), ref_list=[uint32(42)])
+    buf = bytes(block)
+    block2, consumed = FullBlock.parse_rust(buf)
+    assert consumed == len(buf)
+    assert block2.transactions_generator_ref_list == [42]
+
+
+def test_v1_no_ref_list_serialized() -> None:
+    """v1 serialization omits transactions_generator_ref_list entirely."""
+    block_v0 = make_full_block_v0(
+        generator=Program.fromhex("80"), ref_list=[uint32(42)]
+    )
+    buf_v0 = bytes(block_v0)
+
+    block_v1 = make_full_block_v1(generator_buffer=b"\x80")
+    buf_v1 = bytes(block_v1)
+
+    # v1 should be shorter since it doesn't include ref_list but does include
+    # a 4-byte length prefix for the generator buffer
+    # v0: 1 (prefix) + 1 (program "80") + 4 (ref_list len) + 4 (one u32) = 10
+    # v1: 1 (prefix) + 4 (length) + 1 (data) = 6
+    assert len(buf_v1) < len(buf_v0)

--- a/wheel/python/chia_rs/chia_rs.pyi
+++ b/wheel/python/chia_rs/chia_rs.pyi
@@ -2033,6 +2033,8 @@ class FullBlock:
     transactions_info: Optional[TransactionsInfo]
     transactions_generator: Optional[Program]
     transactions_generator_ref_list: list[uint32]
+    transactions_generator_buffer: Optional[list[uint8]]
+    version: uint8
     prev_header_hash: bytes32
     header_hash: bytes32
     def is_transaction_block(self) -> bool: ...
@@ -2054,7 +2056,9 @@ class FullBlock:
         foliage_transaction_block: Optional[FoliageTransactionBlock],
         transactions_info: Optional[TransactionsInfo],
         transactions_generator: Optional[Program],
-        transactions_generator_ref_list: Sequence[uint32]
+        transactions_generator_ref_list: Sequence[uint32],
+        transactions_generator_buffer: Optional[Sequence[uint8]],
+        version: uint8
     ) -> Self: ...
     def __hash__(self) -> int: ...
     def __repr__(self) -> str: ...
@@ -2084,7 +2088,9 @@ class FullBlock:
         foliage_transaction_block: Union[ Optional[FoliageTransactionBlock], _Unspec] = _Unspec(),
         transactions_info: Union[ Optional[TransactionsInfo], _Unspec] = _Unspec(),
         transactions_generator: Union[ Optional[Program], _Unspec] = _Unspec(),
-        transactions_generator_ref_list: Union[ list[uint32], _Unspec] = _Unspec()) -> FullBlock: ...
+        transactions_generator_ref_list: Union[ list[uint32], _Unspec] = _Unspec(),
+        transactions_generator_buffer: Union[ Optional[list[uint8]], _Unspec] = _Unspec(),
+        version: Union[ uint8, _Unspec] = _Unspec()) -> FullBlock: ...
     def truncate(self, field: str, length: int) -> None: ...
 
 @final


### PR DESCRIPTION
 where the block generator is just a buffer.

This must be combined with a check in `chia-blockchain` that `version == 1` iff the hard-fork has activated.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes consensus-relevant block serialization and parsing; v1 must be gated by hard-fork checks in chia-blockchain (not in this PR) to avoid accepting invalid blocks on the network.
> 
> **Overview**
> Adds a **versioned `FullBlock` wire format** so post–hard-fork blocks can carry the transaction generator as **raw length-prefixed bytes** instead of a CLVM `Program` plus `transactions_generator_ref_list`.
> 
> `FullBlock` drops the derived `#[streamable]` impl in favor of a **manual `Streamable`** implementation. **Version 0** keeps the legacy tail: optional `Program` generator and `ref_list`. **Version 1** encodes the format in the optional prefix byte (bit `0b10`, same pattern as `ProofOfSpace`): no ref list on the wire; optional generator is `Bytes`-style (4-byte length + payload) stored in new `transactions_generator_buffer`, with in-memory `version` driving encode/decode. Invalid versions return **`Error::InvalidFullBlock`**.
> 
> The Python surface (`chia_rs.pyi`) gains `transactions_generator_buffer` and `version`. **Rust unit tests** and a new **`tests/test_full_block.py`** cover round-trips, prefix-byte encoding, and v1 omitting the ref list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d4ac5db5b9781676ceca1390cd3af2de37e0bac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->