### PR TITLE
Validation err transition

### DIFF
--- a/crates/chia-consensus/fuzz/fuzz_targets/sanitize-uint.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/sanitize-uint.rs
@@ -8,7 +8,12 @@ use clvmr::allocator::Allocator;
 fuzz_target!(|data: &[u8]| {
     let mut a = Allocator::new();
     let atom = a.new_atom(data).unwrap();
-    match sanitize_uint(&a, atom, 8, ErrorCode::InvalidCoinAmount) {
+    match sanitize_uint(
+        &a,
+        atom,
+        8,
+        ValidationErr::Err(ErrorCode::InvalidCoinAmount),
+    ) {
         Ok(SanitizedUint::Ok(_)) => {
             assert!(data.len() <= 9);
             if data.len() == 9 {
@@ -29,7 +34,12 @@ fuzz_target!(|data: &[u8]| {
         }
     }
 
-    match sanitize_uint(&a, atom, 4, ErrorCode::InvalidCoinAmount) {
+    match sanitize_uint(
+        &a,
+        atom,
+        4,
+        ValidationErr::Err(ErrorCode::InvalidCoinAmount),
+    ) {
         Ok(SanitizedUint::Ok(_)) => {
             assert!(data.len() <= 5);
             if data.len() == 5 {

--- a/crates/chia-consensus/src/additions_and_removals.rs
+++ b/crates/chia-consensus/src/additions_and_removals.rs
@@ -91,7 +91,11 @@ where
         while let Some((mut c, next)) = next(&a, iter)? {
             iter = next;
             let op = first(&a, c)?;
-            let Ok(op) = atom(&a, op, ErrorCode::InvalidConditionOpcode) else {
+            let Ok(op) = atom(
+                &a,
+                op,
+                ValidationErr::Err(ErrorCode::InvalidConditionOpcode),
+            ) else {
                 // unknown opcodes (including pairs) are simply ingnored in
                 // consensus mode
                 continue;

--- a/crates/chia-consensus/src/check_time_locks.rs
+++ b/crates/chia-consensus/src/check_time_locks.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::owned_conditions::OwnedSpendBundleConditions;
-use crate::validation_error::ErrorCode;
+use crate::validation_error::{ErrorCode, ValidationErr};
 use chia_protocol::Bytes32;
 use chia_protocol::CoinRecord;
 #[cfg(feature = "py-bindings")]
@@ -15,37 +15,41 @@ pub fn check_time_locks(
     prev_transaction_block_height: u32,
     timestamp: u64,
     nowrap: bool,
-) -> Result<(), ErrorCode> {
+) -> Result<(), ValidationErr> {
     if prev_transaction_block_height < bundle_conds.height_absolute {
-        return Err(ErrorCode::AssertHeightAbsoluteFailed);
+        return Err(ValidationErr::Err(ErrorCode::AssertHeightAbsoluteFailed));
     }
     if timestamp < bundle_conds.seconds_absolute {
-        return Err(ErrorCode::AssertSecondsAbsoluteFailed);
+        return Err(ValidationErr::Err(ErrorCode::AssertSecondsAbsoluteFailed));
     }
     if let Some(before_height_absolute) = bundle_conds.before_height_absolute {
         if prev_transaction_block_height >= before_height_absolute {
-            return Err(ErrorCode::AssertBeforeHeightAbsoluteFailed);
+            return Err(ValidationErr::Err(
+                ErrorCode::AssertBeforeHeightAbsoluteFailed,
+            ));
         }
     }
     if let Some(before_seconds_absolute) = bundle_conds.before_seconds_absolute {
         if timestamp >= before_seconds_absolute {
-            return Err(ErrorCode::AssertBeforeSecondsAbsoluteFailed);
+            return Err(ValidationErr::Err(
+                ErrorCode::AssertBeforeSecondsAbsoluteFailed,
+            ));
         }
     }
 
     for spend in &bundle_conds.spends {
         let Some(unspent) = removal_coin_records.get(&Bytes32::from(spend.coin_id)) else {
-            return Err(ErrorCode::InvalidCoinId);
+            return Err(ValidationErr::Err(ErrorCode::InvalidCoinId));
         };
 
         if let Some(birth_height) = spend.birth_height {
             if birth_height != unspent.confirmed_block_index {
-                return Err(ErrorCode::AssertMyBirthHeightFailed);
+                return Err(ValidationErr::Err(ErrorCode::AssertMyBirthHeightFailed));
             }
         }
         if let Some(birth_seconds) = spend.birth_seconds {
             if birth_seconds != unspent.timestamp {
-                return Err(ErrorCode::AssertMyBirthSecondsFailed);
+                return Err(ValidationErr::Err(ErrorCode::AssertMyBirthSecondsFailed));
             }
         }
         if let Some(height_relative) = spend.height_relative {
@@ -55,21 +59,21 @@ pub fn check_time_locks(
                         .confirmed_block_index
                         .saturating_add(height_relative)
                 {
-                    return Err(ErrorCode::AssertHeightRelativeFailed);
+                    return Err(ValidationErr::Err(ErrorCode::AssertHeightRelativeFailed));
                 }
             } else if prev_transaction_block_height
                 < unspent.confirmed_block_index.wrapping_add(height_relative)
             {
-                return Err(ErrorCode::AssertHeightRelativeFailed);
+                return Err(ValidationErr::Err(ErrorCode::AssertHeightRelativeFailed));
             }
         }
         if let Some(seconds_relative) = spend.seconds_relative {
             if nowrap {
                 if timestamp < unspent.timestamp.saturating_add(seconds_relative) {
-                    return Err(ErrorCode::AssertSecondsRelativeFailed);
+                    return Err(ValidationErr::Err(ErrorCode::AssertSecondsRelativeFailed));
                 }
             } else if timestamp < unspent.timestamp.wrapping_add(seconds_relative) {
-                return Err(ErrorCode::AssertSecondsRelativeFailed);
+                return Err(ValidationErr::Err(ErrorCode::AssertSecondsRelativeFailed));
             }
         }
         if let Some(before_height_relative) = spend.before_height_relative {
@@ -79,23 +83,31 @@ pub fn check_time_locks(
                         .confirmed_block_index
                         .saturating_add(before_height_relative)
                 {
-                    return Err(ErrorCode::AssertBeforeHeightRelativeFailed);
+                    return Err(ValidationErr::Err(
+                        ErrorCode::AssertBeforeHeightRelativeFailed,
+                    ));
                 }
             } else if prev_transaction_block_height
                 >= unspent
                     .confirmed_block_index
                     .wrapping_add(before_height_relative)
             {
-                return Err(ErrorCode::AssertBeforeHeightRelativeFailed);
+                return Err(ValidationErr::Err(
+                    ErrorCode::AssertBeforeHeightRelativeFailed,
+                ));
             }
         }
         if let Some(before_seconds_relative) = spend.before_seconds_relative {
             if nowrap {
                 if timestamp >= unspent.timestamp.saturating_add(before_seconds_relative) {
-                    return Err(ErrorCode::AssertBeforeSecondsRelativeFailed);
+                    return Err(ValidationErr::Err(
+                        ErrorCode::AssertBeforeSecondsRelativeFailed,
+                    ));
                 }
             } else if timestamp >= unspent.timestamp.wrapping_add(before_seconds_relative) {
-                return Err(ErrorCode::AssertBeforeSecondsRelativeFailed);
+                return Err(ValidationErr::Err(
+                    ErrorCode::AssertBeforeSecondsRelativeFailed,
+                ));
             }
         }
     }
@@ -124,7 +136,7 @@ pub fn py_check_time_locks(
 
     match res {
         Ok(()) => Ok(None),
-        Err(ec) => Ok(Some(ec.into())),
+        Err(ec) => Ok(Some(ec.error_code().into())),
     }
 }
 
@@ -132,6 +144,7 @@ pub fn py_check_time_locks(
 mod tests {
     use super::*;
     use crate::owned_conditions::OwnedSpendConditions;
+    use crate::validation_error::ValidationErr;
     use chia_protocol::Coin;
     use rstest::rstest;
     use std::collections::HashMap;
@@ -155,7 +168,7 @@ mod tests {
         OwnedSpendBundleConditions { height_absolute: 11, ..Default::default() },
         10,
         0,
-        Err(ErrorCode::AssertHeightAbsoluteFailed)
+        Err(ValidationErr::Err(ErrorCode::AssertHeightAbsoluteFailed))
     )]
     #[case::height_absolute_exact(
         OwnedSpendBundleConditions { height_absolute: 10, ..Default::default() },
@@ -173,7 +186,7 @@ mod tests {
         OwnedSpendBundleConditions { seconds_absolute: 1001, ..Default::default() },
         0,
         1000,
-        Err(ErrorCode::AssertSecondsAbsoluteFailed)
+        Err(ValidationErr::Err(ErrorCode::AssertSecondsAbsoluteFailed))
     )]
     #[case::seconds_absolute_exact(
         OwnedSpendBundleConditions { seconds_absolute: 1000, ..Default::default() },
@@ -197,13 +210,13 @@ mod tests {
         OwnedSpendBundleConditions { before_height_absolute: Some(10), ..Default::default() },
         10,
         0,
-        Err(ErrorCode::AssertBeforeHeightAbsoluteFailed)
+        Err(ValidationErr::Err(ErrorCode::AssertBeforeHeightAbsoluteFailed))
     )]
     #[case::before_height_absolute_over(
         OwnedSpendBundleConditions { before_height_absolute: Some(10), ..Default::default() },
         11,
         0,
-        Err(ErrorCode::AssertBeforeHeightAbsoluteFailed)
+        Err(ValidationErr::Err(ErrorCode::AssertBeforeHeightAbsoluteFailed))
     )]
     #[case::before_seconds_absolute_under(
         OwnedSpendBundleConditions { before_seconds_absolute: Some(1000), ..Default::default() },
@@ -215,19 +228,19 @@ mod tests {
         OwnedSpendBundleConditions { before_seconds_absolute: Some(1000), ..Default::default() },
         0,
         1000,
-        Err(ErrorCode::AssertBeforeSecondsAbsoluteFailed)
+        Err(ValidationErr::Err(ErrorCode::AssertBeforeSecondsAbsoluteFailed))
     )]
     #[case::before_seconds_absolute_over(
         OwnedSpendBundleConditions { before_seconds_absolute: Some(1000), ..Default::default() },
         0,
         1001,
-        Err(ErrorCode::AssertBeforeSecondsAbsoluteFailed)
+        Err(ValidationErr::Err(ErrorCode::AssertBeforeSecondsAbsoluteFailed))
     )]
     fn test_absolute_constraints(
         #[case] bundle: OwnedSpendBundleConditions,
         #[case] prev_height: u32,
         #[case] timestamp: u64,
-        #[case] expected: Result<(), ErrorCode>,
+        #[case] expected: Result<(), ValidationErr>,
         #[values(true, false)] nowrap: bool,
     ) {
         let result = check_time_locks(&HashMap::new(), &bundle, prev_height, timestamp, nowrap);
@@ -245,8 +258,8 @@ mod tests {
     // 200 < 100 + 101 = 201 -> Err (both agree, no overflow)
     #[case::height_relative_under(
         Osc { height_relative: Some(101), ..Default::default() },
-        Err(ErrorCode::AssertHeightRelativeFailed),
-        Err(ErrorCode::AssertHeightRelativeFailed),
+        Err(ValidationErr::Err(ErrorCode::AssertHeightRelativeFailed)),
+        Err(ValidationErr::Err(ErrorCode::AssertHeightRelativeFailed)),
     )]
     // 200 < 100 + 100 = 200 -> Ok (both agree, no overflow)
     #[case::height_relative_exact(
@@ -263,15 +276,15 @@ mod tests {
     // 200 < 100 + u32::MAX -> Err with nowrap (saturates), Ok without (wraps)
     #[case::height_relative_wrap(
         Osc { height_relative: Some(0xffff_ffff), ..Default::default() },
-        Err(ErrorCode::AssertHeightRelativeFailed),
+        Err(ValidationErr::Err(ErrorCode::AssertHeightRelativeFailed)),
         Ok(()),
     )]
     // seconds_relative check: timestamp < coin_time + seconds_relative -> Err
     // 2000 < 1000 + 1001 = 2001 -> Err (both agree, no overflow)
     #[case::seconds_relative_under(
         Osc { seconds_relative: Some(1001), ..Default::default() },
-        Err(ErrorCode::AssertSecondsRelativeFailed),
-        Err(ErrorCode::AssertSecondsRelativeFailed),
+        Err(ValidationErr::Err(ErrorCode::AssertSecondsRelativeFailed)),
+        Err(ValidationErr::Err(ErrorCode::AssertSecondsRelativeFailed)),
     )]
     // 2000 < 1000 + 1000 = 2000 -> Ok (both agree, no overflow)
     #[case::seconds_relative_exact(
@@ -288,7 +301,7 @@ mod tests {
     // 2000 < 1000 + u64::MAX -> Err with nowrap (saturates), Ok without (wraps)
     #[case::seconds_relative_wrap(
         Osc { seconds_relative: Some(0xffff_ffff_ffff_ffff), ..Default::default() },
-        Err(ErrorCode::AssertSecondsRelativeFailed),
+        Err(ValidationErr::Err(ErrorCode::AssertSecondsRelativeFailed)),
         Ok(()),
     )]
     // before_height_relative check: prev_height >= confirmed + before_height_relative -> Err
@@ -301,20 +314,20 @@ mod tests {
     // 200 >= 100 + 100 = 200 -> Err (both agree, no overflow)
     #[case::before_height_relative_exact(
         Osc { before_height_relative: Some(100), ..Default::default() },
-        Err(ErrorCode::AssertBeforeHeightRelativeFailed),
-        Err(ErrorCode::AssertBeforeHeightRelativeFailed),
+        Err(ValidationErr::Err(ErrorCode::AssertBeforeHeightRelativeFailed)),
+        Err(ValidationErr::Err(ErrorCode::AssertBeforeHeightRelativeFailed)),
     )]
     // 200 >= 100 + 99 = 199 -> Err (both agree, no overflow)
     #[case::before_height_relative_over(
         Osc { before_height_relative: Some(99), ..Default::default() },
-        Err(ErrorCode::AssertBeforeHeightRelativeFailed),
-        Err(ErrorCode::AssertBeforeHeightRelativeFailed),
+        Err(ValidationErr::Err(ErrorCode::AssertBeforeHeightRelativeFailed)),
+        Err(ValidationErr::Err(ErrorCode::AssertBeforeHeightRelativeFailed)),
     )]
     // 200 >= 100 + 0xffff_ffff -> Ok with nowrap (saturates), Err without (wraps)
     #[case::before_height_relative_wrap(
         Osc { before_height_relative: Some(0xffff_ffff), ..Default::default() },
         Ok(()),
-        Err(ErrorCode::AssertBeforeHeightRelativeFailed),
+        Err(ValidationErr::Err(ErrorCode::AssertBeforeHeightRelativeFailed)),
     )]
     // before_seconds_relative check: timestamp >= coin_time + before_seconds_relative -> Err
     // 2000 >= 1000 + 1001 = 2001 -> Ok (both agree, no overflow)
@@ -326,25 +339,25 @@ mod tests {
     // 2000 >= 1000 + 1000 = 2000 -> Err (both agree, no overflow)
     #[case::before_seconds_relative_exact(
         Osc { before_seconds_relative: Some(1000), ..Default::default() },
-        Err(ErrorCode::AssertBeforeSecondsRelativeFailed),
-        Err(ErrorCode::AssertBeforeSecondsRelativeFailed),
+        Err(ValidationErr::Err(ErrorCode::AssertBeforeSecondsRelativeFailed)),
+        Err(ValidationErr::Err(ErrorCode::AssertBeforeSecondsRelativeFailed)),
     )]
     // 2000 >= 1000 + 999 = 1999 -> Err (both agree, no overflow)
     #[case::before_seconds_relative_over(
         Osc { before_seconds_relative: Some(999), ..Default::default() },
-        Err(ErrorCode::AssertBeforeSecondsRelativeFailed),
-        Err(ErrorCode::AssertBeforeSecondsRelativeFailed),
+        Err(ValidationErr::Err(ErrorCode::AssertBeforeSecondsRelativeFailed)),
+        Err(ValidationErr::Err(ErrorCode::AssertBeforeSecondsRelativeFailed)),
     )]
     // 2000 >= 1000 + u64::MAX -> Ok with nowrap (saturates), Err without (wraps)
     #[case::before_seconds_relative_wrap(
         Osc { before_seconds_relative: Some(0xffff_ffff_ffff_ffff), ..Default::default() },
         Ok(()),
-        Err(ErrorCode::AssertBeforeSecondsRelativeFailed),
+        Err(ValidationErr::Err(ErrorCode::AssertBeforeSecondsRelativeFailed)),
     )]
     fn test_relative_constraints(
         #[case] spend: OwnedSpendConditions,
-        #[case] expected_nowrap: Result<(), ErrorCode>,
-        #[case] expected_no_nowrap: Result<(), ErrorCode>,
+        #[case] expected_nowrap: Result<(), ValidationErr>,
+        #[case] expected_no_nowrap: Result<(), ValidationErr>,
         #[values(true, false)] nowrap: bool,
     ) {
         let expected = if nowrap {
@@ -369,7 +382,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result: Result<(), ErrorCode> =
+        let result: Result<(), ValidationErr> =
             check_time_locks(&map, &bundle, now_height, now_timestamp, nowrap);
         assert_eq!(result, expected);
     }
@@ -386,7 +399,7 @@ mod tests {
             ..Default::default()
         };
         let result = check_time_locks(&HashMap::new(), &bundle, 0, 0, nowrap);
-        assert_eq!(result, Err(ErrorCode::InvalidCoinId));
+        assert_eq!(result, Err(ValidationErr::Err(ErrorCode::InvalidCoinId)));
     }
 
     #[rstest]
@@ -440,7 +453,10 @@ mod tests {
         };
 
         let result = check_time_locks(&map, &bundle, 100, 1000, nowrap);
-        assert_eq!(result, Err(ErrorCode::AssertMyBirthHeightFailed));
+        assert_eq!(
+            result,
+            Err(ValidationErr::Err(ErrorCode::AssertMyBirthHeightFailed))
+        );
     }
 
     #[rstest]
@@ -464,7 +480,10 @@ mod tests {
         };
 
         let result = check_time_locks(&map, &bundle, 100, 1000, nowrap);
-        assert_eq!(result, Err(ErrorCode::AssertMyBirthSecondsFailed));
+        assert_eq!(
+            result,
+            Err(ValidationErr::Err(ErrorCode::AssertMyBirthSecondsFailed))
+        );
     }
 
     #[rstest]
@@ -515,7 +534,10 @@ mod tests {
 
         // spend_relative_fail should fail first as 59 is below required 61 height
         let result = check_time_locks(&map, &bundle, 59, 600, nowrap);
-        assert_eq!(result, Err(ErrorCode::AssertHeightRelativeFailed));
+        assert_eq!(
+            result,
+            Err(ValidationErr::Err(ErrorCode::AssertHeightRelativeFailed))
+        );
 
         let mut map = HashMap::new();
         map.insert(coin_id_1, coin_record_1);
@@ -528,6 +550,9 @@ mod tests {
 
         // spend_birth_fail should now fail
         let result = check_time_locks(&map, &bundle, 59, 600, nowrap);
-        assert_eq!(result, Err(ErrorCode::AssertMyBirthHeightFailed));
+        assert_eq!(
+            result,
+            Err(ValidationErr::Err(ErrorCode::AssertMyBirthHeightFailed))
+        );
     }
 }

--- a/crates/chia-consensus/src/condition_sanitizers.rs
+++ b/crates/chia-consensus/src/condition_sanitizers.rs
@@ -8,7 +8,7 @@ pub fn sanitize_hash(
     size: usize,
     code: ErrorCode,
 ) -> Result<NodePtr, ValidationErr> {
-    let buf = atom(a, n, code)?;
+    let buf = atom(a, n, ValidationErr::Err(code))?;
 
     if buf.as_ref().len() == size {
         Ok(n)
@@ -19,7 +19,7 @@ pub fn sanitize_hash(
 
 pub fn parse_amount(a: &Allocator, n: NodePtr, code: ErrorCode) -> Result<u64, ValidationErr> {
     // amounts are not allowed to exceed 2^64. i.e. 8 bytes
-    match sanitize_uint(a, n, 8, code)? {
+    match sanitize_uint(a, n, 8, ValidationErr::Err(code))? {
         SanitizedUint::NegativeOverflow | SanitizedUint::PositiveOverflow => {
             Err(ValidationErr::Err(code))
         }
@@ -32,7 +32,7 @@ pub fn sanitize_announce_msg(
     n: NodePtr,
     code: ErrorCode,
 ) -> Result<NodePtr, ValidationErr> {
-    let buf = atom(a, n, code)?;
+    let buf = atom(a, n, ValidationErr::Err(code))?;
 
     if buf.as_ref().len() > 1024 {
         Err(ValidationErr::Err(code))

--- a/crates/chia-consensus/src/conditions.rs
+++ b/crates/chia-consensus/src/conditions.rs
@@ -545,10 +545,14 @@ pub fn parse_args(
         ASSERT_MY_BIRTH_SECONDS => {
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
-            let code = ErrorCode::AssertMyBirthSecondsFailed;
-            match sanitize_uint(a, node, 8, ValidationErr::Err(code))? {
+            match sanitize_uint(
+                a,
+                node,
+                8,
+                ValidationErr::Err(ErrorCode::AssertMyBirthSecondsFailed),
+            )? {
                 SanitizedUint::PositiveOverflow | SanitizedUint::NegativeOverflow => {
-                    Err(ValidationErr::Err(code))
+                    Err(ValidationErr::Err(ErrorCode::AssertMyBirthSecondsFailed))
                 }
                 SanitizedUint::Ok(r) => Ok(Condition::AssertMyBirthSeconds(r)),
             }
@@ -556,10 +560,14 @@ pub fn parse_args(
         ASSERT_MY_BIRTH_HEIGHT => {
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
-            let code = ErrorCode::AssertMyBirthHeightFailed;
-            match sanitize_uint(a, node, 4, ValidationErr::Err(code))? {
+            match sanitize_uint(
+                a,
+                node,
+                4,
+                ValidationErr::Err(ErrorCode::AssertMyBirthHeightFailed),
+            )? {
                 SanitizedUint::PositiveOverflow | SanitizedUint::NegativeOverflow => {
-                    Err(ValidationErr::Err(code))
+                    Err(ValidationErr::Err(ErrorCode::AssertMyBirthHeightFailed))
                 }
                 SanitizedUint::Ok(r) => Ok(Condition::AssertMyBirthHeight(r as u32)),
             }
@@ -574,9 +582,15 @@ pub fn parse_args(
         ASSERT_SECONDS_RELATIVE => {
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
-            let code = ErrorCode::AssertSecondsRelativeFailed;
-            match sanitize_uint(a, node, 8, ValidationErr::Err(code))? {
-                SanitizedUint::PositiveOverflow => Err(ValidationErr::Err(code)),
+            match sanitize_uint(
+                a,
+                node,
+                8,
+                ValidationErr::Err(ErrorCode::AssertSecondsRelativeFailed),
+            )? {
+                SanitizedUint::PositiveOverflow => {
+                    Err(ValidationErr::Err(ErrorCode::AssertSecondsRelativeFailed))
+                }
                 SanitizedUint::NegativeOverflow => Ok(Condition::SkipRelativeCondition),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertSecondsRelative(r)),
             }
@@ -584,9 +598,15 @@ pub fn parse_args(
         ASSERT_SECONDS_ABSOLUTE => {
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
-            let code = ErrorCode::AssertSecondsAbsoluteFailed;
-            match sanitize_uint(a, node, 8, ValidationErr::Err(code))? {
-                SanitizedUint::PositiveOverflow => Err(ValidationErr::Err(code)),
+            match sanitize_uint(
+                a,
+                node,
+                8,
+                ValidationErr::Err(ErrorCode::AssertSecondsAbsoluteFailed),
+            )? {
+                SanitizedUint::PositiveOverflow => {
+                    Err(ValidationErr::Err(ErrorCode::AssertSecondsAbsoluteFailed))
+                }
                 SanitizedUint::NegativeOverflow => Ok(Condition::Skip),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertSecondsAbsolute(r)),
             }
@@ -594,9 +614,15 @@ pub fn parse_args(
         ASSERT_HEIGHT_RELATIVE => {
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
-            let code = ErrorCode::AssertHeightRelativeFailed;
-            match sanitize_uint(a, node, 4, ValidationErr::Err(code))? {
-                SanitizedUint::PositiveOverflow => Err(ValidationErr::Err(code)),
+            match sanitize_uint(
+                a,
+                node,
+                4,
+                ValidationErr::Err(ErrorCode::AssertHeightRelativeFailed),
+            )? {
+                SanitizedUint::PositiveOverflow => {
+                    Err(ValidationErr::Err(ErrorCode::AssertHeightRelativeFailed))
+                }
                 SanitizedUint::NegativeOverflow => Ok(Condition::SkipRelativeCondition),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertHeightRelative(r as u32)),
             }
@@ -604,9 +630,15 @@ pub fn parse_args(
         ASSERT_HEIGHT_ABSOLUTE => {
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
-            let code = ErrorCode::AssertHeightAbsoluteFailed;
-            match sanitize_uint(a, node, 4, ValidationErr::Err(code))? {
-                SanitizedUint::PositiveOverflow => Err(ValidationErr::Err(code)),
+            match sanitize_uint(
+                a,
+                node,
+                4,
+                ValidationErr::Err(ErrorCode::AssertHeightAbsoluteFailed),
+            )? {
+                SanitizedUint::PositiveOverflow => {
+                    Err(ValidationErr::Err(ErrorCode::AssertHeightAbsoluteFailed))
+                }
                 SanitizedUint::NegativeOverflow => Ok(Condition::Skip),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertHeightAbsolute(r as u32)),
             }
@@ -614,41 +646,64 @@ pub fn parse_args(
         ASSERT_BEFORE_SECONDS_RELATIVE => {
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
-            let code = ErrorCode::AssertBeforeSecondsRelativeFailed;
-            match sanitize_uint(a, node, 8, ValidationErr::Err(code))? {
+            match sanitize_uint(
+                a,
+                node,
+                8,
+                ValidationErr::Err(ErrorCode::AssertBeforeSecondsRelativeFailed),
+            )? {
                 SanitizedUint::PositiveOverflow => Ok(Condition::SkipRelativeCondition),
-                SanitizedUint::NegativeOverflow => Err(ValidationErr::Err(code)),
+                SanitizedUint::NegativeOverflow => Err(ValidationErr::Err(
+                    ErrorCode::AssertBeforeSecondsRelativeFailed,
+                )),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertBeforeSecondsRelative(r)),
             }
         }
         ASSERT_BEFORE_SECONDS_ABSOLUTE => {
             maybe_check_args_terminator(a, c, flags)?;
-
             let node = first(a, c)?;
-            let code = ErrorCode::AssertBeforeSecondsAbsoluteFailed;
-            match sanitize_uint(a, node, 8, ValidationErr::Err(code))? {
+            match sanitize_uint(
+                a,
+                node,
+                8,
+                ValidationErr::Err(ErrorCode::AssertBeforeSecondsAbsoluteFailed),
+            )? {
                 SanitizedUint::PositiveOverflow => Ok(Condition::Skip),
-                SanitizedUint::NegativeOverflow => Err(ValidationErr::Err(code)),
+                SanitizedUint::NegativeOverflow => Err(ValidationErr::Err(
+                    ErrorCode::AssertBeforeSecondsAbsoluteFailed,
+                )),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertBeforeSecondsAbsolute(r)),
             }
         }
         ASSERT_BEFORE_HEIGHT_RELATIVE => {
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
-            let code = ErrorCode::AssertBeforeHeightRelativeFailed;
-            match sanitize_uint(a, node, 4, ValidationErr::Err(code))? {
+            match sanitize_uint(
+                a,
+                node,
+                4,
+                ValidationErr::Err(ErrorCode::AssertBeforeHeightRelativeFailed),
+            )? {
                 SanitizedUint::PositiveOverflow => Ok(Condition::SkipRelativeCondition),
-                SanitizedUint::NegativeOverflow => Err(ValidationErr::Err(code)),
+                SanitizedUint::NegativeOverflow => Err(ValidationErr::Err(
+                    ErrorCode::AssertBeforeHeightRelativeFailed,
+                )),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertBeforeHeightRelative(r as u32)),
             }
         }
         ASSERT_BEFORE_HEIGHT_ABSOLUTE => {
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
-            let code = ErrorCode::AssertBeforeHeightAbsoluteFailed;
-            match sanitize_uint(a, node, 4, ValidationErr::Err(code))? {
+            match sanitize_uint(
+                a,
+                node,
+                4,
+                ValidationErr::Err(ErrorCode::AssertBeforeHeightAbsoluteFailed),
+            )? {
                 SanitizedUint::PositiveOverflow => Ok(Condition::Skip),
-                SanitizedUint::NegativeOverflow => Err(ValidationErr::Err(code)),
+                SanitizedUint::NegativeOverflow => Err(ValidationErr::Err(
+                    ErrorCode::AssertBeforeHeightAbsoluteFailed,
+                )),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertBeforeHeightAbsolute(r as u32)),
             }
         }

--- a/crates/chia-consensus/src/conditions.rs
+++ b/crates/chia-consensus/src/conditions.rs
@@ -412,7 +412,12 @@ pub fn parse_args(
             let puzzle_hash = sanitize_hash(a, first(a, c)?, 32, ErrorCode::InvalidPuzzleHash)?;
             c = rest(a, c)?;
             let node = first(a, c)?;
-            let amount = match sanitize_uint(a, node, 8, ErrorCode::InvalidCoinAmount)? {
+            let amount = match sanitize_uint(
+                a,
+                node,
+                8,
+                ValidationErr::Err(ErrorCode::InvalidCoinAmount),
+            )? {
                 SanitizedUint::PositiveOverflow => {
                     return Err(ValidationErr::Err(ErrorCode::CoinAmountExceedsMaximum));
                 }
@@ -455,7 +460,12 @@ pub fn parse_args(
                 // are all unknown
                 Err(ValidationErr::Err(ErrorCode::InvalidConditionOpcode))
             } else {
-                match sanitize_uint(a, first(a, c)?, 4, ErrorCode::InvalidSoftforkCost)? {
+                match sanitize_uint(
+                    a,
+                    first(a, c)?,
+                    4,
+                    ValidationErr::Err(ErrorCode::InvalidSoftforkCost),
+                )? {
                     // the first argument represents the cost of the condition.
                     // We scale it by 10000 to make the argument be a bit smaller
                     SanitizedUint::Ok(cost) => Ok(Condition::Softfork(cost * 10000)),
@@ -536,7 +546,7 @@ pub fn parse_args(
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
             let code = ErrorCode::AssertMyBirthSecondsFailed;
-            match sanitize_uint(a, node, 8, code)? {
+            match sanitize_uint(a, node, 8, ValidationErr::Err(code))? {
                 SanitizedUint::PositiveOverflow | SanitizedUint::NegativeOverflow => {
                     Err(ValidationErr::Err(code))
                 }
@@ -547,7 +557,7 @@ pub fn parse_args(
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
             let code = ErrorCode::AssertMyBirthHeightFailed;
-            match sanitize_uint(a, node, 4, code)? {
+            match sanitize_uint(a, node, 4, ValidationErr::Err(code))? {
                 SanitizedUint::PositiveOverflow | SanitizedUint::NegativeOverflow => {
                     Err(ValidationErr::Err(code))
                 }
@@ -565,7 +575,7 @@ pub fn parse_args(
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
             let code = ErrorCode::AssertSecondsRelativeFailed;
-            match sanitize_uint(a, node, 8, code)? {
+            match sanitize_uint(a, node, 8, ValidationErr::Err(code))? {
                 SanitizedUint::PositiveOverflow => Err(ValidationErr::Err(code)),
                 SanitizedUint::NegativeOverflow => Ok(Condition::SkipRelativeCondition),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertSecondsRelative(r)),
@@ -575,7 +585,7 @@ pub fn parse_args(
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
             let code = ErrorCode::AssertSecondsAbsoluteFailed;
-            match sanitize_uint(a, node, 8, code)? {
+            match sanitize_uint(a, node, 8, ValidationErr::Err(code))? {
                 SanitizedUint::PositiveOverflow => Err(ValidationErr::Err(code)),
                 SanitizedUint::NegativeOverflow => Ok(Condition::Skip),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertSecondsAbsolute(r)),
@@ -585,7 +595,7 @@ pub fn parse_args(
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
             let code = ErrorCode::AssertHeightRelativeFailed;
-            match sanitize_uint(a, node, 4, code)? {
+            match sanitize_uint(a, node, 4, ValidationErr::Err(code))? {
                 SanitizedUint::PositiveOverflow => Err(ValidationErr::Err(code)),
                 SanitizedUint::NegativeOverflow => Ok(Condition::SkipRelativeCondition),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertHeightRelative(r as u32)),
@@ -595,7 +605,7 @@ pub fn parse_args(
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
             let code = ErrorCode::AssertHeightAbsoluteFailed;
-            match sanitize_uint(a, node, 4, code)? {
+            match sanitize_uint(a, node, 4, ValidationErr::Err(code))? {
                 SanitizedUint::PositiveOverflow => Err(ValidationErr::Err(code)),
                 SanitizedUint::NegativeOverflow => Ok(Condition::Skip),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertHeightAbsolute(r as u32)),
@@ -605,7 +615,7 @@ pub fn parse_args(
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
             let code = ErrorCode::AssertBeforeSecondsRelativeFailed;
-            match sanitize_uint(a, node, 8, code)? {
+            match sanitize_uint(a, node, 8, ValidationErr::Err(code))? {
                 SanitizedUint::PositiveOverflow => Ok(Condition::SkipRelativeCondition),
                 SanitizedUint::NegativeOverflow => Err(ValidationErr::Err(code)),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertBeforeSecondsRelative(r)),
@@ -616,7 +626,7 @@ pub fn parse_args(
 
             let node = first(a, c)?;
             let code = ErrorCode::AssertBeforeSecondsAbsoluteFailed;
-            match sanitize_uint(a, node, 8, code)? {
+            match sanitize_uint(a, node, 8, ValidationErr::Err(code))? {
                 SanitizedUint::PositiveOverflow => Ok(Condition::Skip),
                 SanitizedUint::NegativeOverflow => Err(ValidationErr::Err(code)),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertBeforeSecondsAbsolute(r)),
@@ -626,7 +636,7 @@ pub fn parse_args(
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
             let code = ErrorCode::AssertBeforeHeightRelativeFailed;
-            match sanitize_uint(a, node, 4, code)? {
+            match sanitize_uint(a, node, 4, ValidationErr::Err(code))? {
                 SanitizedUint::PositiveOverflow => Ok(Condition::SkipRelativeCondition),
                 SanitizedUint::NegativeOverflow => Err(ValidationErr::Err(code)),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertBeforeHeightRelative(r as u32)),
@@ -636,7 +646,7 @@ pub fn parse_args(
             maybe_check_args_terminator(a, c, flags)?;
             let node = first(a, c)?;
             let code = ErrorCode::AssertBeforeHeightAbsoluteFailed;
-            match sanitize_uint(a, node, 4, code)? {
+            match sanitize_uint(a, node, 4, ValidationErr::Err(code))? {
                 SanitizedUint::PositiveOverflow => Ok(Condition::Skip),
                 SanitizedUint::NegativeOverflow => Err(ValidationErr::Err(code)),
                 SanitizedUint::Ok(r) => Ok(Condition::AssertBeforeHeightAbsolute(r as u32)),

--- a/crates/chia-consensus/src/get_puzzle_and_solution.rs
+++ b/crates/chia-consensus/src/get_puzzle_and_solution.rs
@@ -9,7 +9,11 @@ pub fn parse_coin_spend(
     a: &Allocator,
     coin_spend: NodePtr,
 ) -> Result<(Atom<'_>, u64, NodePtr, NodePtr), ValidationErr> {
-    let parent = atom(a, first(a, coin_spend)?, ErrorCode::InvalidParentId)?;
+    let parent = atom(
+        a,
+        first(a, coin_spend)?,
+        ValidationErr::Err(ErrorCode::InvalidParentId),
+    )?;
     let coin_spend = rest(a, coin_spend)?;
     let puzzle = first(a, coin_spend)?;
     let coin_spend = rest(a, coin_spend)?;

--- a/crates/chia-consensus/src/messages.rs
+++ b/crates/chia-consensus/src/messages.rs
@@ -58,8 +58,12 @@ impl SpendId {
         };
 
         let amount = if (mode & AMOUNT) != 0 {
-            let amount = match sanitize_uint(a, first(a, *args)?, 8, ErrorCode::InvalidCoinAmount)?
-            {
+            let amount = match sanitize_uint(
+                a,
+                first(a, *args)?,
+                8,
+                ValidationErr::Err(ErrorCode::InvalidCoinAmount),
+            )? {
                 SanitizedUint::PositiveOverflow => {
                     return Err(ValidationErr::Err(ErrorCode::CoinAmountExceedsMaximum));
                 }

--- a/crates/chia-consensus/src/sanitize_int.rs
+++ b/crates/chia-consensus/src/sanitize_int.rs
@@ -1,5 +1,5 @@
-use super::validation_error::{ErrorCode, ValidationErr, atom};
-use clvmr::allocator::{Allocator, NodePtr};
+use super::validation_error::ValidationErr;
+use clvmr::allocator::{Allocator, NodePtr, SExp};
 
 use clvmr::op_utils::u64_from_bytes;
 
@@ -14,11 +14,14 @@ pub fn sanitize_uint(
     a: &Allocator,
     n: NodePtr,
     max_size: usize,
-    code: ErrorCode,
+    code: ValidationErr,
 ) -> Result<SanitizedUint, ValidationErr> {
     assert!(max_size <= 8);
 
-    let buf = atom(a, n, code)?;
+    let buf = match a.sexp(n) {
+        SExp::Atom => a.atom(n),
+        SExp::Pair(..) => return Err(code),
+    };
     let buf = buf.as_ref();
 
     if buf.is_empty() {
@@ -34,7 +37,7 @@ pub fn sanitize_uint(
     // be interpreted as a negative integer. i.e. if the next top bit is set
     // all other leading zeros are invalid
     if buf == [0_u8] || (buf.len() > 1 && buf[0] == 0 && (buf[1] & 0x80) == 0) {
-        return Err(ValidationErr::Err(code));
+        return Err(code);
     }
 
     // strip the leading zero byte if there is one
@@ -50,6 +53,7 @@ pub fn sanitize_uint(
 
 #[test]
 fn test_sanitize_uint() {
+    use super::validation_error::ErrorCode;
     let mut a = Allocator::new();
 
     // start with one big buffer.
@@ -70,12 +74,15 @@ fn test_sanitize_uint() {
     let e = ErrorCode::InvalidCoinAmount;
     let no_leading_zero = a.new_substr(atom, 0, 8).unwrap();
     // this is a negative number, not allowed
-    assert!(sanitize_uint(&a, no_leading_zero, 8, e) == Ok(SanitizedUint::NegativeOverflow));
+    assert!(
+        sanitize_uint(&a, no_leading_zero, 8, ValidationErr::Err(e))
+            == Ok(SanitizedUint::NegativeOverflow)
+    );
 
     let just_zeros = a.new_substr(atom, 10, 70).unwrap();
     // a zero value must be represented by an empty atom
     assert_eq!(
-        sanitize_uint(&a, just_zeros, 8, e)
+        sanitize_uint(&a, just_zeros, 8, ValidationErr::Err(e))
             .unwrap_err()
             .error_code(),
         ErrorCode::InvalidCoinAmount
@@ -83,26 +90,32 @@ fn test_sanitize_uint() {
 
     let a1 = a.new_substr(atom, 1, 101).unwrap();
     assert_eq!(
-        sanitize_uint(&a, a1, 8, e).unwrap_err().error_code(),
+        sanitize_uint(&a, a1, 8, ValidationErr::Err(e))
+            .unwrap_err()
+            .error_code(),
         ErrorCode::InvalidCoinAmount
     );
 
     let a1 = a.new_substr(atom, 1, 101).unwrap();
     assert_eq!(
-        sanitize_uint(&a, a1, 8, e).unwrap_err().error_code(),
+        sanitize_uint(&a, a1, 8, ValidationErr::Err(e))
+            .unwrap_err()
+            .error_code(),
         ErrorCode::InvalidCoinAmount
     );
 
     // a new all-zeros range
     let a1 = a.new_substr(atom, 1000, 1024).unwrap();
     assert_eq!(
-        sanitize_uint(&a, a1, 8, e).unwrap_err().error_code(),
+        sanitize_uint(&a, a1, 8, ValidationErr::Err(e))
+            .unwrap_err()
+            .error_code(),
         ErrorCode::InvalidCoinAmount
     );
 
     let exceed_maximum = a.new_substr(atom, 100, 110).unwrap();
     assert_eq!(
-        sanitize_uint(&a, exceed_maximum, 8, e),
+        sanitize_uint(&a, exceed_maximum, 8, ValidationErr::Err(e)),
         Ok(SanitizedUint::PositiveOverflow)
     );
 }

--- a/crates/chia-consensus/src/validation_error.rs
+++ b/crates/chia-consensus/src/validation_error.rs
@@ -405,15 +405,18 @@ pub fn next(a: &Allocator, n: NodePtr) -> Result<Option<(NodePtr, NodePtr)>, Val
     }
 }
 
-pub fn atom(a: &Allocator, n: NodePtr, code: ErrorCode) -> Result<Atom<'_>, ValidationErr> {
+pub fn atom(a: &Allocator, n: NodePtr, code: ValidationErr) -> Result<Atom<'_>, ValidationErr> {
     match a.sexp(n) {
         SExp::Atom => Ok(a.atom(n)),
-        SExp::Pair(..) => Err(ValidationErr::Err(code)),
+        SExp::Pair(..) => Err(code),
     }
 }
 
 pub fn check_nil(a: &Allocator, n: NodePtr) -> Result<(), ValidationErr> {
-    if atom(a, n, ErrorCode::InvalidCondition)?.as_ref().is_empty() {
+    if atom(a, n, ValidationErr::Err(ErrorCode::InvalidCondition))?
+        .as_ref()
+        .is_empty()
+    {
         Ok(())
     } else {
         Err(ValidationErr::Err(ErrorCode::InvalidCondition))


### PR DESCRIPTION
best reviewed one commit at a time.

This is a step towards merging `ValidationErr` with `ErrorCode` to form a more typical rust error type. This reduces the places where `ErrorCode` is used alone, outside of `ValidationErr`.

The goal I envision is to have `ValidationErr` be an enum with all `ErrorCode` values in it, and remove `ErrorCode`. Like this:

```rust
#[derive(Debug, PartialEq, Error)]
pub enum ValidationErr {
    Unknown,
    InvalidBlockSolution,
    InvalidCoinSolution,
    DuplicateOutput,
    DoubleSpend,
    UnknownUnspent,
    // ...
    #[error("eval error: {0}")]
    Eval(EvalErr),
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus validation and time-lock paths across many call sites; behavior should be equivalent but any missed conversion could change error handling at the network boundary.
> 
> **Overview**
> This PR **standardizes consensus validation errors** around `ValidationErr` instead of bare `ErrorCode` at low-level helpers and several public APIs.
> 
> **`sanitize_uint`** and **`atom`** now take a full `ValidationErr` (typically `ValidationErr::Err(ErrorCode::…)`) as the failure value; callers across condition parsing, coin parsing, messages, additions/removals, and fuzz targets are updated accordingly. **`sanitize_uint`** also reads atoms via `a.sexp` / `a.atom` directly rather than going through `atom()`, but still rejects non-atoms with the passed-in error.
> 
> **`check_time_locks`** now returns `Result<(), ValidationErr>`; Python bindings map failures with `error_code()`. Tests and fuzz harnesses expect `ValidationErr::Err(...)` where they previously used `ErrorCode` alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc1843598da15aedba90618238000f764554c0ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->