### PR TITLE
[CHIA-4270] optimize additions_and_removals()

### DIFF
--- a/crates/chia-consensus/src/additions_and_removals.rs
+++ b/crates/chia-consensus/src/additions_and_removals.rs
@@ -10,7 +10,7 @@ use crate::validation_error::{ErrorCode, ValidationErr, atom, first, next, rest}
 use chia_protocol::{Bytes, Bytes32};
 use clvm_traits::FromClvm;
 use clvm_utils::{TreeCache, tree_hash_cached};
-use clvmr::allocator::NodePtr;
+use clvmr::allocator::{NodePtr, SExp};
 use clvmr::chia_dialect::ChiaDialect;
 use clvmr::reduction::Reduction;
 use clvmr::run_program::run_program;
@@ -118,8 +118,16 @@ where
             // side, the list element
 
             let hint =
-                if let Ok(((hint, _), _)) = <((Bytes, NodePtr), NodePtr)>::from_clvm(&a, hint) {
-                    if hint.len() <= 32 { Some(hint) } else { None }
+                if let Ok(((hint, _), _)) = <((NodePtr, NodePtr), NodePtr)>::from_clvm(&a, hint) {
+                    if let SExp::Atom = a.sexp(hint) {
+                        if a.atom_len(hint) <= 32 {
+                            Some(Into::<Bytes>::into(a.atom(hint).as_ref()))
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 };
@@ -245,5 +253,82 @@ mod test {
         for r in &removals {
             assert!(expect_removals.contains(&r.1));
         }
+    }
+
+    fn make_create_coin_generator(hint_size: usize) -> Vec<u8> {
+        use crate::solution_generator::solution_generator;
+        use clvm_traits::ToClvm;
+        use clvmr::allocator::Allocator;
+        use clvmr::serde::node_to_bytes;
+
+        let mut a = Allocator::new();
+
+        let hint = Bytes::new(vec![0x42u8; hint_size]);
+        let ph = Bytes32::from([0xab; 32]);
+
+        // ((51 puzzle_hash amount (hint)))
+        let conditions = ((51u8, (ph, (1000u64, ((hint, ()), ())))), ())
+            .to_clvm(&mut a)
+            .unwrap();
+
+        let solution_bytes = node_to_bytes(&a, conditions).unwrap();
+        let puzzle_bytes = [0x01u8];
+        let coin = Coin::new([0xcc; 32].into(), [0xdd; 32].into(), 1000);
+        solution_generator([(coin, puzzle_bytes.as_slice(), solution_bytes.as_slice())]).unwrap()
+    }
+
+    #[rstest]
+    #[case(1, true)]
+    #[case(32, true)]
+    #[case(33, false)]
+    #[case(100_000, false)]
+    fn test_hint_length_filtering(#[case] hint_size: usize, #[case] expect_hint: bool) {
+        let no_blocks: &[&[u8]] = &[];
+        let generator = make_create_coin_generator(hint_size);
+        let (additions, _removals) = additions_and_removals(
+            &generator,
+            no_blocks,
+            ConsensusFlags::empty(),
+            &TEST_CONSTANTS,
+        )
+        .unwrap();
+        assert_eq!(additions.len(), 1);
+        assert_eq!(additions[0].1.is_some(), expect_hint);
+    }
+
+    #[test]
+    fn test_pair_hint_is_ignored() {
+        use crate::solution_generator::solution_generator;
+        use clvm_traits::ToClvm;
+        use clvmr::allocator::Allocator;
+        use clvmr::serde::node_to_bytes;
+
+        let mut a = Allocator::new();
+
+        let pair_hint = (1u8, 2u8).to_clvm(&mut a).unwrap();
+        let ph = Bytes32::from([0xab; 32]);
+
+        // ((51 puzzle_hash amount ((1 . 2))))
+        let conditions = ((51u8, (ph, (1000u64, ((pair_hint, ()), ())))), ())
+            .to_clvm(&mut a)
+            .unwrap();
+
+        let solution_bytes = node_to_bytes(&a, conditions).unwrap();
+        let puzzle_bytes = [0x01u8];
+        let coin = Coin::new([0xcc; 32].into(), [0xdd; 32].into(), 1000);
+        let generator =
+            solution_generator([(coin, puzzle_bytes.as_slice(), solution_bytes.as_slice())])
+                .unwrap();
+
+        let no_blocks: &[&[u8]] = &[];
+        let (additions, _removals) = additions_and_removals(
+            &generator,
+            no_blocks,
+            ConsensusFlags::empty(),
+            &TEST_CONSTANTS,
+        )
+        .unwrap();
+        assert_eq!(additions.len(), 1);
+        assert!(additions[0].1.is_none(), "pair hint should be ignored");
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how CREATE_COIN hints are interpreted when scanning trusted generators; wrong atom/pair handling could misreport additions for indexers, though new tests lock expected behavior.
> 
> **Overview**
> **CREATE_COIN** hint extraction in `additions_and_removals()` no longer decodes hints through `FromClvm` as `Bytes`. Hints are read as allocator `NodePtr`s, then only kept when the node is an **atom** with length ≤ 32; longer atoms and **pair** hints are dropped (`None`).
> 
> New tests cover hint length boundaries (1–32 bytes kept, 33+ dropped) and that a pair-shaped hint is ignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7865ac9d0bb3c679358dad275aeb846449ff1b90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->