### PR TITLE
introduce a new serialization for the generator in UnfinishedBlock

### DIFF
--- a/crates/chia-protocol/src/fullblock.rs
+++ b/crates/chia-protocol/src/fullblock.rs
@@ -13,7 +13,7 @@ use chia_traits::Streamable;
 use chia_traits::chia_error::{Error, Result};
 use std::io::Cursor;
 
-// Similar to ProofOfSpace, we use unused bits in the Optional<> prefix byte
+// Similar to ProofOfSpace, we use unused bits in the Option<> prefix byte
 // for transactions_generator to encode a version flag. Bit 1 (0b10) indicates
 // the "raw bytes" format where the generator is serialized as length-prefixed
 // bytes (like Bytes) instead of a self-describing CLVM Program, and
@@ -121,7 +121,7 @@ impl Streamable for FullBlock {
         let transactions_info = <Option<TransactionsInfo> as Streamable>::parse::<TRUSTED>(input)?;
 
         let prefix = <u8 as Streamable>::parse::<TRUSTED>(input)?;
-        let version = u8::from((prefix & 0b10) != 0);
+        let version = prefix >> 1;
         let has_generator = (prefix & 1) != 0;
 
         if version == 0 {
@@ -546,5 +546,37 @@ mod tests {
         let buf = block.to_bytes().unwrap();
         let block2 = FullBlock::parse::<false>(&mut Cursor::new(&buf)).unwrap();
         assert_eq!(block2.transactions_generator_buffer.unwrap(), garbage);
+    }
+
+    // The version flag is packed into the transactions_generator Option prefix
+    // byte. Only bit 0 (the Option flag) and bit 1 (the version) carry
+    // meaning. The high bits (2..=7) must be rejected, matching the strictness
+    // of a plain Option<> prefix in earlier protocol versions where this byte
+    // could only ever be 0 or 1.
+    #[test]
+    fn high_prefix_bits_rejected() {
+        let v0_none = make_v0_block(None, vec![]).to_bytes().unwrap();
+        let v0_some = make_v0_block(Some(Program::from(vec![0x80])), vec![])
+            .to_bytes()
+            .unwrap();
+        let offset = v0_none
+            .iter()
+            .zip(v0_some.iter())
+            .position(|(a, b)| a != b)
+            .unwrap();
+        assert_eq!(v0_none[offset], 0b00);
+
+        let v1_none = make_v1_block(None).to_bytes().unwrap();
+        assert_eq!(v1_none[offset], 0b10);
+
+        for valid in [&v0_none, &v1_none] {
+            for bit in 2..8u8 {
+                let mut buf = valid.clone();
+                buf[offset] |= 1 << bit;
+                let err = FullBlock::parse::<false>(&mut Cursor::new(&buf))
+                    .expect_err("high prefix bit must be rejected");
+                assert_eq!(err, Error::InvalidFullBlock);
+            }
+        }
     }
 }

--- a/crates/chia-protocol/src/program.rs
+++ b/crates/chia-protocol/src/program.rs
@@ -364,7 +364,7 @@ impl Program {
         // and it being treated as the CLVM structure it represents. In python's
         // SerializedProgram, we have a hack where we interpret the first
         // "layer" of SerializedProgram, or lists of SerializedProgram this way.
-        // But if we encounter an Optional or tuple, we defer to the clvm
+        // But if we encounter an Option or tuple, we defer to the clvm
         // wheel's conversion function to SExp. This level does not have any
         // special treatment for SerializedProgram (as that would cause a
         // circular dependency).

--- a/crates/chia-protocol/src/proof_of_space.rs
+++ b/crates/chia-protocol/src/proof_of_space.rs
@@ -207,7 +207,7 @@ impl ProofOfSpace {
 // ProofOfSpace was updated in Chia 3.0 to support v2 proofs. In order to stay
 // backwards compatible with the network protocol and the block hashes of
 // previous versions, for v1 proofs, some care has to be taken.
-// Optional fields are serialized with a 1-byte prefix indicating whether the
+// Option fields are serialized with a 1-byte prefix indicating whether the
 // field is set or not. This byte is either 0 or 1. This leaves 7 unused bits.
 // We use bit 2 in the byte prefix for the pool_contract_puzzle_hash field to
 // indicate whether this is a v2 proof or not. v1 proofs leave this bit as 0,
@@ -368,7 +368,7 @@ mod tests {
         )
     }
 
-    // Locate the pool_contract_puzzle_hash Optional prefix byte (which also
+    // Locate the pool_contract_puzzle_hash Option prefix byte (which also
     // encodes the version) by finding where a contract-present and a
     // contract-absent serialization first differ.
     fn prefix_offset() -> usize {
@@ -495,7 +495,7 @@ mod tests {
     }
 
     // Round-trip every accepted prefix-byte combination. For v0 (legacy v1
-    // proofs) the pool_contract Optional is lenient and accepts any of
+    // proofs) the pool_contract Option is lenient and accepts any of
     // {neither, pool_pk, contract, both}, exactly like the original plain
     // Option<> derive. For v1 (v2 proofs) the size field is not stored and
     // collapses to 0 on parse.
@@ -547,10 +547,10 @@ mod tests {
         }
     }
 
-    // The version flag is packed into the pool_contract_puzzle_hash Optional
-    // prefix byte. Only bit 0 (the Optional flag) and bit 1 (the version) carry
+    // The version flag is packed into the pool_contract_puzzle_hash Option
+    // prefix byte. Only bit 0 (the Option flag) and bit 1 (the version) carry
     // meaning. The high bits (2..=7) must be rejected for both versions,
-    // matching the strictness of a plain Optional<> prefix in earlier protocol
+    // matching the strictness of a plain Option<> prefix in earlier protocol
     // versions where this byte could only ever be 0 or 1.
     #[rstest]
     fn high_prefix_bits_rejected(#[values(0, 1)] version: u8, #[values(2, 3, 4, 5, 6, 7)] bit: u8) {

--- a/crates/chia-protocol/src/unfinished_block.rs
+++ b/crates/chia-protocol/src/unfinished_block.rs
@@ -1,5 +1,7 @@
+use chia_sha2::Sha256;
 use chia_streamable_macro::streamable;
 
+use crate::Bytes;
 use crate::Bytes32;
 use crate::EndOfSubSlotBundle;
 use crate::Program;
@@ -7,8 +9,15 @@ use crate::RewardChainBlockUnfinished;
 use crate::VDFProof;
 use crate::{Foliage, FoliageTransactionBlock, TransactionsInfo};
 use chia_traits::Streamable;
+use chia_traits::chia_error::{Error, Result};
+use std::io::Cursor;
 
-#[streamable]
+// Similar to FullBlock, we use unused bits in the Option<> prefix byte
+// for transactions_generator to encode a version flag. Bit 1 (0b10) indicates
+// the "raw bytes" format where the generator is serialized as length-prefixed
+// bytes (like Bytes) instead of a self-describing CLVM Program, and
+// transactions_generator_ref_list is omitted entirely.
+#[streamable(no_streamable)]
 pub struct UnfinishedBlock {
     // Full block, without the final VDFs
     finished_sub_slots: Vec<EndOfSubSlotBundle>, // If first sb
@@ -20,6 +29,136 @@ pub struct UnfinishedBlock {
     transactions_info: Option<TransactionsInfo>, // Reward chain foliage data (tx block additional)
     transactions_generator: Option<Program>,     // Program that generates transactions
     transactions_generator_ref_list: Vec<u32>, // List of block heights of previous generators referenced in this block
+
+    // Raw generator bytes, only used when version == 1. Mutually exclusive
+    // with transactions_generator and transactions_generator_ref_list.
+    transactions_generator_buffer: Option<Vec<u8>>,
+
+    // 0 = legacy format (Program serialization + ref_list)
+    // 1 = raw bytes format (length-prefixed bytes, ref_list omitted)
+    version: u8,
+}
+
+impl Streamable for UnfinishedBlock {
+    fn update_digest(&self, digest: &mut Sha256) {
+        self.finished_sub_slots.update_digest(digest);
+        self.reward_chain_block.update_digest(digest);
+        self.challenge_chain_sp_proof.update_digest(digest);
+        self.reward_chain_sp_proof.update_digest(digest);
+        self.foliage.update_digest(digest);
+        self.foliage_transaction_block.update_digest(digest);
+        self.transactions_info.update_digest(digest);
+
+        if self.version == 0 {
+            self.transactions_generator.update_digest(digest);
+            self.transactions_generator_ref_list.update_digest(digest);
+        } else if self.version == 1 {
+            match &self.transactions_generator_buffer {
+                None => {
+                    0b10_u8.update_digest(digest);
+                }
+                Some(buf) => {
+                    0b11_u8.update_digest(digest);
+                    (buf.len() as u32).update_digest(digest);
+                    digest.update(buf);
+                }
+            }
+        } else {
+            digest.update(b"invalid-unfinished-block-version");
+        }
+    }
+
+    fn stream(&self, out: &mut Vec<u8>) -> Result<()> {
+        self.finished_sub_slots.stream(out)?;
+        self.reward_chain_block.stream(out)?;
+        self.challenge_chain_sp_proof.stream(out)?;
+        self.reward_chain_sp_proof.stream(out)?;
+        self.foliage.stream(out)?;
+        self.foliage_transaction_block.stream(out)?;
+        self.transactions_info.stream(out)?;
+
+        if self.version == 0 {
+            self.transactions_generator.stream(out)?;
+            self.transactions_generator_ref_list.stream(out)?;
+        } else if self.version == 1 {
+            match &self.transactions_generator_buffer {
+                None => {
+                    0b10_u8.stream(out)?;
+                }
+                Some(buf) => {
+                    0b11_u8.stream(out)?;
+                    (buf.len() as u32).stream(out)?;
+                    out.extend_from_slice(buf);
+                }
+            }
+        } else {
+            return Err(Error::InvalidUnfinishedBlock);
+        }
+        Ok(())
+    }
+
+    fn parse<const TRUSTED: bool>(input: &mut Cursor<&[u8]>) -> Result<Self> {
+        let finished_sub_slots = <Vec<EndOfSubSlotBundle> as Streamable>::parse::<TRUSTED>(input)?;
+        let reward_chain_block =
+            <RewardChainBlockUnfinished as Streamable>::parse::<TRUSTED>(input)?;
+        let challenge_chain_sp_proof = <Option<VDFProof> as Streamable>::parse::<TRUSTED>(input)?;
+        let reward_chain_sp_proof = <Option<VDFProof> as Streamable>::parse::<TRUSTED>(input)?;
+        let foliage = <Foliage as Streamable>::parse::<TRUSTED>(input)?;
+        let foliage_transaction_block =
+            <Option<FoliageTransactionBlock> as Streamable>::parse::<TRUSTED>(input)?;
+        let transactions_info = <Option<TransactionsInfo> as Streamable>::parse::<TRUSTED>(input)?;
+
+        let prefix = <u8 as Streamable>::parse::<TRUSTED>(input)?;
+        let version = prefix >> 1;
+        let has_generator = (prefix & 1) != 0;
+
+        if version == 0 {
+            let transactions_generator = if has_generator {
+                Some(<Program as Streamable>::parse::<TRUSTED>(input)?)
+            } else {
+                None
+            };
+            let transactions_generator_ref_list =
+                <Vec<u32> as Streamable>::parse::<TRUSTED>(input)?;
+
+            Ok(UnfinishedBlock {
+                finished_sub_slots,
+                reward_chain_block,
+                challenge_chain_sp_proof,
+                reward_chain_sp_proof,
+                foliage,
+                foliage_transaction_block,
+                transactions_info,
+                transactions_generator,
+                transactions_generator_ref_list,
+                transactions_generator_buffer: None,
+                version,
+            })
+        } else if version == 1 {
+            let transactions_generator_buffer = if has_generator {
+                let bytes = <Bytes as Streamable>::parse::<TRUSTED>(input)?;
+                Some(bytes.into_inner())
+            } else {
+                None
+            };
+
+            Ok(UnfinishedBlock {
+                finished_sub_slots,
+                reward_chain_block,
+                challenge_chain_sp_proof,
+                reward_chain_sp_proof,
+                foliage,
+                foliage_transaction_block,
+                transactions_info,
+                transactions_generator: None,
+                transactions_generator_ref_list: vec![],
+                transactions_generator_buffer,
+                version,
+            })
+        } else {
+            Err(Error::InvalidUnfinishedBlock)
+        }
+    }
 }
 
 impl UnfinishedBlock {
@@ -69,5 +208,259 @@ impl UnfinishedBlock {
     #[pyo3(name = "total_iters")]
     fn py_total_iters<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
         ChiaToPython::to_python(&self.total_iters(), py)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{FoliageBlockData, PoolTarget, ProofOfSpace};
+    use chia_bls::{G1Element, G2Element};
+    use rstest::rstest;
+
+    fn make_proof_of_space() -> ProofOfSpace {
+        ProofOfSpace::new(
+            Bytes32::default(),
+            Some(G1Element::default()),
+            None,
+            G1Element::default(),
+            0,
+            0,
+            0,
+            0,
+            32,
+            Bytes::from(vec![0x80]),
+        )
+    }
+
+    fn make_reward_chain_block_unfinished() -> RewardChainBlockUnfinished {
+        RewardChainBlockUnfinished::new(
+            1,
+            0,
+            Bytes32::default(),
+            make_proof_of_space(),
+            None,
+            G2Element::default(),
+            None,
+            G2Element::default(),
+        )
+    }
+
+    fn make_foliage() -> Foliage {
+        let pool_target = PoolTarget::new(Bytes32::default(), 0);
+        let foliage_block_data = FoliageBlockData::new(
+            Bytes32::default(),
+            pool_target,
+            Some(G2Element::default()),
+            Bytes32::default(),
+            Bytes32::default(),
+        );
+        Foliage::new(
+            Bytes32::default(),
+            Bytes32::default(),
+            foliage_block_data,
+            G2Element::default(),
+            None,
+            None,
+        )
+    }
+
+    fn make_v0_block(generator: Option<Program>, ref_list: Vec<u32>) -> UnfinishedBlock {
+        UnfinishedBlock::new(
+            vec![],
+            make_reward_chain_block_unfinished(),
+            None,
+            None,
+            make_foliage(),
+            None,
+            None,
+            generator,
+            ref_list,
+            None,
+            0,
+        )
+    }
+
+    fn make_v1_block(buffer: Option<Vec<u8>>) -> UnfinishedBlock {
+        UnfinishedBlock::new(
+            vec![],
+            make_reward_chain_block_unfinished(),
+            None,
+            None,
+            make_foliage(),
+            None,
+            None,
+            None,
+            vec![],
+            buffer,
+            1,
+        )
+    }
+
+    #[test]
+    fn v0_no_generator_roundtrip() {
+        let block = make_v0_block(None, vec![]);
+        let buf = block.to_bytes().unwrap();
+        let block2 = UnfinishedBlock::parse::<false>(&mut Cursor::new(&buf)).unwrap();
+
+        assert_eq!(block2.version, 0);
+        assert!(block2.transactions_generator.is_none());
+        assert!(block2.transactions_generator_ref_list.is_empty());
+        assert!(block2.transactions_generator_buffer.is_none());
+        assert_eq!(block2.to_bytes().unwrap(), buf);
+    }
+
+    #[test]
+    fn v0_with_generator_roundtrip() {
+        let generator = Program::from(vec![0xff, 0x01, 0x80]);
+        let block = make_v0_block(Some(generator.clone()), vec![100, 200]);
+        let buf = block.to_bytes().unwrap();
+        let block2 = UnfinishedBlock::parse::<false>(&mut Cursor::new(&buf)).unwrap();
+
+        assert_eq!(block2.version, 0);
+        assert_eq!(
+            block2.transactions_generator.as_ref().unwrap().as_ref(),
+            generator.as_ref()
+        );
+        assert_eq!(block2.transactions_generator_ref_list, vec![100, 200]);
+        assert!(block2.transactions_generator_buffer.is_none());
+        assert_eq!(block2.to_bytes().unwrap(), buf);
+    }
+
+    #[test]
+    fn v1_no_generator_roundtrip() {
+        let block = make_v1_block(None);
+        let buf = block.to_bytes().unwrap();
+        let block2 = UnfinishedBlock::parse::<false>(&mut Cursor::new(&buf)).unwrap();
+
+        assert_eq!(block2.version, 1);
+        assert!(block2.transactions_generator.is_none());
+        assert!(block2.transactions_generator_ref_list.is_empty());
+        assert!(block2.transactions_generator_buffer.is_none());
+        assert_eq!(block2.to_bytes().unwrap(), buf);
+    }
+
+    #[test]
+    fn v1_with_buffer_roundtrip() {
+        let raw = vec![0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe];
+        let block = make_v1_block(Some(raw.clone()));
+        let buf = block.to_bytes().unwrap();
+        let block2 = UnfinishedBlock::parse::<false>(&mut Cursor::new(&buf)).unwrap();
+
+        assert_eq!(block2.version, 1);
+        assert!(block2.transactions_generator.is_none());
+        assert!(block2.transactions_generator_ref_list.is_empty());
+        assert_eq!(block2.transactions_generator_buffer.as_ref().unwrap(), &raw);
+        assert_eq!(block2.to_bytes().unwrap(), buf);
+    }
+
+    #[rstest]
+    #[case::v0(0, 0b00, 0b01)]
+    #[case::v1(1, 0b10, 0b11)]
+    fn prefix_byte_encoding(
+        #[case] version: u8,
+        #[case] expected_none: u8,
+        #[case] expected_some: u8,
+    ) {
+        let (buf_none, buf_some) = if version == 0 {
+            (
+                make_v0_block(None, vec![]).to_bytes().unwrap(),
+                make_v0_block(Some(Program::from(vec![0x80])), vec![])
+                    .to_bytes()
+                    .unwrap(),
+            )
+        } else {
+            (
+                make_v1_block(None).to_bytes().unwrap(),
+                make_v1_block(Some(vec![0x80])).to_bytes().unwrap(),
+            )
+        };
+
+        let prefix_offset = buf_none
+            .iter()
+            .zip(buf_some.iter())
+            .position(|(a, b)| a != b)
+            .unwrap();
+
+        assert_eq!(buf_none[prefix_offset], expected_none);
+        assert_eq!(buf_some[prefix_offset], expected_some);
+    }
+
+    #[test]
+    fn v1_generator_has_length_prefix() {
+        let raw = vec![0xca, 0xfe, 0xba, 0xbe];
+        let block = make_v1_block(Some(raw.clone()));
+        let buf = block.to_bytes().unwrap();
+
+        let block_empty = make_v1_block(None);
+        let buf_empty = block_empty.to_bytes().unwrap();
+
+        let prefix_offset = buf
+            .iter()
+            .zip(buf_empty.iter())
+            .position(|(a, b)| a != b)
+            .unwrap();
+
+        assert_eq!(buf[prefix_offset], 0b11);
+        let len = u32::from_be_bytes(
+            buf[prefix_offset + 1..prefix_offset + 5]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(len as usize, raw.len());
+        assert_eq!(&buf[prefix_offset + 5..prefix_offset + 5 + raw.len()], &raw);
+        assert_eq!(prefix_offset + 5 + raw.len(), buf.len());
+    }
+
+    #[test]
+    fn v1_omits_ref_list() {
+        let block_v0 = make_v0_block(Some(Program::from(vec![0x80])), vec![42]);
+        let buf_v0 = block_v0.to_bytes().unwrap();
+
+        let block_v1 = make_v1_block(Some(vec![0x80]));
+        let buf_v1 = block_v1.to_bytes().unwrap();
+
+        assert!(buf_v1.len() < buf_v0.len());
+    }
+
+    #[test]
+    fn v1_unvalidated_buffer_roundtrips() {
+        let garbage = vec![0xff; 1000];
+        let block = make_v1_block(Some(garbage.clone()));
+        let buf = block.to_bytes().unwrap();
+        let block2 = UnfinishedBlock::parse::<false>(&mut Cursor::new(&buf)).unwrap();
+        assert_eq!(block2.transactions_generator_buffer.unwrap(), garbage);
+    }
+
+    // The version flag is packed into the transactions_generator Option prefix
+    // byte. Only bit 0 (the Option flag) and bit 1 (the version) carry
+    // meaning. The high bits (2..=7) must be rejected, matching the strictness
+    // of a plain Option<> prefix in earlier protocol versions where this byte
+    // could only ever be 0 or 1.
+    #[test]
+    fn high_prefix_bits_rejected() {
+        let v0_none = make_v0_block(None, vec![]).to_bytes().unwrap();
+        let v0_some = make_v0_block(Some(Program::from(vec![0x80])), vec![])
+            .to_bytes()
+            .unwrap();
+        let offset = v0_none
+            .iter()
+            .zip(v0_some.iter())
+            .position(|(a, b)| a != b)
+            .unwrap();
+        assert_eq!(v0_none[offset], 0b00);
+
+        let v1_none = make_v1_block(None).to_bytes().unwrap();
+        assert_eq!(v1_none[offset], 0b10);
+
+        for valid in [&v0_none, &v1_none] {
+            for bit in 2..8u8 {
+                let mut buf = valid.clone();
+                buf[offset] |= 1 << bit;
+                let err = UnfinishedBlock::parse::<false>(&mut Cursor::new(&buf))
+                    .expect_err("high prefix bit must be rejected");
+                assert_eq!(err, Error::InvalidUnfinishedBlock);
+            }
+        }
     }
 }

--- a/crates/chia-protocol/src/utils.rs
+++ b/crates/chia-protocol/src/utils.rs
@@ -29,7 +29,7 @@ pub fn update_digest<T: Streamable, U: Streamable>(
 
 // we serialize these two optionals in a backwards compatible way, by
 // sharing the byte indicating whether the optional is set or not. A
-// normal Optional uses 8 bits to store 1 bit. We use two bits to store
+// normal Option uses 8 bits to store 1 bit. We use two bits to store
 // two optionals. As long as the second one isn't set, the data
 // strsucture is backward compatible with the previous RewardChainBlock
 pub fn stream<T: Streamable, U: Streamable>(

--- a/crates/chia-traits/src/chia_error.rs
+++ b/crates/chia-traits/src/chia_error.rs
@@ -24,6 +24,8 @@ pub enum Error {
     InvalidPoS,
     #[error("Invalid FullBlock")]
     InvalidFullBlock,
+    #[error("Invalid UnfinishedBlock")]
+    InvalidUnfinishedBlock,
     #[error("{0}")]
     Custom(String),
 }

--- a/wheel/python/chia_rs/chia_rs.pyi
+++ b/wheel/python/chia_rs/chia_rs.pyi
@@ -2719,6 +2719,8 @@ class UnfinishedBlock:
     transactions_info: Optional[TransactionsInfo]
     transactions_generator: Optional[Program]
     transactions_generator_ref_list: list[uint32]
+    transactions_generator_buffer: Optional[list[uint8]]
+    version: uint8
     prev_header_hash: bytes32
     partial_hash: bytes32
     def is_transaction_block(self) -> bool: ...
@@ -2733,7 +2735,9 @@ class UnfinishedBlock:
         foliage_transaction_block: Optional[FoliageTransactionBlock],
         transactions_info: Optional[TransactionsInfo],
         transactions_generator: Optional[Program],
-        transactions_generator_ref_list: Sequence[uint32]
+        transactions_generator_ref_list: Sequence[uint32],
+        transactions_generator_buffer: Optional[Sequence[uint8]],
+        version: uint8
     ) -> Self: ...
     def __hash__(self) -> int: ...
     def __repr__(self) -> str: ...
@@ -2760,7 +2764,9 @@ class UnfinishedBlock:
         foliage_transaction_block: Union[ Optional[FoliageTransactionBlock], _Unspec] = _Unspec(),
         transactions_info: Union[ Optional[TransactionsInfo], _Unspec] = _Unspec(),
         transactions_generator: Union[ Optional[Program], _Unspec] = _Unspec(),
-        transactions_generator_ref_list: Union[ list[uint32], _Unspec] = _Unspec()) -> UnfinishedBlock: ...
+        transactions_generator_ref_list: Union[ list[uint32], _Unspec] = _Unspec(),
+        transactions_generator_buffer: Union[ Optional[list[uint8]], _Unspec] = _Unspec(),
+        version: Union[ uint8, _Unspec] = _Unspec()) -> UnfinishedBlock: ...
     def truncate(self, field: str, length: int) -> None: ...
 
 @final


### PR DESCRIPTION
just like FullBlock, where the generator is serialized as a byte blob. To parse an UnfinishedBlock, with the new format, we no longer need to deserialize CLVM.

This mirrors the changes in https://github.com/Chia-Network/chia_rs/pull/1456 and https://github.com/Chia-Network/chia_rs/pull/1345 .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consensus-relevant block serialization and parsing for unfinished blocks on the network; backward compatibility for version 0 is preserved, but any mismatch with FullBlock or peers on v1 encoding would be high impact.
> 
> **Overview**
> **UnfinishedBlock** now mirrors **FullBlock**’s dual generator wire format: **version 0** keeps CLVM `Program` plus `transactions_generator_ref_list`; **version 1** stores length-prefixed raw bytes in `transactions_generator_buffer` and omits the ref list, so peers can parse the block without deserializing CLVM. A custom `Streamable` implementation packs version and presence into the `transactions_generator` Option prefix byte (bit 0 = present, bit 1 = v1).
> 
> **FullBlock** parsing now derives `version` with `prefix >> 1` instead of a single-bit check, and adds tests that prefix bytes with bits 2–7 set are rejected as `InvalidFullBlock`. **UnfinishedBlock** gets the same strict prefix rules via `InvalidUnfinishedBlock` (new error in `chia-traits`). Python stubs expose `transactions_generator_buffer` and `version` on `UnfinishedBlock`.
> 
> Comment-only renames from “Optional” to “Option” appear in a few protocol files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2798fa8a68e6466f8e4e8619e41dd351691fb3fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->