### PR TITLE
bump clvmr dependency to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,7 @@ version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a70dfe8540688eaed5bdecffd51c26df489b8bc610890b613b81461411f90cc9"
 dependencies = [
+ "arbitrary",
  "blst",
  "chia-sha2 0.38.2",
  "chia-traits 0.38.2",
@@ -587,15 +588,6 @@ dependencies = [
 
 [[package]]
 name = "chia-sha2"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f06500dc809a916fa0c70f5219b8b79a598462382a4ddca91ef1a3cb32b826ce"
-dependencies = [
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "chia-sha2"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a57be484b5abb4481a3ea8b2e6fc0404f41222e0cfb35b81269c2404b64107a"
@@ -754,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -764,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -776,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -788,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clvm-derive"
@@ -803,14 +795,18 @@ dependencies = [
 
 [[package]]
 name = "clvm-fuzzing"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5299206365e0f6d328151054de9a605b987c94a471a075b11db5eb57ad86c831"
+checksum = "edfac8b7af2c7202157ce59439a63882da45492dc414a7e4e15b8590b6d08b88"
 dependencies = [
  "anyhow",
  "arbitrary",
- "chia-sha2 0.34.0",
+ "chia-bls 0.38.2",
+ "chia-sha2 0.38.2",
+ "clap",
  "clvmr",
+ "hex",
+ "rand",
 ]
 
 [[package]]
@@ -864,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.17.7"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3060bcd64cb8cf2b32fe6ee3a82698835c03361c8e1da446d2e9d058fbfffd5f"
+checksum = "05a2651e364d36ec9a9848c819e763c892477317b5887fa140085ae79fc0bc4f"
 dependencies = [
  "bitflags",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,8 +143,8 @@ chia-puzzle-types-fuzz = { path = "./crates/chia-puzzle-types/fuzz", version = "
 clvm-traits-fuzz = { path = "./crates/clvm-traits/fuzz", version = "0.45.0" }
 clvm-utils-fuzz = { path = "./crates/clvm-utils/fuzz", version = "0.45.0" }
 blst = { version = "0.3.16", features = ["portable"] }
-clvmr = "0.17.7"
-clvm-fuzzing = "0.17.0"
+clvmr = "0.18.0"
+clvm-fuzzing = "0.18.0"
 syn = "2.0.101"
 quote = "1.0.40"
 proc-macro2 = "1.0.95"

--- a/crates/chia-consensus/src/flags.rs
+++ b/crates/chia-consensus/src/flags.rs
@@ -21,7 +21,7 @@ bitflags! {
         const NO_UNKNOWN_OPS = 0x0002;
         const LIMIT_HEAP = 0x0004;
         const RELAXED_BLS = 0x0008;
-        const LIMITS = 0x0010;
+        const LIMIT_SOFTFORK = 0x0010;
         const ENABLE_GC = 0x0020;
         const ENABLE_KECCAK_OPS_OUTSIDE_GUARD = 0x0100;
         const DISABLE_OP = 0x0200;
@@ -77,8 +77,8 @@ impl ConsensusFlags {
         if clvm.contains(ClvmFlags::RELAXED_BLS) {
             out = out.union(ConsensusFlags::RELAXED_BLS);
         }
-        if clvm.contains(ClvmFlags::LIMITS) {
-            out = out.union(ConsensusFlags::LIMITS);
+        if clvm.contains(ClvmFlags::LIMIT_SOFTFORK) {
+            out = out.union(ConsensusFlags::LIMIT_SOFTFORK);
         }
         if clvm.contains(ClvmFlags::ENABLE_GC) {
             out = out.union(ConsensusFlags::ENABLE_GC);
@@ -118,8 +118,8 @@ impl ConsensusFlags {
         if self.contains(ConsensusFlags::RELAXED_BLS) {
             out.insert(ClvmFlags::RELAXED_BLS);
         }
-        if self.contains(ConsensusFlags::LIMITS) {
-            out.insert(ClvmFlags::LIMITS);
+        if self.contains(ConsensusFlags::LIMIT_SOFTFORK) {
+            out.insert(ClvmFlags::LIMIT_SOFTFORK);
         }
         if self.contains(ConsensusFlags::ENABLE_GC) {
             out.insert(ClvmFlags::ENABLE_GC);

--- a/crates/chia-consensus/src/spendbundle_validation.rs
+++ b/crates/chia-consensus/src/spendbundle_validation.rs
@@ -97,7 +97,6 @@ pub fn get_flags_for_height_and_constants(
     if prev_tx_height >= constants.soft_fork9_height {
         flags |= ConsensusFlags::SIMPLE_GENERATOR
             | ConsensusFlags::CANONICAL_INTS
-            | ConsensusFlags::LIMITS
             | ConsensusFlags::LIMIT_SPENDS;
     }
     flags

--- a/tests/run-programs.py
+++ b/tests/run-programs.py
@@ -57,7 +57,9 @@ for hexname in sorted(glob.glob("programs/*.hex")):
     end = time.perf_counter()
 
     if "FAIL: " not in output or (
-        "cost exceeded" not in output and "too many pairs" not in output
+        "cost exceeded" not in output
+        and "too many pairs" not in output
+        and "InvalidOperatorArg" not in output
     ):
         ret += 1
         print(


### PR DESCRIPTION
One change in `clvm_rs` is that it dropped the `LIMITS` flag (which has been activated and is part of consensus now) and it introduced `LIMIT_SOFTFORK`.

The new flag is a mempool-only limit, that does not affect consensus.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus flag wiring and height-based validation flags for CLVM execution; behavior must stay aligned with clvm_rs 0.18 and Python flag bit compatibility.
> 
> **Overview**
> Upgrades **`clvmr`** and **`clvm-fuzzing`** to **0.18.0** (with lockfile churn for related crates such as `clap` and `chia-sha2`).
> 
> **Consensus flag sync:** Renames the shared CLVM flag from **`LIMITS`** to **`LIMIT_SOFTFORK`** in `ConsensusFlags` and in the `ClvmFlags` ↔ `ConsensusFlags` mappers, matching clvm_rs 0.18. Stops OR-ing that flag in **`get_flags_for_height_and_constants`** at soft fork 9 height, since the old `LIMITS` behavior is no longer toggled that way upstream.
> 
> **Tests:** `tests/run-programs.py` now treats **`InvalidOperatorArg`** in program output as an acceptable expected failure alongside cost/pair-limit failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6debd65beb67ff4d49184774bef8555be4f3c86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->