### PR TITLE
bump pyo3 to 0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1938,15 +1938,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,14 +2307,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a6df7eab65fc7bee654a421404947e10a0f7085b6951bf2ea395f4659fb0cf"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "inventory",
  "libc",
- "memoffset",
  "num-bigint",
  "num-traits",
  "once_cell",
@@ -2331,23 +2320,22 @@ dependencies = [
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77d387774f6f6eec64a004eac0ed525aab7fa1966d94b42f743797b3e395afb"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd13844a4242793e02df3e2ec093f540d948299a6a77ea9ce7afd8623f542be"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2355,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf8f9f1108270b90d3676b8679586385430e5c0bb78bb5f043f95499c821a71"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2367,13 +2355,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a3b2274450ba5288bc9b8c1b69ff569d1d61189d4bff38f8d22e03d17f932b"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -2921,9 +2908,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -3153,12 +3140,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,7 @@ hkdf = "0.12.0"
 getrandom = { version = "0.4", features = ["sys_rng"] }
 hex = "0.4.3"
 thiserror = "2.0.0"
-pyo3 = "0.27.1"
+pyo3 = "0.29.0"
 arbitrary = "1.4.1"
 rand = "0.9"
 criterion = "0.5.1"

--- a/crates/chia-bls/src/bls_cache.rs
+++ b/crates/chia-bls/src/bls_cache.rs
@@ -36,7 +36,10 @@ impl BlsCacheData {
     }
 }
 
-#[cfg_attr(feature = "py-bindings", pyo3::pyclass(name = "BLSCache"))]
+#[cfg_attr(
+    feature = "py-bindings",
+    pyo3::pyclass(name = "BLSCache", from_py_object)
+)]
 #[derive(Debug)]
 pub struct BlsCache {
     cache: Mutex<BlsCacheData>,

--- a/crates/chia-bls/src/gtelement.rs
+++ b/crates/chia-bls/src/gtelement.rs
@@ -16,7 +16,7 @@ use std::ops::{Mul, MulAssign};
 
 #[cfg_attr(
     feature = "py-bindings",
-    pyo3::pyclass,
+    pyo3::pyclass(from_py_object),
     derive(chia_py_streamable_macro::PyStreamable)
 )]
 #[derive(Clone)]

--- a/crates/chia-bls/src/public_key.rs
+++ b/crates/chia-bls/src/public_key.rs
@@ -18,7 +18,7 @@ use std::ops::{Add, AddAssign, Neg, SubAssign};
 
 #[cfg_attr(
     feature = "py-bindings",
-    pyo3::pyclass(name = "G1Element"),
+    pyo3::pyclass(name = "G1Element", from_py_object),
     derive(chia_py_streamable_macro::PyStreamable)
 )]
 #[derive(Clone, Copy, Default)]

--- a/crates/chia-bls/src/secret_key.rs
+++ b/crates/chia-bls/src/secret_key.rs
@@ -17,7 +17,7 @@ use std::ops::{Add, AddAssign};
 
 #[cfg_attr(
     feature = "py-bindings",
-    pyo3::pyclass(name = "PrivateKey"),
+    pyo3::pyclass(name = "PrivateKey", from_py_object),
     derive(chia_py_streamable_macro::PyStreamable)
 )]
 #[derive(PartialEq, Eq, Clone)]

--- a/crates/chia-bls/src/signature.rs
+++ b/crates/chia-bls/src/signature.rs
@@ -20,7 +20,7 @@ pub(crate) const DST: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_";
 
 #[cfg_attr(
     feature = "py-bindings",
-    pyo3::pyclass(name = "G2Element"),
+    pyo3::pyclass(name = "G2Element", from_py_object),
     derive(chia_py_streamable_macro::PyStreamable)
 )]
 #[derive(Clone, Default)]

--- a/crates/chia-consensus/src/consensus_constants.rs
+++ b/crates/chia-consensus/src/consensus_constants.rs
@@ -9,7 +9,7 @@ use hex_literal::hex;
 /// tests, simulations and testnets.
 #[cfg_attr(
     feature = "py-bindings",
-    pyo3::pyclass(module = "chia_rs"),
+    pyo3::pyclass(module = "chia_rs", from_py_object),
     derive(PyJsonDict, PyStreamable, PyGetters),
     py_uppercase,
     py_pickle

--- a/crates/chia-consensus/src/merkle_tree.rs
+++ b/crates/chia-consensus/src/merkle_tree.rs
@@ -31,7 +31,10 @@ pub enum ArrayTypes {
 
 // represents a MerkleSet by putting all the nodes in a vec. Root is the last entry.
 #[derive(PartialEq, Debug, Clone, Default)]
-#[cfg_attr(feature = "py-bindings", pyclass(frozen, name = "MerkleSet"))]
+#[cfg_attr(
+    feature = "py-bindings",
+    pyclass(frozen, name = "MerkleSet", from_py_object)
+)]
 pub struct MerkleSet {
     nodes_vec: Vec<(ArrayTypes, [u8; 32])>,
     // This is true if the tree was built from a proof. This means the tree may

--- a/crates/chia-consensus/src/owned_conditions.rs
+++ b/crates/chia-consensus/src/owned_conditions.rs
@@ -19,7 +19,7 @@ use pyo3::types::PyType;
 #[derive(Streamable, Hash, Debug, Clone, Eq, PartialEq, Default)]
 #[cfg_attr(
     feature = "py-bindings",
-    pyo3::pyclass(name = "SpendConditions"),
+    pyo3::pyclass(name = "SpendConditions", from_py_object),
     derive(PyJsonDict, PyStreamable, chia_py_streamable_macro::PyGetters)
 )]
 pub struct OwnedSpendConditions {
@@ -51,7 +51,7 @@ pub struct OwnedSpendConditions {
 #[derive(Streamable, Hash, Debug, Clone, Eq, PartialEq, Default)]
 #[cfg_attr(
     feature = "py-bindings",
-    pyo3::pyclass(name = "SpendBundleConditions"),
+    pyo3::pyclass(name = "SpendBundleConditions", from_py_object),
     derive(PyJsonDict, PyStreamable, chia_py_streamable_macro::PyGetters)
 )]
 pub struct OwnedSpendBundleConditions {

--- a/crates/chia-datalayer/src/merkle/blob.rs
+++ b/crates/chia-datalayer/src/merkle/blob.rs
@@ -69,7 +69,7 @@ pub enum Side {
     Right = 1,
 }
 
-#[cfg_attr(feature = "py-bindings", pyclass)]
+#[cfg_attr(feature = "py-bindings", pyclass(from_py_object))]
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub enum InsertLocation {
     // error: Unit variant `Auto` is not yet supported in a complex enum
@@ -85,7 +85,7 @@ pub fn block_range(index: TreeIndex) -> Range<usize> {
     block_start..block_start + BLOCK_SIZE
 }
 
-#[cfg_attr(feature = "py-bindings", pyclass)]
+#[cfg_attr(feature = "py-bindings", pyclass(from_py_object))]
 #[derive(Clone, Debug)]
 pub struct BlockStatusCache {
     free_indexes: IndexSet<TreeIndex>,
@@ -302,7 +302,7 @@ pub type LeafNodesMap = HashMap<Hash, (KeyId, ValueId)>;
 /// do not hold the DataLayer key and value data but instead an id for each of the key and value
 /// such that the code using a merkle blob can store the key and value as they see fit.  Each node
 /// stores the hash for the merkle aspect of the tree.
-#[cfg_attr(feature = "py-bindings", pyclass(get_all))]
+#[cfg_attr(feature = "py-bindings", pyclass(get_all, from_py_object))]
 #[derive(Clone, Debug)]
 pub struct MerkleBlob {
     pub(crate) blob: Vec<u8>,

--- a/crates/chia-datalayer/src/merkle/format.rs
+++ b/crates/chia-datalayer/src/merkle/format.rs
@@ -11,7 +11,11 @@ use std::ops::Range;
 
 pub type TreeIndexType = u32;
 
-#[cfg_attr(feature = "py-bindings", pyclass, derive(PyJsonDict, PyStreamable))]
+#[cfg_attr(
+    feature = "py-bindings",
+    pyclass(from_py_object),
+    derive(PyJsonDict, PyStreamable)
+)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Streamable)]
 // ISSUE: this cfg()/cfg(not()) is terrible, but there's an issue with pyo3
 //        being found with a cfg_attr
@@ -58,7 +62,11 @@ pub struct Hash(pub Bytes32);
 /// Key and value ids are provided from outside of this code and are implemented as
 /// the row id from sqlite which is a signed 8 byte integer.  The actual key and
 /// value data bytes will not be handled within this code, only outside.
-#[cfg_attr(feature = "py-bindings", pyclass, derive(PyJsonDict, PyStreamable))]
+#[cfg_attr(
+    feature = "py-bindings",
+    pyclass(from_py_object),
+    derive(PyJsonDict, PyStreamable)
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Streamable)]
 // ISSUE: this cfg()/cfg(not()) is terrible, but there's an issue with pyo3
@@ -81,7 +89,11 @@ impl KeyId {
     }
 }
 
-#[cfg_attr(feature = "py-bindings", pyclass, derive(PyJsonDict, PyStreamable))]
+#[cfg_attr(
+    feature = "py-bindings",
+    pyclass(from_py_object),
+    derive(PyJsonDict, PyStreamable)
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Streamable)]
 // ISSUE: this cfg()/cfg(not()) is terrible, but there's an issue with pyo3
@@ -155,7 +167,7 @@ pub struct NodeMetadata {
 
 #[cfg_attr(
     feature = "py-bindings",
-    pyclass(get_all),
+    pyclass(get_all, from_py_object),
     derive(PyJsonDict, PyStreamable)
 )]
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Streamable)]
@@ -190,7 +202,7 @@ impl InternalNode {
 
 #[cfg_attr(
     feature = "py-bindings",
-    pyclass(get_all),
+    pyclass(get_all, from_py_object),
     derive(PyJsonDict, PyStreamable)
 )]
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Streamable)]

--- a/crates/chia-datalayer/src/merkle/proof_of_inclusion.rs
+++ b/crates/chia-datalayer/src/merkle/proof_of_inclusion.rs
@@ -7,7 +7,7 @@ use pyo3::{pyclass, pymethods};
 
 #[cfg_attr(
     feature = "py-bindings",
-    pyclass(get_all),
+    pyclass(get_all, from_py_object),
     derive(PyJsonDict, PyStreamable)
 )]
 #[derive(Clone, Debug, std::hash::Hash, Eq, PartialEq, Streamable)]
@@ -19,7 +19,7 @@ pub struct ProofOfInclusionLayer {
 
 #[cfg_attr(
     feature = "py-bindings",
-    pyclass(get_all),
+    pyclass(get_all, from_py_object),
     derive(PyJsonDict, PyStreamable)
 )]
 #[derive(Clone, Debug, std::hash::Hash, Eq, PartialEq, Streamable)]

--- a/crates/chia-protocol/src/lazy_node.rs
+++ b/crates/chia-protocol/src/lazy_node.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use std::rc::Rc;
 
-#[pyclass(subclass, unsendable, frozen)]
+#[pyclass(subclass, unsendable, frozen, from_py_object)]
 #[derive(Clone)]
 pub struct LazyNode {
     allocator: Rc<Allocator>,

--- a/crates/chia-protocol/src/program.rs
+++ b/crates/chia-protocol/src/program.rs
@@ -27,7 +27,11 @@ use std::rc::Rc;
 #[cfg(feature = "py-bindings")]
 use clvm_utils::CurriedProgram;
 
-#[cfg_attr(feature = "py-bindings", pyclass(subclass), derive(PyStreamable))]
+#[cfg_attr(
+    feature = "py-bindings",
+    pyclass(subclass, from_py_object),
+    derive(PyStreamable)
+)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Program(Bytes);

--- a/crates/chia_streamable_macro/src/lib.rs
+++ b/crates/chia_streamable_macro/src/lib.rs
@@ -130,7 +130,7 @@ pub fn streamable(attr: TokenStream, item: TokenStream) -> TokenStream {
 
         quote! {
             #[cfg_attr(
-                feature = "py-bindings", pyo3::pyclass(#class_attrs), derive(
+                feature = "py-bindings", pyo3::pyclass(from_py_object, #class_attrs), derive(
                     chia_py_streamable_macro::PyStreamable,
                     chia_py_streamable_macro::PyGetters
                 )


### PR DESCRIPTION
this addresses two cargo audit issues:

```
Crate:     pyo3
error: 2 vulnerabilities found!
warning: 9 allowed warnings found
Version:   0.27.1
Title:     Out-of-bounds read in `nth` / `nth_back` for `PyList` and `PyTuple` iterators
Date:      2026-06-11
ID:        RUSTSEC-2026-0176
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0176
Solution:  Upgrade to >=0.29.0

Crate:     pyo3
Version:   0.27.1
Title:     Missing `Sync` bound on `PyCFunction::new_closure` closures
Date:      2026-06-11
ID:        RUSTSEC-2026-0177
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0177
Solution:  Upgrade to >=0.29.0
```