### PR TITLE
fix warnings issued by latest version of clippy

### DIFF
--- a/crates/chia-bls/src/gtelement.rs
+++ b/crates/chia-bls/src/gtelement.rs
@@ -83,10 +83,7 @@ impl Mul<&GTElement> for &GTElement {
 
 impl fmt::Debug for GTElement {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_fmt(format_args!(
-            "<GTElement {}>",
-            &hex::encode(self.to_bytes())
-        ))
+        formatter.write_fmt(format_args!("<GTElement {}>", hex::encode(self.to_bytes())))
     }
 }
 

--- a/crates/chia-bls/src/public_key.rs
+++ b/crates/chia-bls/src/public_key.rs
@@ -271,10 +271,7 @@ impl Add<&PublicKey> for PublicKey {
 
 impl fmt::Debug for PublicKey {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_fmt(format_args!(
-            "<G1Element {}>",
-            &hex::encode(self.to_bytes())
-        ))
+        formatter.write_fmt(format_args!("<G1Element {}>", hex::encode(self.to_bytes())))
     }
 }
 
@@ -625,8 +622,11 @@ mod tests {
         let pk2 = pk1.derive_unhardened(1);
         let pk3 = pk1.derive_unhardened(2);
 
-        assert!(hash(pk2) != hash(pk3));
-        assert!(hash(pk1.derive_unhardened(42)) == hash(pk1.derive_unhardened(42)));
+        assert_ne!(hash(pk2), hash(pk3));
+        assert_eq!(
+            hash(pk1.derive_unhardened(42)),
+            hash(pk1.derive_unhardened(42))
+        );
     }
 
     #[test]
@@ -702,10 +702,10 @@ mod tests {
             let g1 = PublicKey::from_integer(&data);
             let mut g1_neg = g1;
             g1_neg.negate();
-            assert!(g1_neg != g1);
+            assert_ne!(g1_neg, g1);
 
             g1_neg.negate();
-            assert!(g1_neg == g1);
+            assert_eq!(g1_neg, g1);
         }
     }
 
@@ -715,7 +715,7 @@ mod tests {
         let mut g1_neg = g1;
         // negate on infinity is a no-op
         g1_neg.negate();
-        assert!(g1_neg == g1);
+        assert_eq!(g1_neg, g1);
     }
 
     #[test]
@@ -734,9 +734,9 @@ mod tests {
             let mut g1_double = g1;
             // adding the negative undoes adding the positive
             g1_double += &g1;
-            assert!(g1_double != g1);
+            assert_ne!(g1_double, g1);
             g1_double += &g1_neg;
-            assert!(g1_double == g1);
+            assert_eq!(g1_double, g1);
         }
     }
 
@@ -752,10 +752,10 @@ mod tests {
             let mut g1 = PublicKey::from_integer(&data);
             let mut g1_double = g1;
             g1_double += &g1;
-            assert!(g1_double != g1);
+            assert_ne!(g1_double, g1);
             // scalar multiply by 2 is the same as adding oneself
             g1.scalar_multiply(&[2]);
-            assert!(g1_double == g1);
+            assert_eq!(g1_double, g1);
         }
     }
 
@@ -770,7 +770,7 @@ mod tests {
             rng.fill(&mut msg);
             let default_hash = hash_to_g1(&msg);
             assert_eq!(default_hash, hash_to_g1_with_dst(&msg, DEFAULT_DST));
-            assert!(default_hash != hash_to_g1_with_dst(&msg, CUSTOM_DST));
+            assert_ne!(default_hash, hash_to_g1_with_dst(&msg, CUSTOM_DST));
         }
     }
 

--- a/crates/chia-bls/src/secret_key.rs
+++ b/crates/chia-bls/src/secret_key.rs
@@ -509,8 +509,8 @@ mod tests {
         rng.fill(data.as_mut_slice());
         let sk3 = SecretKey::from_seed(&data);
 
-        assert!(hash(&sk1) == hash(&sk2));
-        assert!(hash(&sk1) != hash(&sk3));
+        assert_eq!(hash(&sk1), hash(&sk2));
+        assert_ne!(hash(&sk1), hash(&sk3));
     }
 
     #[test]

--- a/crates/chia-bls/src/signature.rs
+++ b/crates/chia-bls/src/signature.rs
@@ -170,10 +170,7 @@ impl Hash for Signature {
 
 impl fmt::Debug for Signature {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_fmt(format_args!(
-            "<G2Element {}>",
-            &hex::encode(self.to_bytes())
-        ))
+        formatter.write_fmt(format_args!("<G2Element {}>", hex::encode(self.to_bytes())))
     }
 }
 
@@ -1142,7 +1139,7 @@ mod tests {
         let sig1 = sign(&sk, [0, 1, 2]);
         let sig2 = sign(&sk, [0, 1, 2, 3]);
 
-        assert!(hash(sig1) != hash(sig2));
+        assert_ne!(hash(sig1), hash(sig2));
         assert_eq!(hash(sign(&sk, [0, 1, 2])), hash(sign(&sk, [0, 1, 2])));
     }
 
@@ -1199,10 +1196,10 @@ mod tests {
 
             let mut g2_neg = g2.clone();
             g2_neg.negate();
-            assert!(g2_neg != g2);
+            assert_ne!(g2_neg, g2);
 
             g2_neg.negate();
-            assert!(g2_neg == g2);
+            assert_eq!(g2_neg, g2);
         }
     }
 
@@ -1212,7 +1209,7 @@ mod tests {
         let mut g2_neg = g2.clone();
         // negate on infinity is a no-op
         g2_neg.negate();
-        assert!(g2_neg == g2);
+        assert_eq!(g2_neg, g2);
     }
 
     #[test]
@@ -1231,9 +1228,9 @@ mod tests {
             let mut g2_double = g2.clone();
             // adding the negative undoes adding the positive
             g2_double += &g2;
-            assert!(g2_double != g2);
+            assert_ne!(g2_double, g2);
             g2_double += &g2_neg;
-            assert!(g2_double == g2);
+            assert_eq!(g2_double, g2);
         }
     }
 
@@ -1249,10 +1246,10 @@ mod tests {
             let mut g2 = sign(&sk, msg);
             let mut g2_double = g2.clone();
             g2_double += &g2;
-            assert!(g2_double != g2);
+            assert_ne!(g2_double, g2);
             // scalar multiply by 2 is the same as adding oneself
             g2.scalar_multiply(&[2]);
-            assert!(g2_double == g2);
+            assert_eq!(g2_double, g2);
         }
     }
 
@@ -1267,7 +1264,7 @@ mod tests {
             rng.fill(&mut msg);
             let default_hash = hash_to_g2(&msg);
             assert_eq!(default_hash, hash_to_g2_with_dst(&msg, DEFAULT_DST));
-            assert!(default_hash != hash_to_g2_with_dst(&msg, CUSTOM_DST));
+            assert_ne!(default_hash, hash_to_g2_with_dst(&msg, CUSTOM_DST));
         }
     }
 

--- a/crates/chia-consensus/fuzz/fuzz_targets/fast-forward.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/fast-forward.rs
@@ -213,7 +213,7 @@ fn test_ff(
             // rebased/fast-forwarded, it should at least not be considered
             // eligible.
             let msg2 = e2.error_code();
-            assert!((conditions1.spends[0].flags & ELIGIBLE_FOR_FF) == 0);
+            assert_eq!(conditions1.spends[0].flags & ELIGIBLE_FOR_FF, 0);
             assert!(discrepancy_errors.contains(&msg2));
         }
         (Err(e1), Ok(conditions2)) => {
@@ -223,7 +223,7 @@ fn test_ff(
             // happen if there's an ASSERT_MY_COINID that's only valid after the
             // fast-forward
             let msg1 = e1.error_code();
-            assert!((conditions2.spends[0].flags & ELIGIBLE_FOR_FF) == 0);
+            assert_eq!(conditions2.spends[0].flags & ELIGIBLE_FOR_FF, 0);
             assert!(discrepancy_errors.contains(&msg1));
         }
     }

--- a/crates/chia-consensus/fuzz/fuzz_targets/merkle-set.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/merkle-set.rs
@@ -31,8 +31,9 @@ fuzz_target!(|leafs_: Vec::<[u8; 32]>| -> Corpus {
             .expect("failed to validate proof");
         assert_eq!(rebuilt.get_root(), root);
         assert_eq!(included, expect_included);
-        assert!(
-            validate_merkle_proof(&proof, item, &root).expect("proof failed") == expect_included
+        assert_eq!(
+            validate_merkle_proof(&proof, item, &root).expect("proof failed"),
+            expect_included
         );
     }
     Corpus::Keep

--- a/crates/chia-consensus/fuzz/fuzz_targets/run-generator.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/run-generator.rs
@@ -49,8 +49,8 @@ fuzz_target!(|data: &[u8]| {
         }
         (r1, r2) => {
             println!("mismatching result");
-            println!(" run_block_generator: {:?}", &r1);
-            println!("run_block_generator2: {:?}", &r2);
+            println!(" run_block_generator: {r1:?}");
+            println!("run_block_generator2: {r2:?}");
             panic!("failed");
         }
     }

--- a/crates/chia-consensus/fuzz/fuzz_targets/sanitize-uint.rs
+++ b/crates/chia-consensus/fuzz/fuzz_targets/sanitize-uint.rs
@@ -17,17 +17,17 @@ fuzz_target!(|data: &[u8]| {
         Ok(SanitizedUint::Ok(_)) => {
             assert!(data.len() <= 9);
             if data.len() == 9 {
-                assert!(data[0] == 0);
+                assert_eq!(data[0], 0);
             }
         }
         Ok(SanitizedUint::NegativeOverflow) => {
-            assert!(!data.is_empty() && (data[0] & 0x80) != 0);
+            assert_ne!(data[0] & 0x80, 0);
         }
         Ok(SanitizedUint::PositiveOverflow) => {
             assert!(data.len() > 8);
         }
         Err(ValidationErr::Err(c)) => {
-            assert!(c == ErrorCode::InvalidCoinAmount);
+            assert_eq!(c, ErrorCode::InvalidCoinAmount);
         }
         _ => {
             panic!("invalid state");
@@ -43,17 +43,17 @@ fuzz_target!(|data: &[u8]| {
         Ok(SanitizedUint::Ok(_)) => {
             assert!(data.len() <= 5);
             if data.len() == 5 {
-                assert!(data[0] == 0);
+                assert_eq!(data[0], 0);
             }
         }
         Ok(SanitizedUint::NegativeOverflow) => {
-            assert!(!data.is_empty() && (data[0] & 0x80) != 0);
+            assert_ne!(data[0] & 0x80, 0);
         }
         Ok(SanitizedUint::PositiveOverflow) => {
             assert!(data.len() > 4);
         }
         Err(ValidationErr::Err(c)) => {
-            assert!(c == ErrorCode::InvalidCoinAmount);
+            assert_eq!(c, ErrorCode::InvalidCoinAmount);
         }
         _ => {
             panic!("invalid state");

--- a/crates/chia-consensus/src/conditions.rs
+++ b/crates/chia-consensus/src/conditions.rs
@@ -2379,7 +2379,7 @@ fn test_extra_arg(
     let spend = &conds.spends[0];
     assert_eq!(*spend.coin_id, test_coin_id(H1, H2, 123));
     assert_eq!(a.atom(spend.puzzle_hash).as_ref(), H2);
-    assert!((spend.flags & ELIGIBLE_FOR_DEDUP) == 0);
+    assert_eq!(spend.flags & ELIGIBLE_FOR_DEDUP, 0);
 
     test(&conds, spend);
 }
@@ -2433,7 +2433,7 @@ fn test_single_condition(
     let spend = &conds.spends[0];
     assert_eq!(*spend.coin_id, test_coin_id(H1, H2, 123));
     assert_eq!(a.atom(spend.puzzle_hash).as_ref(), H2);
-    assert!((spend.flags & ELIGIBLE_FOR_DEDUP) == 0);
+    assert_eq!(spend.flags & ELIGIBLE_FOR_DEDUP, 0);
 
     test(&conds, spend);
 }
@@ -2576,7 +2576,7 @@ fn test_multiple_conditions(
     let spend = &conds.spends[0];
     assert_eq!(*spend.coin_id, test_coin_id(H1, H2, 1234));
     assert_eq!(a.atom(spend.puzzle_hash).as_ref(), H2);
-    assert!((spend.flags & ELIGIBLE_FOR_DEDUP) == 0);
+    assert_eq!(spend.flags & ELIGIBLE_FOR_DEDUP, 0);
 
     test(&conds, spend);
 }
@@ -3639,7 +3639,7 @@ fn test_agg_sig_extra_arg(#[case] condition: ConditionOpcode) {
     let spend = &conds.spends[0];
     assert_eq!(*spend.coin_id, test_coin_id(H1, H2, 123));
     assert_eq!(a.atom(spend.puzzle_hash).as_ref(), H2);
-    assert!((spend.flags & ELIGIBLE_FOR_DEDUP) == 0);
+    assert_eq!(spend.flags & ELIGIBLE_FOR_DEDUP, 0);
 
     if condition != AGG_SIG_UNSAFE {
         let agg_sigs = agg_sig_vec(condition, spend);
@@ -4462,7 +4462,7 @@ fn test_impossible_constraints_single_spend(
         assert_eq!(*spend.coin_id, test_coin_id(H1, H1, 123));
         assert_eq!(a.atom(spend.puzzle_hash).as_ref(), H1);
         assert_eq!(spend.agg_sig_me.len(), 0);
-        assert!((spend.flags & ELIGIBLE_FOR_DEDUP) == 0);
+        assert_eq!(spend.flags & ELIGIBLE_FOR_DEDUP, 0);
     }
 }
 
@@ -4559,13 +4559,13 @@ fn test_impossible_constraints_separate_spends(
         assert_eq!(*spend.coin_id, test_coin_id(H1, H1, 123));
         assert_eq!(a.atom(spend.puzzle_hash).as_ref(), H1);
         assert_eq!(spend.agg_sig_me.len(), 0);
-        assert!((spend.flags & ELIGIBLE_FOR_DEDUP) == 0);
+        assert_eq!(spend.flags & ELIGIBLE_FOR_DEDUP, 0);
 
         let spend = &conds.spends[1];
         assert_eq!(*spend.coin_id, test_coin_id(H1, H2, 123));
         assert_eq!(a.atom(spend.puzzle_hash).as_ref(), H2);
         assert_eq!(spend.agg_sig_me.len(), 0);
-        assert!((spend.flags & ELIGIBLE_FOR_DEDUP) == 0);
+        assert_eq!(spend.flags & ELIGIBLE_FOR_DEDUP, 0);
     }
 }
 
@@ -4607,7 +4607,7 @@ fn test_multiple_my_birth_assertions(
     let spend = &conds.spends[0];
     assert_eq!(*spend.coin_id, test_coin_id(H1, H2, 1234));
     assert_eq!(a.atom(spend.puzzle_hash).as_ref(), H2);
-    assert!((spend.flags & ELIGIBLE_FOR_DEDUP) == 0);
+    assert_eq!(spend.flags & ELIGIBLE_FOR_DEDUP, 0);
 
     test(spend);
 }
@@ -4885,7 +4885,7 @@ fn test_relative_condition_on_ephemeral(
         );
         assert_eq!(a.atom(spend.puzzle_hash).as_ref(), H2);
         assert_eq!(spend.agg_sig_me.len(), 0);
-        assert!((spend.flags & ELIGIBLE_FOR_DEDUP) == 0);
+        assert_eq!(spend.flags & ELIGIBLE_FOR_DEDUP, 0);
     }
 }
 

--- a/crates/chia-consensus/src/fast_forward.rs
+++ b/crates/chia-consensus/src/fast_forward.rs
@@ -310,7 +310,10 @@ mod tests {
         )
         .expect("run_puzzle");
 
-        assert!(conditions1.spends[0].create_coin == conditions2.spends[0].create_coin);
+        assert_eq!(
+            conditions1.spends[0].create_coin,
+            conditions2.spends[0].create_coin
+        );
     }
 
     #[allow(clippy::needless_pass_by_value)]

--- a/crates/chia-consensus/src/merkle_set.rs
+++ b/crates/chia-consensus/src/merkle_set.rs
@@ -96,7 +96,7 @@ fn radix_sort(range: &mut [[u8; 32]], depth: u8) -> ([u8; 32], NodeType) {
             // duplicate values are collapsed (since this is a set)
             // so just return one of the duplicates as if there was only one
             debug_assert!(range.len() > 1);
-            debug_assert!(range[0] == range[1]);
+            debug_assert_eq!(range[0], range[1]);
             (range[0], NodeType::Term)
         } else {
             // this means either the left or right bucket/sub tree was empty.

--- a/crates/chia-consensus/src/merkle_tree.rs
+++ b/crates/chia-consensus/src/merkle_tree.rs
@@ -469,7 +469,7 @@ impl MerkleSet {
                 // duplicate values are collapsed (since this is a set)
                 // so just return one of the duplicates as if there was only one
                 debug_assert!(range.len() > 1);
-                debug_assert!(range[0] == range[1]);
+                debug_assert_eq!(range[0], range[1]);
                 self.nodes_vec.push((ArrayTypes::Leaf, range[0]));
                 (range[0], NodeType::Term)
             } else {

--- a/crates/chia-consensus/src/spendbundle_validation.rs
+++ b/crates/chia-consensus/src/spendbundle_validation.rs
@@ -308,8 +308,8 @@ ff843B9ACA00\
         )
         .expect("SpendBundle should be valid for this test");
 
-        assert!((conds.spends[0].flags & ELIGIBLE_FOR_DEDUP) != 0);
-        assert!(conds.spends[0].fingerprint != Bytes::default());
+        assert_ne!(conds.spends[0].flags & ELIGIBLE_FOR_DEDUP, 0);
+        assert_ne!(conds.spends[0].fingerprint, Bytes::default());
     }
 
     #[test]

--- a/crates/chia-protocol/fuzz/fuzz_targets/streamable.rs
+++ b/crates/chia-protocol/fuzz/fuzz_targets/streamable.rs
@@ -11,7 +11,7 @@ pub fn test_streamable<T: Streamable + std::fmt::Debug + PartialEq>(obj: &T) {
         panic!(
             "failed to parse input: {}, from object: {:?}",
             hex::encode(&bytes),
-            &obj
+            obj
         )
     };
     assert_eq!(obj, &obj2);
@@ -27,12 +27,18 @@ pub fn test_streamable<T: Streamable + std::fmt::Debug + PartialEq>(obj: &T) {
     // make sure input too large is an error
     let mut corrupt_bytes = bytes.clone();
     corrupt_bytes.push(0);
-    assert!(T::from_bytes_unchecked(&corrupt_bytes) == Err(chia_traits::Error::InputTooLarge));
+    assert_eq!(
+        T::from_bytes_unchecked(&corrupt_bytes),
+        Err(chia_traits::Error::InputTooLarge)
+    );
 
     if !bytes.is_empty() {
         // make sure input too short is an error
         corrupt_bytes.truncate(bytes.len() - 1);
-        assert!(T::from_bytes_unchecked(&corrupt_bytes) == Err(chia_traits::Error::EndOfBuffer));
+        assert_eq!(
+            T::from_bytes_unchecked(&corrupt_bytes),
+            Err(chia_traits::Error::EndOfBuffer)
+        );
     }
 }
 fn test<'a, T: Arbitrary<'a> + Streamable + std::fmt::Debug + PartialEq>(data: &'a [u8]) {

--- a/crates/chia-protocol/src/bytes.rs
+++ b/crates/chia-protocol/src/bytes.rs
@@ -551,8 +551,8 @@ mod tests {
                 assert_eq!(lhs, rhs);
                 assert_eq!(rhs, lhs);
             } else {
-                assert!(lhs != rhs);
-                assert!(rhs != lhs);
+                assert_ne!(lhs, rhs);
+                assert_ne!(rhs, lhs);
             }
         } else {
             let lhs = Bytes::from(lhs_vec.clone());
@@ -568,8 +568,8 @@ mod tests {
                 assert_eq!(lhs, rhs);
                 assert_eq!(rhs, lhs);
             } else {
-                assert!(lhs != rhs);
-                assert!(rhs != lhs);
+                assert_ne!(lhs, rhs);
+                assert_ne!(rhs, lhs);
             }
         }
     }

--- a/crates/chia-protocol/src/program.rs
+++ b/crates/chia-protocol/src/program.rs
@@ -479,7 +479,7 @@ impl FromJsonDict for Program {
             // If the bytes in the JSON string is not a valid CLVM
             // serialization, or if it has garbage at the end of the string,
             // reject it
-            return Err(Error::InvalidClvm)?;
+            Err(Error::InvalidClvm)?;
         }
         Ok(Self(bytes))
     }

--- a/crates/chia-tools/src/bin/compress-clvm.rs
+++ b/crates/chia-tools/src/bin/compress-clvm.rs
@@ -32,5 +32,5 @@ fn main() {
     let input = node_from_bytes(&mut a, &input[..]).expect("failed to parse input file");
 
     let compressed = node_to_bytes_backrefs(&a, input).expect("failed to compress input file");
-    write!(output, "{}", &hex::encode(compressed)).expect("failed to write to output file");
+    write!(output, "{}", hex::encode(compressed)).expect("failed to write to output file");
 }

--- a/crates/chia-tools/src/bin/run-spend.rs
+++ b/crates/chia-tools/src/bin/run-spend.rs
@@ -258,7 +258,7 @@ fn print_puzzle_info(a: &Allocator, puzzle: NodePtr, solution: NodePtr) {
 
         // Unknown puzzle
         n => {
-            println!("  Unknown puzzle {}", &hex::encode(n));
+            println!("  Unknown puzzle {}", hex::encode(n));
         }
     }
 }
@@ -287,7 +287,7 @@ fn main() {
         .to_clvm(&mut a)
         .expect("deserialize solution");
 
-    println!("Spending {:?}", &spend.coin);
+    println!("Spending {:?}", spend.coin);
     println!("   coin-id: {}\n", hex::encode(spend.coin.coin_id()));
     let dialect = ChiaDialect::new(ClvmFlags::empty());
     let Reduction(_clvm_cost, conditions) =
@@ -306,7 +306,7 @@ fn main() {
         iter = next;
         let op_ptr = first(&a, c).expect("parsing conditions");
         let Some(op) = parse_opcode(&a, op_ptr, ConsensusFlags::empty()) else {
-            println!("  UNKNOWN CONDITION [{}]", &hex::encode(a.atom(op_ptr)));
+            println!("  UNKNOWN CONDITION [{}]", hex::encode(a.atom(op_ptr)));
             continue;
         };
 

--- a/crates/clvm-utils/src/tree_hash.rs
+++ b/crates/clvm-utils/src/tree_hash.rs
@@ -250,7 +250,7 @@ pub fn tree_hash(a: &Allocator, node: NodePtr) -> TreeHash {
         }
     }
 
-    assert!(hashes.len() == 1);
+    assert_eq!(hashes.len(), 1);
     hashes[0]
 }
 
@@ -303,7 +303,7 @@ pub fn tree_hash_cached(a: &Allocator, node: NodePtr, cache: &mut TreeCache) -> 
         }
     }
 
-    assert!(hashes.len() == 1);
+    assert_eq!(hashes.len(), 1);
     hashes[0]
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Style and test assertion refactors only; no production logic changes beyond trivial formatting and a redundant `return` removal in JSON parsing.
> 
> **Overview**
> Addresses **new Clippy lints** repo-wide with mechanical edits only—no intended behavior changes.
> 
> **Assertions:** Tests and fuzz targets swap `assert!(x == y)` / `assert!(x != y)` for `assert_eq!` / `assert_ne!`, including flag bitmask checks like `assert_eq!(spend.flags & ELIGIBLE_FOR_DEDUP, 0)`. Merkle code uses `debug_assert_eq!` for duplicate-leaf invariants.
> 
> **Formatting:** `Debug` impls for BLS `GTElement`, `PublicKey`, and `Signature` use single-line `format_args!` and drop redundant `&` on `hex::encode`. Fuzz/tools use inline `{var:?}` in `println!` / `write!` where Clippy prefers it.
> 
> **Small cleanups:** `Program::from_json_dict` drops a needless `return` before `Err(...)`. Streamable fuzz compares parse errors with `assert_eq!` instead of `assert!(expr == Err(...))`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd72dd3147510497fa317eab2d66165c2c2b948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->