### PR TITLE
bump version to 0.45.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chia"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
- "chia-bls 0.45.0",
+ "chia-bls 0.45.1",
  "chia-client",
  "chia-consensus",
  "chia-datalayer",
@@ -312,9 +312,9 @@ dependencies = [
  "chia-puzzle-types",
  "chia-secp",
  "chia-serde",
- "chia-sha2 0.45.0",
+ "chia-sha2 0.45.1",
  "chia-ssl",
- "chia-traits 0.45.0",
+ "chia-traits 0.45.1",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -338,13 +338,13 @@ dependencies = [
 
 [[package]]
 name = "chia-bls"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "arbitrary",
  "blst",
  "chia-serde",
- "chia-sha2 0.45.0",
- "chia-traits 0.45.0",
+ "chia-sha2 0.45.1",
+ "chia-traits 0.45.1",
  "chia_py_streamable_macro",
  "criterion",
  "hex",
@@ -360,18 +360,18 @@ dependencies = [
 
 [[package]]
 name = "chia-bls-fuzz"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
- "chia-bls 0.45.0",
+ "chia-bls 0.45.1",
  "libfuzzer-sys",
 ]
 
 [[package]]
 name = "chia-client"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "chia-protocol",
- "chia-traits 0.45.0",
+ "chia-traits 0.45.1",
  "futures-util",
  "thiserror 2.0.18",
  "tokio",
@@ -381,18 +381,18 @@ dependencies = [
 
 [[package]]
 name = "chia-consensus"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "bitflags",
  "blocking-threadpool",
- "chia-bls 0.45.0",
+ "chia-bls 0.45.1",
  "chia-protocol",
  "chia-puzzle-types",
  "chia-puzzles",
- "chia-sha2 0.45.0",
- "chia-traits 0.45.0",
+ "chia-sha2 0.45.1",
+ "chia-traits 0.45.1",
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.45.0",
+ "chia_streamable_macro 0.45.1",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -409,13 +409,13 @@ dependencies = [
 
 [[package]]
 name = "chia-consensus-fuzz"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
- "chia-bls 0.45.0",
+ "chia-bls 0.45.1",
  "chia-consensus",
  "chia-protocol",
- "chia-sha2 0.45.0",
- "chia-traits 0.45.0",
+ "chia-sha2 0.45.1",
+ "chia-traits 0.45.1",
  "clvm-fuzzing",
  "clvm-traits",
  "clvm-utils",
@@ -426,16 +426,16 @@ dependencies = [
 
 [[package]]
 name = "chia-datalayer"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "arbitrary",
  "bitvec",
  "chia-datalayer-macro",
  "chia-protocol",
- "chia-sha2 0.45.0",
- "chia-traits 0.45.0",
+ "chia-sha2 0.45.1",
+ "chia-traits 0.45.1",
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.45.0",
+ "chia_streamable_macro 0.45.1",
  "clvm-utils",
  "expect-test",
  "hex",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "chia-datalayer-fuzz"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "chia-datalayer",
  "libfuzzer-sys",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "chia-datalayer-macro"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -483,17 +483,17 @@ dependencies = [
 
 [[package]]
 name = "chia-protocol"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "arbitrary",
- "chia-bls 0.45.0",
+ "chia-bls 0.45.1",
  "chia-pos2",
  "chia-serde",
- "chia-sha2 0.45.0",
- "chia-traits 0.45.0",
+ "chia-sha2 0.45.1",
+ "chia-traits 0.45.1",
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.45.0",
+ "chia_streamable_macro 0.45.1",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -509,12 +509,12 @@ dependencies = [
 
 [[package]]
 name = "chia-protocol-fuzz"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "arbitrary",
  "chia-protocol",
- "chia-sha2 0.45.0",
- "chia-traits 0.45.0",
+ "chia-sha2 0.45.1",
+ "chia-traits 0.45.1",
  "clvm-traits",
  "clvmr",
  "hex",
@@ -523,14 +523,14 @@ dependencies = [
 
 [[package]]
 name = "chia-puzzle-types"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "arbitrary",
- "chia-bls 0.45.0",
+ "chia-bls 0.45.1",
  "chia-protocol",
  "chia-puzzles",
- "chia-sha2 0.45.0",
+ "chia-sha2 0.45.1",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "chia-puzzle-types-fuzz"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "chia-puzzle-types",
  "clvm-traits",
@@ -562,11 +562,11 @@ dependencies = [
 
 [[package]]
 name = "chia-secp"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "arbitrary",
- "chia-sha2 0.45.0",
+ "chia-sha2 0.45.1",
  "hex",
  "k256",
  "p256",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "chia-serde"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sha2"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "openssl",
  "sha2 0.10.9",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "chia-ssl"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "getrandom 0.4.2",
  "rcgen",
@@ -625,17 +625,17 @@ dependencies = [
 
 [[package]]
 name = "chia-tools"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "bitflags",
  "blocking-threadpool",
- "chia-bls 0.45.0",
+ "chia-bls 0.45.1",
  "chia-consensus",
  "chia-protocol",
  "chia-puzzle-types",
  "chia-puzzles",
- "chia-sha2 0.45.0",
- "chia-traits 0.45.0",
+ "chia-sha2 0.45.1",
+ "chia-traits 0.45.1",
  "clap",
  "clvm-traits",
  "clvm-utils",
@@ -659,17 +659,17 @@ dependencies = [
 
 [[package]]
 name = "chia-traits"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
- "chia-sha2 0.45.0",
- "chia_streamable_macro 0.45.0",
+ "chia-sha2 0.45.1",
+ "chia_streamable_macro 0.45.1",
  "pyo3",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "chia_py_streamable_macro"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -679,18 +679,18 @@ dependencies = [
 
 [[package]]
 name = "chia_rs"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "bincode",
- "chia-bls 0.45.0",
+ "chia-bls 0.45.1",
  "chia-client",
  "chia-consensus",
  "chia-datalayer",
  "chia-pos2",
  "chia-protocol",
- "chia-sha2 0.45.0",
+ "chia-sha2 0.45.1",
  "chia-ssl",
- "chia-traits 0.45.0",
+ "chia-traits 0.45.1",
  "clvm-utils",
  "clvmr",
  "pyo3",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "chia_streamable_macro"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "chia_wasm"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -794,7 +794,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clvm-derive"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "clvm-traits"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
- "chia-bls 0.45.0",
+ "chia-bls 0.45.1",
  "chia-secp",
  "clvm-derive",
  "clvmr",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-traits-fuzz"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "clvm-traits",
  "clvmr",
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "clvm-utils"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
- "chia-sha2 0.45.0",
+ "chia-sha2 0.45.1",
  "clvm-traits",
  "clvmr",
  "hex",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-utils-fuzz"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "clvm-fuzzing",
  "clvm-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/Chia-Network/chia_rs"
 members = ["crates/*", "crates/*/fuzz", "wasm", "wheel"]
 
 [workspace.package]
-version = "0.45.0"
+version = "0.45.1"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "deny", priority = -1 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only change with no application or consensus logic modified; risk is limited to release coordination and consumers pinning the new crate versions.
> 
> **Overview**
> Bumps the shared workspace release from **0.45.0** to **0.45.1** by updating `[workspace.package].version` in `Cargo.toml` and regenerating `Cargo.lock` so every in-workspace `chia*` / `clvm-*` crate and fuzz/binary targets resolve at the new patch version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c54b6a87c3ac8c1a0a2da876071929cad747f7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->