### PR TITLE
bump crossbeam-epoch from 0.9.18 -> 0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
address cargo audit issue:

```
Crate:     crossbeam-epoch
error: 1 vulnerability found!
warning: 10 allowed warnings found
Version:   0.9.18
Title:     Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid
Date:      2026-07-06
ID:        RUSTSEC-2026-0204
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0204
Solution:  Upgrade to >=0.9.20
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only security patch to a transitive concurrency crate; no direct API or business-logic changes in this repo.
> 
> **Overview**
> Updates **`Cargo.lock`** only, pinning **`crossbeam-epoch`** from **0.9.18** to **0.9.20** to clear **RUSTSEC-2026-0204** (invalid pointer dereference in `fmt::Pointer` for `Atomic`/`Shared` when the underlying pointer is invalid). No crate manifests or source changes; the crate remains a transitive dependency (e.g. via **`crossbeam-deque`** / **`rayon-core`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f87ecc3dab045fff5d4e7a04bf2f67efa634e0c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->