### PR TITLE
bump version to 0.46.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chia"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
- "chia-bls 0.45.0",
+ "chia-bls 0.46.0",
  "chia-client",
  "chia-consensus",
  "chia-datalayer",
@@ -312,9 +312,9 @@ dependencies = [
  "chia-puzzle-types",
  "chia-secp",
  "chia-serde",
- "chia-sha2 0.45.0",
+ "chia-sha2 0.46.0",
  "chia-ssl",
- "chia-traits 0.45.0",
+ "chia-traits 0.46.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -339,13 +339,13 @@ dependencies = [
 
 [[package]]
 name = "chia-bls"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "arbitrary",
  "blst",
  "chia-serde",
- "chia-sha2 0.45.0",
- "chia-traits 0.45.0",
+ "chia-sha2 0.46.0",
+ "chia-traits 0.46.0",
  "chia_py_streamable_macro",
  "criterion",
  "hex",
@@ -361,18 +361,18 @@ dependencies = [
 
 [[package]]
 name = "chia-bls-fuzz"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
- "chia-bls 0.45.0",
+ "chia-bls 0.46.0",
  "libfuzzer-sys",
 ]
 
 [[package]]
 name = "chia-client"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "chia-protocol",
- "chia-traits 0.45.0",
+ "chia-traits 0.46.0",
  "futures-util",
  "thiserror 2.0.18",
  "tokio",
@@ -382,18 +382,18 @@ dependencies = [
 
 [[package]]
 name = "chia-consensus"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "bitflags",
  "blocking-threadpool",
- "chia-bls 0.45.0",
+ "chia-bls 0.46.0",
  "chia-protocol",
  "chia-puzzle-types",
  "chia-puzzles",
- "chia-sha2 0.45.0",
- "chia-traits 0.45.0",
+ "chia-sha2 0.46.0",
+ "chia-traits 0.46.0",
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.45.0",
+ "chia_streamable_macro 0.46.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -410,13 +410,13 @@ dependencies = [
 
 [[package]]
 name = "chia-consensus-fuzz"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
- "chia-bls 0.45.0",
+ "chia-bls 0.46.0",
  "chia-consensus",
  "chia-protocol",
- "chia-sha2 0.45.0",
- "chia-traits 0.45.0",
+ "chia-sha2 0.46.0",
+ "chia-traits 0.46.0",
  "clvm-fuzzing",
  "clvm-traits",
  "clvm-utils",
@@ -427,16 +427,16 @@ dependencies = [
 
 [[package]]
 name = "chia-datalayer"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "arbitrary",
  "bitvec",
  "chia-datalayer-macro",
  "chia-protocol",
- "chia-sha2 0.45.0",
- "chia-traits 0.45.0",
+ "chia-sha2 0.46.0",
+ "chia-traits 0.46.0",
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.45.0",
+ "chia_streamable_macro 0.46.0",
  "clvm-utils",
  "expect-test",
  "hex",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "chia-datalayer-fuzz"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "chia-datalayer",
  "libfuzzer-sys",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "chia-datalayer-macro"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -484,17 +484,17 @@ dependencies = [
 
 [[package]]
 name = "chia-protocol"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "chia-bls 0.45.0",
+ "chia-bls 0.46.0",
  "chia-pos2",
  "chia-serde",
- "chia-sha2 0.45.0",
- "chia-traits 0.45.0",
+ "chia-sha2 0.46.0",
+ "chia-traits 0.46.0",
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.45.0",
+ "chia_streamable_macro 0.46.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -510,12 +510,12 @@ dependencies = [
 
 [[package]]
 name = "chia-protocol-fuzz"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "arbitrary",
  "chia-protocol",
- "chia-sha2 0.45.0",
- "chia-traits 0.45.0",
+ "chia-sha2 0.46.0",
+ "chia-traits 0.46.0",
  "clvm-traits",
  "clvmr",
  "hex",
@@ -524,14 +524,14 @@ dependencies = [
 
 [[package]]
 name = "chia-puzzle-types"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "chia-bls 0.45.0",
+ "chia-bls 0.46.0",
  "chia-protocol",
  "chia-puzzles",
- "chia-sha2 0.45.0",
+ "chia-sha2 0.46.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "chia-puzzle-types-fuzz"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "chia-puzzle-types",
  "clvm-traits",
@@ -563,11 +563,11 @@ dependencies = [
 
 [[package]]
 name = "chia-secp"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "chia-sha2 0.45.0",
+ "chia-sha2 0.46.0",
  "hex",
  "k256",
  "p256",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "chia-serde"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sha2"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "openssl",
  "sha2 0.10.9",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "chia-ssl"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "getrandom 0.4.2",
  "rcgen",
@@ -617,17 +617,17 @@ dependencies = [
 
 [[package]]
 name = "chia-tools"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "bitflags",
  "blocking-threadpool",
- "chia-bls 0.45.0",
+ "chia-bls 0.46.0",
  "chia-consensus",
  "chia-protocol",
  "chia-puzzle-types",
  "chia-puzzles",
- "chia-sha2 0.45.0",
- "chia-traits 0.45.0",
+ "chia-sha2 0.46.0",
+ "chia-traits 0.46.0",
  "clap",
  "clvm-traits",
  "clvm-utils",
@@ -651,17 +651,17 @@ dependencies = [
 
 [[package]]
 name = "chia-traits"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
- "chia-sha2 0.45.0",
- "chia_streamable_macro 0.45.0",
+ "chia-sha2 0.46.0",
+ "chia_streamable_macro 0.46.0",
  "pyo3",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "chia_py_streamable_macro"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -671,18 +671,18 @@ dependencies = [
 
 [[package]]
 name = "chia_rs"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "bincode",
- "chia-bls 0.45.0",
+ "chia-bls 0.46.0",
  "chia-client",
  "chia-consensus",
  "chia-datalayer",
  "chia-pos2",
  "chia-protocol",
- "chia-sha2 0.45.0",
+ "chia-sha2 0.46.0",
  "chia-ssl",
- "chia-traits 0.45.0",
+ "chia-traits 0.46.0",
  "clvm-utils",
  "clvmr",
  "pyo3",
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "chia_streamable_macro"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "chia_wasm"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -786,7 +786,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clvm-derive"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "clvm-traits"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
- "chia-bls 0.45.0",
+ "chia-bls 0.46.0",
  "chia-secp",
  "clvm-derive",
  "clvmr",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-traits-fuzz"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "clvm-traits",
  "clvmr",
@@ -837,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "clvm-utils"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
- "chia-sha2 0.45.0",
+ "chia-sha2 0.46.0",
  "clvm-traits",
  "clvmr",
  "hex",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-utils-fuzz"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "clvm-fuzzing",
  "clvm-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/Chia-Network/chia_rs"
 members = ["crates/*", "crates/*/fuzz", "wasm", "wheel"]
 
 [workspace.package]
-version = "0.45.0"
+version = "0.46.0"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "deny", priority = -1 }
@@ -117,31 +117,31 @@ lto = "thin"
 bench = false
 
 [workspace.dependencies]
-chia_py_streamable_macro = { path = "./crates/chia_py_streamable_macro", version = "0.45.0" }
-chia_streamable_macro = { path = "./crates/chia_streamable_macro", version = "0.45.0" }
-chia-bls = { path = "./crates/chia-bls", version = "0.45.0" }
-chia-client = { path = "./crates/chia-client", version = "0.45.0" }
-chia-consensus = { path = "./crates/chia-consensus", version = "0.45.0" }
-chia-datalayer = { path = "./crates/chia-datalayer", version = "0.45.0" }
-chia-datalayer-macro = { path = "./crates/chia-datalayer/macro", version = "0.45.0" }
-chia-protocol = { path = "./crates/chia-protocol", version = "0.45.0" }
-chia-secp = { path = "./crates/chia-secp", version = "0.45.0" }
-chia-ssl = { path = "./crates/chia-ssl", version = "0.45.0" }
-chia-traits = { path = "./crates/chia-traits", version = "0.45.0" }
-chia-puzzle-types = { path = "./crates/chia-puzzle-types", version = "0.45.0" }
-chia-sha2 = { path = "./crates/chia-sha2", version = "0.45.0" }
-chia-serde = { path = "./crates/chia-serde", version = "0.45.0" }
-clvm-traits = { path = "./crates/clvm-traits", version = "0.45.0" }
-clvm-utils = { path = "./crates/clvm-utils", version = "0.45.0" }
-clvm-derive = { path = "./crates/clvm-derive", version = "0.45.0" }
+chia_py_streamable_macro = { path = "./crates/chia_py_streamable_macro", version = "0.46.0" }
+chia_streamable_macro = { path = "./crates/chia_streamable_macro", version = "0.46.0" }
+chia-bls = { path = "./crates/chia-bls", version = "0.46.0" }
+chia-client = { path = "./crates/chia-client", version = "0.46.0" }
+chia-consensus = { path = "./crates/chia-consensus", version = "0.46.0" }
+chia-datalayer = { path = "./crates/chia-datalayer", version = "0.46.0" }
+chia-datalayer-macro = { path = "./crates/chia-datalayer/macro", version = "0.46.0" }
+chia-protocol = { path = "./crates/chia-protocol", version = "0.46.0" }
+chia-secp = { path = "./crates/chia-secp", version = "0.46.0" }
+chia-ssl = { path = "./crates/chia-ssl", version = "0.46.0" }
+chia-traits = { path = "./crates/chia-traits", version = "0.46.0" }
+chia-puzzle-types = { path = "./crates/chia-puzzle-types", version = "0.46.0" }
+chia-sha2 = { path = "./crates/chia-sha2", version = "0.46.0" }
+chia-serde = { path = "./crates/chia-serde", version = "0.46.0" }
+clvm-traits = { path = "./crates/clvm-traits", version = "0.46.0" }
+clvm-utils = { path = "./crates/clvm-utils", version = "0.46.0" }
+clvm-derive = { path = "./crates/clvm-derive", version = "0.46.0" }
 chia-pos2 = "0.6.0"
-chia-consensus-fuzz = { path = "./crates/chia-consensus/fuzz", version = "0.45.0" }
-chia-bls-fuzz = { path = "./crates/chia-bls/fuzz", version = "0.45.0" }
-chia-datalayer-fuzz = { path = "./crates/chia-datalayer/fuzz", version = "0.45.0" }
-chia-protocol-fuzz = { path = "./crates/chia-protocol/fuzz", version = "0.45.0" }
-chia-puzzle-types-fuzz = { path = "./crates/chia-puzzle-types/fuzz", version = "0.45.0" }
-clvm-traits-fuzz = { path = "./crates/clvm-traits/fuzz", version = "0.45.0" }
-clvm-utils-fuzz = { path = "./crates/clvm-utils/fuzz", version = "0.45.0" }
+chia-consensus-fuzz = { path = "./crates/chia-consensus/fuzz", version = "0.46.0" }
+chia-bls-fuzz = { path = "./crates/chia-bls/fuzz", version = "0.46.0" }
+chia-datalayer-fuzz = { path = "./crates/chia-datalayer/fuzz", version = "0.46.0" }
+chia-protocol-fuzz = { path = "./crates/chia-protocol/fuzz", version = "0.46.0" }
+chia-puzzle-types-fuzz = { path = "./crates/chia-puzzle-types/fuzz", version = "0.46.0" }
+clvm-traits-fuzz = { path = "./crates/clvm-traits/fuzz", version = "0.46.0" }
+clvm-utils-fuzz = { path = "./crates/clvm-utils/fuzz", version = "0.46.0" }
 blst = { version = "0.3.16", features = ["portable"] }
 clvmr = "0.18.0"
 clvm-fuzzing = "0.18.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only change with no logic diffs; risk is limited to release coordination and consumers pinning the new crate versions.
> 
> **Overview**
> Bumps the **chia_rs** monorepo from **0.45.0** to **0.46.0** for release tagging and publishing.
> 
> `[workspace.package]` version in `Cargo.toml` is updated to **0.46.0**, and every in-workspace crate entry under `[workspace.dependencies]` (meta `chia`, `chia-bls`, `chia-consensus`, `clvm-traits`, fuzz crates, macros, etc.) is aligned to the same version. `Cargo.lock` is regenerated so all those workspace packages and their internal dependency edges reference **0.46.0** instead of **0.45.0**.
> 
> No Rust source or API changes appear in this diff—only version metadata and the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fcb1ddbce58cfd912a017306f496037b9ce3efa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->