### PR TITLE
build_interned_block: reset builder on successful finalize()

### DIFF
--- a/crates/chia-consensus/src/build_interned_block.rs
+++ b/crates/chia-consensus/src/build_interned_block.rs
@@ -214,6 +214,12 @@ impl InternedBlockBuilder {
     }
 
     // returns generator, sig, cost
+    //
+    // On success, resets self to a fresh builder (same cost_per_byte /
+    // max_block_cost) so a subsequent finalize() or add_spend_bundles() call
+    // starts from an empty state, rather than emitting a generator that
+    // still contains spends the returned signature doesn't cover. On error,
+    // self is left unchanged so callers can inspect state or retry.
     pub fn finalize(&mut self) -> Result<(Vec<u8>, Signature, u64)> {
         let inner = self
             .allocator
@@ -225,7 +231,10 @@ impl InternedBlockBuilder {
         let total_cost = interned_vbytes(&interned) * self.cost_per_byte + self.block_cost;
 
         assert!(total_cost <= self.max_block_cost);
-        Ok((serialized, std::mem::take(&mut self.signature), total_cost))
+
+        let signature = std::mem::take(&mut self.signature);
+        *self = Self::new_with(self.cost_per_byte, self.max_block_cost);
+        Ok((serialized, signature, total_cost))
     }
 }
 
@@ -268,18 +277,11 @@ impl InternedBlockBuilder {
         self.cost()
     }
 
-    /// generate the block generator
+    /// generate the block generator. Resets the builder on success (see
+    /// `finalize()`), preserving its state on error.
     #[pyo3(name = "finalize")]
     pub fn py_finalize(&mut self) -> PyResult<(Vec<u8>, Signature, u64)> {
-        let cost_per_byte = self.cost_per_byte;
-        let max_block_cost = self.max_block_cost;
-        match self.finalize() {
-            Ok(x) => {
-                *self = InternedBlockBuilder::new_with(cost_per_byte, max_block_cost);
-                Ok(x)
-            }
-            Err(err) => Err(err.into()),
-        }
+        Ok(self.finalize()?)
     }
 }
 

--- a/crates/chia-consensus/src/build_interned_block/additional_tests.rs
+++ b/crates/chia-consensus/src/build_interned_block/additional_tests.rs
@@ -287,6 +287,87 @@ fn test_num_skipped() {
     assert!(result == BuildBlockResult::Done);
 }
 
+/// finalize() must reset the builder to a fresh state on success: a second
+/// finalize() call (with no intervening add_spend_bundles()) must produce
+/// the same empty-spend-list generator, cost, and signature as a brand new
+/// builder — not a generator that still contains the first call's spends
+/// under a signature that no longer covers them.
+#[test]
+fn test_finalize_resets_builder() {
+    let mut builder = InternedBlockBuilder::new(&TEST_CONSTANTS);
+
+    let coin_spend = make_test_coin_spend([1u8; 32], 1000);
+    let bundle = SpendBundle::new(vec![coin_spend], Signature::default());
+    let (added, _) = builder
+        .add_spend_bundles([&bundle], 5000)
+        .expect("add_spend_bundles");
+    assert!(added);
+
+    let (first_generator, _, first_cost) = builder.finalize().expect("finalize");
+    assert!(
+        first_cost > 11 * TEST_CONSTANTS.cost_per_byte + 20,
+        "first finalize should reflect the added spend"
+    );
+
+    // The builder was reset by the first finalize(), so this second call
+    // (with nothing added in between) must behave like a fresh builder.
+    let (second_generator, second_sig, second_cost) = builder.finalize().expect("finalize");
+    assert_eq!(second_sig, Signature::default());
+    assert_eq!(
+        second_cost,
+        11 * TEST_CONSTANTS.cost_per_byte + 20,
+        "second finalize should be the empty-spend-list cost"
+    );
+    assert_ne!(
+        first_generator, second_generator,
+        "second generator must not still contain the first call's spend"
+    );
+
+    let mut fresh = InternedBlockBuilder::new(&TEST_CONSTANTS);
+    let (fresh_generator, fresh_sig, fresh_cost) = fresh.finalize().expect("finalize");
+    assert_eq!(second_generator, fresh_generator);
+    assert_eq!(second_sig, fresh_sig);
+    assert_eq!(second_cost, fresh_cost);
+}
+
+/// add_spend_bundles() after finalize() must start from a clean slate: the
+/// resulting generator/signature/cost must be identical to a brand new
+/// builder that only ever saw the second bundle.
+#[test]
+fn test_add_after_finalize_starts_clean() {
+    let mut builder = InternedBlockBuilder::new(&TEST_CONSTANTS);
+
+    let coin_spend1 = make_test_coin_spend([1u8; 32], 1000);
+    let bundle1 = SpendBundle::new(vec![coin_spend1], Signature::default());
+    let (added, _) = builder
+        .add_spend_bundles([&bundle1], 5000)
+        .expect("add_spend_bundles");
+    assert!(added);
+    builder.finalize().expect("finalize");
+
+    let coin_spend2 = make_test_coin_spend([2u8; 32], 2000);
+    let bundle2 = SpendBundle::new(vec![coin_spend2], Signature::default());
+    let (added, _) = builder
+        .add_spend_bundles([&bundle2], 7000)
+        .expect("add_spend_bundles");
+    assert!(added);
+    let (generator, sig, cost) = builder.finalize().expect("finalize");
+
+    let mut fresh = InternedBlockBuilder::new(&TEST_CONSTANTS);
+    let (added, _) = fresh
+        .add_spend_bundles([&bundle2], 7000)
+        .expect("add_spend_bundles");
+    assert!(added);
+    let (fresh_generator, fresh_sig, fresh_cost) = fresh.finalize().expect("finalize");
+
+    assert_eq!(
+        generator, fresh_generator,
+        "generator should not carry over bundle1"
+    );
+    assert_eq!(sig, fresh_sig);
+    assert_eq!(cost, fresh_cost);
+}
+
 #[test]
 fn test_byte_cost_tracking() {
     let mut builder = InternedBlockBuilder::new(&TEST_CONSTANTS);


### PR DESCRIPTION
Follow-up to #1436. `finalize()` took the aggregated signature via `mem::take` but left `spend_list`, `block_cost`, and `byte_cost` intact, so a second `finalize()` — or an `add_spend_bundles()` after it — would emit a generator that still contains the prior spends under a signature that no longer covers them (Bugbot flagged this on #1436; the Python `py_finalize()` already reset on success, so the Python consumer was safe).

This moves the reset into the Rust `finalize()` itself and has `py_finalize()` just delegate. State is preserved on error so callers can inspect or retry.

Adds two tests: `test_finalize_resets_builder` and `test_add_after_finalize_starts_clean`.

Made with [Cursor](https://cursor.com)