### PR TITLE
Support serde_2026 generators in trusted RPC helpers

### DIFF
--- a/crates/chia-consensus/src/additions_and_removals.rs
+++ b/crates/chia-consensus/src/additions_and_removals.rs
@@ -6,6 +6,7 @@ use chia_protocol::Coin;
 use crate::allocator::make_allocator;
 use crate::consensus_constants::ConsensusConstants;
 use crate::flags::ConsensusFlags;
+use crate::serde_2026::{max_canonical_blob_size, node_from_bytes_auto};
 use crate::validation_error::{ErrorCode, ValidationErr, atom, first, next, rest};
 use chia_protocol::{Bytes, Bytes32};
 use clvm_traits::FromClvm;
@@ -14,7 +15,6 @@ use clvmr::allocator::{NodePtr, SExp};
 use clvmr::chia_dialect::ChiaDialect;
 use clvmr::reduction::Reduction;
 use clvmr::run_program::run_program;
-use clvmr::serde::node_from_bytes_backrefs;
 
 /// Run a *trusted* block generator and return its additions and removals. This
 /// function does not validate the block, it is assumed to be valid.
@@ -36,7 +36,12 @@ where
 
     let mut cost_left = constants.max_block_cost_clvm;
 
-    let program = node_from_bytes_backrefs(&mut a, program)?;
+    // this helper is only used on already-validated blocks, so (unlike the
+    // consensus path, which requires the exact encoding for the block's era)
+    // we sniff the serde_2026 magic prefix and accept any generator encoding
+    let max_blob_size =
+        max_canonical_blob_size(constants.max_block_cost_clvm, constants.cost_per_byte);
+    let program = node_from_bytes_auto(&mut a, program, max_blob_size)?;
 
     let args = setup_generator_args(&mut a, block_refs, flags)?;
     let dialect = ChiaDialect::new(flags.to_clvm_flags());
@@ -334,5 +339,53 @@ mod test {
         .unwrap();
         assert_eq!(additions.len(), 1);
         assert!(additions[0].1.is_none(), "pair hint should be ignored");
+    }
+
+    /// A serde_2026-encoded generator (the only encoding of post-HF2 blocks)
+    /// must produce the same additions and removals as the classic encoding
+    /// of the same spends, regardless of the flags passed in.
+    #[rstest]
+    #[case(ConsensusFlags::empty())]
+    #[case(ConsensusFlags::SIMPLE_GENERATOR | ConsensusFlags::INTERNED_GENERATOR)]
+    fn test_serde_2026_generator_equivalence(#[case] flags: ConsensusFlags) {
+        use crate::solution_generator::{solution_generator, solution_generator_2026};
+        use clvm_traits::ToClvm;
+        use clvmr::allocator::Allocator;
+        use clvmr::serde::{SERDE_2026_MAGIC_PREFIX, node_to_bytes};
+
+        let mut a = Allocator::new();
+        let ph = Bytes32::from([0xab; 32]);
+        let hint = Bytes::new(vec![0x42; 32]);
+        // ((51 puzzle_hash amount (hint)))
+        let conditions = ((51u8, (ph, (1000u64, ((hint, ()), ())))), ())
+            .to_clvm(&mut a)
+            .unwrap();
+        let solution = node_to_bytes(&a, conditions).unwrap();
+
+        let spends = (0..2u8)
+            .map(|i| {
+                (
+                    Coin::new([i; 32].into(), [0xdd; 32].into(), 1000),
+                    vec![0x01],
+                    solution.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let classic = solution_generator(spends.clone()).unwrap();
+        let serde2026 = solution_generator_2026(spends).unwrap();
+        assert!(!classic.starts_with(&SERDE_2026_MAGIC_PREFIX));
+        assert!(serde2026.starts_with(&SERDE_2026_MAGIC_PREFIX));
+
+        let no_blocks: &[&[u8]] = &[];
+        let from_classic =
+            additions_and_removals(&classic, no_blocks, flags, &TEST_CONSTANTS).unwrap();
+        let from_2026 =
+            additions_and_removals(&serde2026, no_blocks, flags, &TEST_CONSTANTS).unwrap();
+        assert_eq!(from_classic, from_2026);
+
+        let (additions, removals) = from_2026;
+        assert_eq!(additions.len(), 2);
+        assert_eq!(removals.len(), 2);
     }
 }

--- a/tests/test_additions_and_removals.py
+++ b/tests/test_additions_and_removals.py
@@ -1,5 +1,13 @@
 from typing import Optional
-from chia_rs import additions_and_removals
+from chia_rs import (
+    Coin,
+    additions_and_removals,
+    solution_generator,
+    solution_generator_2026,
+    tree_hash,
+)
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint64
 from run_gen import DEFAULT_CONSTANTS
 from pathlib import Path
 import glob
@@ -86,3 +94,32 @@ def test_additions_and_removals() -> None:
             assert expected_removals == set()
         except ValueError as e:
             assert "FAILED: " in test_file
+
+
+def test_additions_and_removals_serde_2026() -> None:
+    # post-HF2 blocks (INTERNED_GENERATOR) encode their transactions
+    # generator with serde_2026. This trusted helper detects the encoding
+    # from the magic prefix, so both encodings of the same spends must
+    # produce identical results.
+    target_ph = b"\xab" * 32
+    # ((51 target_ph 1000)) - a single CREATE_COIN condition
+    solution = bytes.fromhex("ffff33ffa0" + target_ph.hex() + "ff8203e88080")
+    puzzle = b"\x01"  # identity
+    coin = Coin(bytes32(b"\xcc" * 32), tree_hash(puzzle), uint64(1000))
+    spends = [(coin, puzzle, solution)]
+
+    classic = solution_generator(spends)
+    serde2026 = solution_generator_2026(spends)
+    assert classic[:1] != b"\xfd"
+    assert serde2026[:1] == b"\xfd"
+
+    expected = additions_and_removals(classic, [], 0, DEFAULT_CONSTANTS)
+    result = additions_and_removals(serde2026, [], 0, DEFAULT_CONSTANTS)
+    assert result == expected
+
+    additions, removals = result
+    assert len(additions) == 1
+    assert additions[0][0].puzzle_hash == target_ph
+    assert additions[0][0].amount == 1000
+    assert len(removals) == 1
+    assert removals[0][1] == coin

--- a/tests/test_get_puzzle_and_solution.py
+++ b/tests/test_get_puzzle_and_solution.py
@@ -3,6 +3,9 @@ from chia_rs import (
     get_puzzle_and_solution_for_coin2,
     run_block_generator2,
     run_chia_program,
+    solution_generator,
+    solution_generator_2026,
+    tree_hash,
     Program,
     Coin,
     G2Element,
@@ -109,3 +112,33 @@ def test_get_puzzle_and_solution_for_coin(input_file: str) -> None:
 
             ret = ret.pair[1]
         assert expected_additions == set()
+
+
+def test_get_puzzle_and_solution_for_coin_serde_2026() -> None:
+    # post-HF2 blocks (INTERNED_GENERATOR) encode their transactions
+    # generator with serde_2026. This trusted helper detects the encoding
+    # from the magic prefix, so both encodings of the same spends must
+    # produce identical results.
+    # get_puzzle_and_solution_for_coin2() accepts serde_2026 the same way,
+    # but it takes the generator as a Program, which cannot hold a
+    # serde_2026 blob yet, so it cannot be exercised from here.
+    target_ph = b"\xab" * 32
+    # ((51 target_ph 1000)) - a single CREATE_COIN condition
+    solution = bytes.fromhex("ffff33ffa0" + target_ph.hex() + "ff8203e88080")
+    puzzle = b"\x01"  # identity
+    parent = bytes32(b"\xcc" * 32)
+    ph = tree_hash(puzzle)
+    spends = [(Coin(parent, ph, uint64(1000)), puzzle, solution)]
+
+    classic = solution_generator(spends)
+    serde2026 = solution_generator_2026(spends)
+    assert classic[:1] != b"\xfd"
+    assert serde2026[:1] == b"\xfd"
+
+    args = b"\xff" + DESERIALIZE_MOD + b"\xff\x80\x80"
+    for generator in [classic, serde2026]:
+        puz, sol = get_puzzle_and_solution_for_coin(
+            generator, args, MAX_COST, parent, 1000, ph, 0
+        )
+        assert puz == puzzle
+        assert sol == solution

--- a/tests/test_run_block_generator.py
+++ b/tests/test_run_block_generator.py
@@ -4,9 +4,15 @@ from chia_rs import (
     generator_interned_vbytes,
     run_block_generator,
     run_block_generator2,
+    solution_generator,
+    solution_generator_2026,
+    tree_hash,
+    Coin,
     G2Element,
     DONT_VALIDATE_SIGNATURE,
 )
+from chia_rs.sized_bytes import bytes32
+from chia_rs.sized_ints import uint64
 from run_gen import print_spend_bundle_conditions, DEFAULT_CONSTANTS
 
 
@@ -171,3 +177,22 @@ def test_generator_interned_vbytes_real_block() -> None:
 def test_generator_interned_vbytes_bad_input() -> None:
     with pytest.raises(ValueError):
         generator_interned_vbytes(b"\xff\xff")
+
+
+def test_generator_interned_vbytes_serde_2026() -> None:
+    # the interned weight is a property of the tree, not its encoding, so
+    # the classic and serde_2026 encodings of the same generator must have
+    # the same weight
+    target_ph = b"\xab" * 32
+    # ((51 target_ph 1000)) - a single CREATE_COIN condition
+    solution = bytes.fromhex("ffff33ffa0" + target_ph.hex() + "ff8203e88080")
+    puzzle = b"\x01"  # identity
+    coin = Coin(bytes32(b"\xcc" * 32), tree_hash(puzzle), uint64(1000))
+    spends = [(coin, puzzle, solution)]
+
+    classic = solution_generator(spends)
+    serde2026 = solution_generator_2026(spends)
+    assert classic[:1] != b"\xfd"
+    assert serde2026[:1] == b"\xfd"
+
+    assert generator_interned_vbytes(serde2026) == generator_interned_vbytes(classic)

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -75,6 +75,7 @@ use crate::run_program::{run_chia_program, serialized_length, serialized_length_
 
 use chia_consensus::fast_forward::fast_forward_singleton as native_ff;
 use chia_consensus::get_puzzle_and_solution::get_puzzle_and_solution_for_coin as parse_puzzle_solution;
+use chia_consensus::serde_2026::node_from_bytes_auto;
 use chia_consensus::validation_error::ValidationErr;
 use clvmr::ChiaDialect;
 use clvmr::allocator::NodePtr;
@@ -196,7 +197,10 @@ pub fn get_puzzle_and_solution_for_coin<'a>(
     let program = py_to_slice::<'a>(program);
     let args = py_to_slice::<'a>(args);
 
-    let program = node_from_bytes_backrefs(&mut allocator, program).map_err(map_pyerr)?;
+    // the generator comes from an already-validated block, so accept any
+    // encoding (sniffing the serde_2026 magic prefix). No size cap: the
+    // classic path never had one and the input is trusted.
+    let program = node_from_bytes_auto(&mut allocator, program, usize::MAX).map_err(map_pyerr)?;
     let args = node_from_bytes_backrefs(&mut allocator, args).map_err(map_pyerr)?;
     let dialect = &ChiaDialect::new(flags.to_clvm_flags());
 
@@ -250,8 +254,9 @@ pub fn get_puzzle_and_solution_for_coin2<'a>(
         py_to_slice::<'a>(buf)
     });
 
+    // see get_puzzle_and_solution_for_coin() for why any encoding is accepted
     let generator =
-        node_from_bytes_backrefs(&mut allocator, generator.as_ref()).map_err(map_pyerr)?;
+        node_from_bytes_auto(&mut allocator, generator.as_ref(), usize::MAX).map_err(map_pyerr)?;
     let args = setup_generator_args(&mut allocator, refs, flags)?;
     let dialect = &ChiaDialect::new(flags.to_clvm_flags());
 

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -8,9 +8,10 @@ use chia_consensus::run_block_generator::run_block_generator as native_run_block
 use chia_consensus::run_block_generator::run_block_generator2 as native_run_block_generator2;
 use chia_protocol::{Bytes, Bytes32, Coin};
 
+use chia_consensus::serde_2026::node_from_bytes_auto;
 use clvmr::allocator::Allocator;
 use clvmr::cost::Cost;
-use clvmr::serde::{intern_tree_limited, node_from_bytes_backrefs};
+use clvmr::serde::intern_tree_limited;
 
 use pyo3::PyResult;
 use pyo3::buffer::PyBuffer;
@@ -153,7 +154,8 @@ pub fn additions_and_removals<'a>(
 
 /// Return the byte-weight-equivalent of a serialized generator program.
 ///
-/// Deserializes (with back-refs), interns the tree, and returns
+/// Deserializes (accepting classic, back-refs and serde_2026 encodings),
+/// interns the tree, and returns
 /// `atom_bytes + 2*atom_count + 3*pair_count`.  Multiply by
 /// `cost_per_byte` from consensus constants to get the full generator size cost.
 #[pyfunction]
@@ -161,7 +163,8 @@ pub fn generator_interned_vbytes(py: Python<'_>, program: PyBuffer<u8>) -> PyRes
     let program = py_to_slice(program);
     py.detach(|| {
         let mut a = Allocator::new();
-        let node = node_from_bytes_backrefs(&mut a, program)
+        // trusted input; no size cap, like the back-refs path had none
+        let node = node_from_bytes_auto(&mut a, program, usize::MAX)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("bad generator: {e}")))?;
         let tree = intern_tree_limited(&a, node, u32::MAX as usize)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("intern failed: {e}")))?;


### PR DESCRIPTION
## Why

#1438 made the `INTERNED_GENERATOR` consensus path emit and require serde_2026-encoded generators. Bugbot flagged on that PR ([r3662079661](https://github.com/Chia-Network/chia_rs/pull/1438#discussion_r3662079661)) that trusted helper functions still parse generators with `node_from_bytes_backrefs()` only, and arvidn confirmed as a non-blocking follow-up: the helper functions the full node uses to respond to RPCs (like `get_puzzle_and_solution_for_coin` and `additions_and_removals`) need to support the new generator format as well.

## Layering: consensus stays strict, trusted read helpers sniff

- The **consensus path** (`run_block_generator2`) is unchanged: with `INTERNED_GENERATOR` active, serde_2026 is the *only* legal encoding, and pre-HF2 the classic/backrefs encodings are the only legal ones. No sniffing there.
- **Trusted (non-consensus) helpers** run on already-validated blocks, so format detection is appropriate. They now dispatch on the serde_2026 magic prefix via the existing `chia_consensus::serde_2026::node_from_bytes_auto()` (introduced for exactly this purpose). Detection is unambiguous: the 6-byte magic starts with `0xfd`, which cannot begin a valid classic CLVM serialization (`0xfd` declares an atom length >= 2^40, above the 2^34 cap).

## Audited surface

Changed (parsed generator blobs with `node_from_bytes_backrefs()` only):

- `additions_and_removals()` (chia-consensus) — also fixes the python binding, which wraps it
- `get_puzzle_and_solution_for_coin()` and `get_puzzle_and_solution_for_coin2()` (python bindings; the generator-bytes parsing for these lives in the wheel)
- `generator_interned_vbytes()` (python binding)

Audited and deliberately unchanged:

- `run_block_generator()` / `run_block_generator2()` — consensus path, stays strict
- `get_coinspends_for_trusted_block()` / `get_coinspends_with_conditions_for_trusted_block()` — already handle serde_2026 (via `INTERNED_GENERATOR` flag dispatch, from #1438)
- `solution_generator*()`, `InternedBlockBuilder`, `run_spendbundle()`, fast-forward — parse puzzle/solution blobs from spend bundles, not block generators
- wheel `run_chia_program()` — general-purpose CLVM runner, not a generator-specific helper
- chia-tools (`visit_spends::run_generator`, `test-block-generators --test-serializer`) — offline analysis tools; can be updated when post-HF2 blocks exist on chain

## Notes

- `Program` (Streamable) cannot hold a serde_2026 blob yet (`serialized_length_from_bytes*` rejects `0xfd`), so `get_puzzle_and_solution_for_coin2()` and the `get_coinspends_*` wrappers — which take the generator as `Program` — can't receive serde_2026 blobs from python until that lands. The buffer-taking helpers are covered end-to-end from python now.
- Python-visible behavior is otherwise unchanged: same signatures, same results for classic generators.

## Tests

Each changed helper has a test exercising it with both a classic and a serde_2026 encoding of the same spends (built with `solution_generator()` / `solution_generator_2026()`, the latter producing the same wire format as `InternedBlockBuilder::finalize()`), asserting identical results:

- Rust: `test_serde_2026_generator_equivalence` in `additions_and_removals.rs` (with pre- and post-HF2 flag sets)
- Python: `test_additions_and_removals_serde_2026`, `test_get_puzzle_and_solution_for_coin_serde_2026`, `test_generator_interned_vbytes_serde_2026`

Made with [Cursor](https://cursor.com)