### PR TITLE
correct transactions_generator_buffer type

### DIFF
--- a/crates/chia-protocol/src/fullblock.rs
+++ b/crates/chia-protocol/src/fullblock.rs
@@ -35,7 +35,7 @@ pub struct FullBlock {
 
     // Raw generator bytes, only used when version == 1. Mutually exclusive
     // with transactions_generator and transactions_generator_ref_list.
-    transactions_generator_buffer: Option<Vec<u8>>,
+    transactions_generator_buffer: Option<Bytes>,
 
     // 0 = legacy format (Program serialization + ref_list)
     // 1 = raw bytes format (length-prefixed bytes, ref_list omitted)
@@ -65,8 +65,7 @@ impl Streamable for FullBlock {
                 }
                 Some(buf) => {
                     0b11_u8.update_digest(digest);
-                    (buf.len() as u32).update_digest(digest);
-                    digest.update(buf);
+                    buf.update_digest(digest);
                 }
             }
         } else {
@@ -96,8 +95,7 @@ impl Streamable for FullBlock {
                 }
                 Some(buf) => {
                     0b11_u8.stream(out)?;
-                    (buf.len() as u32).stream(out)?;
-                    out.extend_from_slice(buf);
+                    buf.stream(out)?;
                 }
             }
         } else {
@@ -151,8 +149,7 @@ impl Streamable for FullBlock {
             })
         } else if version == 1 {
             let transactions_generator_buffer = if has_generator {
-                let bytes = <Bytes as Streamable>::parse::<TRUSTED>(input)?;
-                Some(bytes.into_inner())
+                Some(<Bytes as Streamable>::parse::<TRUSTED>(input)?)
             } else {
                 None
             };
@@ -394,7 +391,7 @@ mod tests {
             None,
             None,
             vec![],
-            buffer,
+            buffer.map(Bytes::from),
             1,
         )
     }
@@ -452,7 +449,14 @@ mod tests {
         assert_eq!(block2.version, 1);
         assert!(block2.transactions_generator.is_none());
         assert!(block2.transactions_generator_ref_list.is_empty());
-        assert_eq!(block2.transactions_generator_buffer.as_ref().unwrap(), &raw);
+        assert_eq!(
+            block2
+                .transactions_generator_buffer
+                .as_ref()
+                .unwrap()
+                .to_vec(),
+            raw
+        );
         assert_eq!(block2.to_bytes().unwrap(), buf);
     }
 
@@ -545,7 +549,10 @@ mod tests {
         let block = make_v1_block(Some(garbage.clone()));
         let buf = block.to_bytes().unwrap();
         let block2 = FullBlock::parse::<false>(&mut Cursor::new(&buf)).unwrap();
-        assert_eq!(block2.transactions_generator_buffer.unwrap(), garbage);
+        assert_eq!(
+            block2.transactions_generator_buffer.unwrap().to_vec(),
+            garbage
+        );
     }
 
     // The version flag is packed into the transactions_generator Option prefix

--- a/crates/chia-protocol/src/unfinished_block.rs
+++ b/crates/chia-protocol/src/unfinished_block.rs
@@ -32,7 +32,7 @@ pub struct UnfinishedBlock {
 
     // Raw generator bytes, only used when version == 1. Mutually exclusive
     // with transactions_generator and transactions_generator_ref_list.
-    transactions_generator_buffer: Option<Vec<u8>>,
+    transactions_generator_buffer: Option<Bytes>,
 
     // 0 = legacy format (Program serialization + ref_list)
     // 1 = raw bytes format (length-prefixed bytes, ref_list omitted)
@@ -59,8 +59,7 @@ impl Streamable for UnfinishedBlock {
                 }
                 Some(buf) => {
                     0b11_u8.update_digest(digest);
-                    (buf.len() as u32).update_digest(digest);
-                    digest.update(buf);
+                    buf.update_digest(digest);
                 }
             }
         } else {
@@ -87,8 +86,7 @@ impl Streamable for UnfinishedBlock {
                 }
                 Some(buf) => {
                     0b11_u8.stream(out)?;
-                    (buf.len() as u32).stream(out)?;
-                    out.extend_from_slice(buf);
+                    buf.stream(out)?;
                 }
             }
         } else {
@@ -136,8 +134,7 @@ impl Streamable for UnfinishedBlock {
             })
         } else if version == 1 {
             let transactions_generator_buffer = if has_generator {
-                let bytes = <Bytes as Streamable>::parse::<TRUSTED>(input)?;
-                Some(bytes.into_inner())
+                Some(<Bytes as Streamable>::parse::<TRUSTED>(input)?)
             } else {
                 None
             };
@@ -292,7 +289,7 @@ mod tests {
             None,
             None,
             vec![],
-            buffer,
+            buffer.map(Bytes::from),
             1,
         )
     }
@@ -350,7 +347,14 @@ mod tests {
         assert_eq!(block2.version, 1);
         assert!(block2.transactions_generator.is_none());
         assert!(block2.transactions_generator_ref_list.is_empty());
-        assert_eq!(block2.transactions_generator_buffer.as_ref().unwrap(), &raw);
+        assert_eq!(
+            block2
+                .transactions_generator_buffer
+                .as_ref()
+                .unwrap()
+                .to_vec(),
+            raw
+        );
         assert_eq!(block2.to_bytes().unwrap(), buf);
     }
 
@@ -429,7 +433,10 @@ mod tests {
         let block = make_v1_block(Some(garbage.clone()));
         let buf = block.to_bytes().unwrap();
         let block2 = UnfinishedBlock::parse::<false>(&mut Cursor::new(&buf)).unwrap();
-        assert_eq!(block2.transactions_generator_buffer.unwrap(), garbage);
+        assert_eq!(
+            block2.transactions_generator_buffer.unwrap().to_vec(),
+            garbage
+        );
     }
 
     // The version flag is packed into the transactions_generator Option prefix

--- a/tests/test_full_block.py
+++ b/tests/test_full_block.py
@@ -113,7 +113,7 @@ def make_full_block_v1(
         None,
         None,
         [],
-        [uint8(b) for b in generator_buffer] if generator_buffer is not None else None,
+        generator_buffer,
         uint8(1),
     )
 

--- a/wheel/python/chia_rs/chia_rs.pyi
+++ b/wheel/python/chia_rs/chia_rs.pyi
@@ -2043,7 +2043,7 @@ class FullBlock:
     transactions_info: Optional[TransactionsInfo]
     transactions_generator: Optional[Program]
     transactions_generator_ref_list: list[uint32]
-    transactions_generator_buffer: Optional[list[uint8]]
+    transactions_generator_buffer: Optional[bytes]
     version: uint8
     prev_header_hash: bytes32
     header_hash: bytes32
@@ -2067,7 +2067,7 @@ class FullBlock:
         transactions_info: Optional[TransactionsInfo],
         transactions_generator: Optional[Program],
         transactions_generator_ref_list: Sequence[uint32],
-        transactions_generator_buffer: Optional[Sequence[uint8]],
+        transactions_generator_buffer: Optional[bytes],
         version: uint8
     ) -> Self: ...
     def __hash__(self) -> int: ...
@@ -2099,7 +2099,7 @@ class FullBlock:
         transactions_info: Union[ Optional[TransactionsInfo], _Unspec] = _Unspec(),
         transactions_generator: Union[ Optional[Program], _Unspec] = _Unspec(),
         transactions_generator_ref_list: Union[ list[uint32], _Unspec] = _Unspec(),
-        transactions_generator_buffer: Union[ Optional[list[uint8]], _Unspec] = _Unspec(),
+        transactions_generator_buffer: Union[ Optional[bytes], _Unspec] = _Unspec(),
         version: Union[ uint8, _Unspec] = _Unspec()) -> FullBlock: ...
     def truncate(self, field: str, length: int) -> None: ...
 
@@ -2729,7 +2729,7 @@ class UnfinishedBlock:
     transactions_info: Optional[TransactionsInfo]
     transactions_generator: Optional[Program]
     transactions_generator_ref_list: list[uint32]
-    transactions_generator_buffer: Optional[list[uint8]]
+    transactions_generator_buffer: Optional[bytes]
     version: uint8
     prev_header_hash: bytes32
     partial_hash: bytes32
@@ -2746,7 +2746,7 @@ class UnfinishedBlock:
         transactions_info: Optional[TransactionsInfo],
         transactions_generator: Optional[Program],
         transactions_generator_ref_list: Sequence[uint32],
-        transactions_generator_buffer: Optional[Sequence[uint8]],
+        transactions_generator_buffer: Optional[bytes],
         version: uint8
     ) -> Self: ...
     def __hash__(self) -> int: ...
@@ -2775,7 +2775,7 @@ class UnfinishedBlock:
         transactions_info: Union[ Optional[TransactionsInfo], _Unspec] = _Unspec(),
         transactions_generator: Union[ Optional[Program], _Unspec] = _Unspec(),
         transactions_generator_ref_list: Union[ list[uint32], _Unspec] = _Unspec(),
-        transactions_generator_buffer: Union[ Optional[list[uint8]], _Unspec] = _Unspec(),
+        transactions_generator_buffer: Union[ Optional[bytes], _Unspec] = _Unspec(),
         version: Union[ uint8, _Unspec] = _Unspec()) -> UnfinishedBlock: ...
     def truncate(self, field: str, length: int) -> None: ...
 


### PR DESCRIPTION
It's a `Vec<u8>` right now, which technically is correct, but `generate_type_stub.py` specifies all `Vec<>` as `List[]`. The `Bytes` type is a thin wrapper around `Vec<u8>` meant to be translated to `bytes` in the python type stubs.

This corrects the type of `transactions_generator_buffer` to be `bytes` rather than `List[uint8]`. This was the original intention.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of an existing field’s Rust/Python typing and serialization helpers on block types; no new protocol semantics, with roundtrip tests still in place.
> 
> **Overview**
> **`transactions_generator_buffer`** on **`FullBlock`** and **`UnfinishedBlock`** is now **`Option<Bytes>`** instead of **`Option<Vec<u8>>`**, so Python stubs expose **`Optional[bytes]`** rather than **`list[uint8]`**.
> 
> v1 **Streamable** digest/stream/parse paths delegate to **`Bytes`**’s **`Streamable`** impl instead of hand-rolling length-prefix + raw bytes; wire encoding should stay the same. Rust and Python tests were adjusted (e.g. **`.to_vec()`** in assertions, v1 helpers pass **`bytes`** directly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de5894951d35c29c4be51575619034bfd2a3ff4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->