### PR TITLE
New cost model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "clvm-fuzzing"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfac8b7af2c7202157ce59439a63882da45492dc414a7e4e15b8590b6d08b88"
+checksum = "de29478366d9c96ef90eb2690d1faef52805f5586701f4e7d079fa60cba14d5c"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -862,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a2651e364d36ec9a9848c819e763c892477317b5887fa140085ae79fc0bc4f"
+checksum = "3a9d2342687e3210c4b7f8556966ee80e4106d451dd4d8b14b1e446412c640a4"
 dependencies = [
  "bitflags",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,8 +143,8 @@ chia-puzzle-types-fuzz = { path = "./crates/chia-puzzle-types/fuzz", version = "
 clvm-traits-fuzz = { path = "./crates/clvm-traits/fuzz", version = "0.46.0" }
 clvm-utils-fuzz = { path = "./crates/clvm-utils/fuzz", version = "0.46.0" }
 blst = { version = "0.3.16", features = ["portable"] }
-clvmr = "0.18.0"
-clvm-fuzzing = "0.18.0"
+clvmr = "0.19.0"
+clvm-fuzzing = "0.19.0"
 syn = "2.0.101"
 quote = "1.0.40"
 proc-macro2 = "1.0.95"

--- a/crates/chia-consensus/src/flags.rs
+++ b/crates/chia-consensus/src/flags.rs
@@ -23,6 +23,7 @@ bitflags! {
         const RELAXED_BLS = 0x0008;
         const LIMIT_SOFTFORK = 0x0010;
         const ENABLE_GC = 0x0020;
+        const LIMITS = 0x0040;
         const ENABLE_KECCAK_OPS_OUTSIDE_GUARD = 0x0100;
         const DISABLE_OP = 0x0200;
         const ENABLE_SHA256_TREE = 0x0400;
@@ -102,6 +103,9 @@ impl ConsensusFlags {
         if clvm.contains(ClvmFlags::NEW_COST_MODEL) {
             out = out.union(ConsensusFlags::NEW_COST_MODEL);
         }
+        if clvm.contains(ClvmFlags::LIMITS) {
+            out = out.union(ConsensusFlags::LIMITS);
+        }
         out
     }
 
@@ -145,6 +149,9 @@ impl ConsensusFlags {
         }
         if self.contains(ConsensusFlags::NEW_COST_MODEL) {
             out.insert(ClvmFlags::NEW_COST_MODEL);
+        }
+        if self.contains(ConsensusFlags::LIMITS) {
+            out.insert(ClvmFlags::LIMITS);
         }
         out
     }

--- a/crates/chia-consensus/src/flags.rs
+++ b/crates/chia-consensus/src/flags.rs
@@ -28,6 +28,7 @@ bitflags! {
         const ENABLE_SHA256_TREE = 0x0400;
         const ENABLE_SECP_OPS = 0x0800;
         const MALACHITE = 0x1000;
+        const NEW_COST_MODEL = 0x2000;
 
         // Consensus flags
         /// Skip validating AGG_SIG / condition signatures.
@@ -98,6 +99,9 @@ impl ConsensusFlags {
         if clvm.contains(ClvmFlags::MALACHITE) {
             out = out.union(ConsensusFlags::MALACHITE);
         }
+        if clvm.contains(ClvmFlags::NEW_COST_MODEL) {
+            out = out.union(ConsensusFlags::NEW_COST_MODEL);
+        }
         out
     }
 
@@ -138,6 +142,9 @@ impl ConsensusFlags {
         }
         if self.contains(ConsensusFlags::MALACHITE) {
             out.insert(ClvmFlags::MALACHITE);
+        }
+        if self.contains(ConsensusFlags::NEW_COST_MODEL) {
+            out.insert(ClvmFlags::NEW_COST_MODEL);
         }
         out
     }

--- a/crates/chia-consensus/src/spendbundle_validation.rs
+++ b/crates/chia-consensus/src/spendbundle_validation.rs
@@ -87,6 +87,7 @@ pub fn get_flags_for_height_and_constants(
         flags |= ConsensusFlags::ENABLE_KECCAK_OPS_OUTSIDE_GUARD
             | ConsensusFlags::COST_CONDITIONS
             | ConsensusFlags::ENABLE_SECP_OPS
+            | ConsensusFlags::NEW_COST_MODEL
             | ConsensusFlags::RELAXED_BLS;
     }
 

--- a/crates/chia-consensus/src/spendbundle_validation.rs
+++ b/crates/chia-consensus/src/spendbundle_validation.rs
@@ -89,10 +89,11 @@ pub fn get_flags_for_height_and_constants(
             | ConsensusFlags::ENABLE_SECP_OPS
             | ConsensusFlags::NEW_COST_MODEL
             | ConsensusFlags::RELAXED_BLS;
-    }
-
-    if prev_tx_height >= constants.soft_fork8_height {
+    } else if prev_tx_height >= constants.soft_fork8_height {
+        // once the hard fork activates, we no longer apply the limits, nor
+        // disable the operators
         flags |= ConsensusFlags::DISABLE_OP;
+        flags |= ConsensusFlags::LIMITS;
     }
 
     if prev_tx_height >= constants.soft_fork9_height {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Consensus and CLVM cost/limit behavior change at defined heights; incorrect flag gating would diverge from network rules and affect block/spend validation.
> 
> **Overview**
> Bumps **clvmr** / **clvm-fuzzing** to **0.19.0** and wires two new dialect flags—**`LIMITS`** and **`NEW_COST_MODEL`**—through **`ConsensusFlags`** and the **`from_clvm_flags` / `to_clvm_flags`** conversions so Python and Rust stay bit-aligned with clvmr.
> 
> **Height-gated behavior** in **`get_flags_for_height_and_constants`** changes: **`NEW_COST_MODEL`** turns on with hard fork 2 alongside the existing HF2 bundle. Soft fork 8’s **`DISABLE_OP`** and **`LIMITS`** are now applied only in the **`else if`** branch (after soft fork 8 but **before** hard fork 2), so those transitional rules stop once HF2 activates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddefb84c2829c5f269cc8989b5ffaab460c966a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->