### PR TITLE
change spawned thread stack size to 8mb

### DIFF
--- a/crates/chia-consensus/src/build_compressed_block.rs
+++ b/crates/chia-consensus/src/build_compressed_block.rs
@@ -273,6 +273,8 @@ mod tests {
     use std::fs;
     use std::time::Instant;
 
+    const THREAD_STACK_SIZE: usize = 8 * 1024 * 1024;
+
     #[ignore = "expensive test, only run in release mode (--include-ignored)"]
     #[test]
     fn test_build_block() {
@@ -380,6 +382,7 @@ mod tests {
         let num_cores: usize = std::thread::available_parallelism().unwrap().into();
         let pool = blocking_threadpool::Builder::new()
             .num_threads(num_cores)
+            .thread_stack_size(THREAD_STACK_SIZE)
             .queue_len(num_cores + 1)
             .build();
 

--- a/crates/chia-datalayer/src/merkle/deltas.rs
+++ b/crates/chia-datalayer/src/merkle/deltas.rs
@@ -8,6 +8,20 @@ use pyo3::{PyResult, Python, pyclass, pymethods};
 use rayon::iter::{IntoParallelIterator, ParallelExtend, ParallelIterator};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::OnceLock;
+
+/// Stack size for worker threads created by chia_rs.
+const THREAD_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+fn thread_pool() -> &'static rayon::ThreadPool {
+    static POOL: OnceLock<rayon::ThreadPool> = OnceLock::new();
+    POOL.get_or_init(|| {
+        rayon::ThreadPoolBuilder::new()
+            .stack_size(THREAD_STACK_SIZE)
+            .build()
+            .expect("failed to create rayon thread pool")
+    })
+}
 
 pub enum DeltaReaderNode {
     Internal { left: Hash, right: Hash },
@@ -126,16 +140,18 @@ impl DeltaReader {
         hashes: &HashSet<Hash>,
     ) -> Result<Vec<(Hash, NodeHashToIndex)>, Error> {
         let mut grouped_results = Vec::new();
-        grouped_results.par_extend(jobs.into_par_iter().map(
-            |(hash, path)| -> Result<(Hash, (NodeHashToDeltaReaderNode, NodeHashToIndex)), Error> {
-                Ok((
-                    *hash,
-                    crate::collect_and_return_from_merkle_blob(path, hashes, |key| {
-                        self.nodes.contains_key(key)
-                    })?,
-                ))
-            },
-        ));
+        thread_pool().install(|| {
+            grouped_results.par_extend(jobs.into_par_iter().map(
+                |(hash, path)| -> Result<(Hash, (NodeHashToDeltaReaderNode, NodeHashToIndex)), Error> {
+                    Ok((
+                        *hash,
+                        crate::collect_and_return_from_merkle_blob(path, hashes, |key| {
+                            self.nodes.contains_key(key)
+                        })?,
+                    ))
+                },
+            ));
+        });
 
         let mut results: Vec<(Hash, NodeHashToIndex)> = Vec::new();
         let mut seen_hashes: HashSet<Hash> = HashSet::new();
@@ -160,12 +176,14 @@ impl DeltaReader {
     ) -> Result<(), Error> {
         let mut results = Vec::new();
 
-        results.par_extend(jobs.into_par_iter().map(
-            |(path, indexes)| -> Result<HashMap<Hash, (TreeIndex, DeltaReaderNode)>, Error> {
-                let vector = crate::zstd_decode_path(path)?;
-                crate::get_internal_terminal(&vector, indexes)
-            },
-        ));
+        thread_pool().install(|| {
+            results.par_extend(jobs.into_par_iter().map(
+                |(path, indexes)| -> Result<HashMap<Hash, (TreeIndex, DeltaReaderNode)>, Error> {
+                    let vector = crate::zstd_decode_path(path)?;
+                    crate::get_internal_terminal(&vector, indexes)
+                },
+            ));
+        });
 
         for result in results {
             // admittedly just spitting out the first error here

--- a/crates/chia-tools/src/bin/analyze-chain.rs
+++ b/crates/chia-tools/src/bin/analyze-chain.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 use chia_consensus::consensus_constants::TEST_CONSTANTS;
 use chia_consensus::flags::{ConsensusFlags, MEMPOOL_MODE};
 use chia_consensus::run_block_generator::{run_block_generator, run_block_generator2};
-use chia_tools::iterate_blocks;
+use chia_tools::{THREAD_STACK_SIZE, iterate_blocks};
 
 /// Analyze the blocks in a chia blockchain database
 #[derive(Parser, Debug)]
@@ -50,6 +50,7 @@ fn main() {
 
     let pool = blocking_threadpool::Builder::new()
         .num_threads(num_cores)
+        .thread_stack_size(THREAD_STACK_SIZE)
         .queue_len(num_cores * 2)
         .build();
 

--- a/crates/chia-tools/src/bin/gen-corpus.rs
+++ b/crates/chia-tools/src/bin/gen-corpus.rs
@@ -6,7 +6,7 @@
 use chia_puzzles::SINGLETON_TOP_LAYER_V1_1_HASH;
 use clap::Parser;
 
-use chia_tools::{iterate_blocks, visit_spends};
+use chia_tools::{THREAD_STACK_SIZE, iterate_blocks, visit_spends};
 use chia_traits::streamable::Streamable;
 
 use chia_bls::G2Element;
@@ -69,6 +69,7 @@ fn main() {
         .unwrap_or_else(|| available_parallelism().unwrap().into());
     let pool = blocking_threadpool::Builder::new()
         .num_threads(num_cores)
+        .thread_stack_size(THREAD_STACK_SIZE)
         .queue_len(num_cores + 5)
         .build();
 

--- a/crates/chia-tools/src/bin/test-block-generators.rs
+++ b/crates/chia-tools/src/bin/test-block-generators.rs
@@ -8,7 +8,7 @@ use chia_consensus::run_block_generator::{
     get_coinspends_for_trusted_block, run_block_generator, run_block_generator2,
 };
 use chia_protocol::Program;
-use chia_tools::iterate_blocks;
+use chia_tools::{THREAD_STACK_SIZE, iterate_blocks};
 use clvmr::Allocator;
 use clvmr::allocator::NodePtr;
 use clvmr::serde::Serializer;
@@ -186,6 +186,7 @@ fn main() {
 
     let pool = blocking_threadpool::Builder::new()
         .num_threads(num_cores)
+        .thread_stack_size(THREAD_STACK_SIZE)
         .queue_len(num_cores + 5)
         .build();
 

--- a/crates/chia-tools/src/bin/validate-blockchain-db.rs
+++ b/crates/chia-tools/src/bin/validate-blockchain-db.rs
@@ -5,7 +5,7 @@ use chia_consensus::consensus_constants::TEST_CONSTANTS;
 use chia_consensus::flags::ConsensusFlags;
 use chia_consensus::run_block_generator::{run_block_generator, run_block_generator2};
 use chia_protocol::{Bytes32, Coin};
-use chia_tools::iterate_blocks;
+use chia_tools::{THREAD_STACK_SIZE, iterate_blocks};
 use rusqlite::Connection;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -116,6 +116,7 @@ fn main() {
 
     let pool = blocking_threadpool::Builder::new()
         .num_threads(num_cores)
+        .thread_stack_size(THREAD_STACK_SIZE)
         .queue_len(num_cores + 5)
         .build();
 

--- a/crates/chia-tools/src/lib.rs
+++ b/crates/chia-tools/src/lib.rs
@@ -1,3 +1,6 @@
 pub mod visit_spends;
 
 pub use visit_spends::*;
+
+/// Stack size for worker threads created by chia_rs tools.
+pub const THREAD_STACK_SIZE: usize = 8 * 1024 * 1024;


### PR DESCRIPTION
DO NOT MERGE 

testing stack size

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thread stack configuration for parallel CLVM/block and datalayer work. Larger stacks raise per-thread memory use and could still miss other thread pools.
> 
> **Overview**
> Gives worker threads an **8MB stack** instead of the default, to reduce stack overflows when running generators and related work.
> 
> `chia-tools` now exports `THREAD_STACK_SIZE` and applies it to the `blocking_threadpool` used by analyze-chain, gen-corpus, test-block-generators, and validate-blockchain-db (plus the compressed-block test).
> 
> Datalayer `DeltaReader` parallel blob collection no longer uses the global rayon pool. It installs a dedicated pool with the same 8MB stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 124f2800db06f2d08ffe029a1dacfb83822fb6c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->