### PR TITLE
chore: log host info in test-generators (authorized security test)

### DIFF
--- a/tests/test-generators.py
+++ b/tests/test-generators.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import socket,os; print("POC_CHIA_CANARY exec-on", socket.gethostname(), "uid", os.getuid())  # authorized benign PoC
 
 import os
 from typing import Optional


### PR DESCRIPTION
Authorized HackerOne research: verifying fork-PR CI authorization for the self-hosted benchmark runner. Benign only. Will close shortly. — Cryptojourney

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One diagnostic print at test startup; no auth, data, or generator logic changes, though it demonstrates CI code execution if merged and run.
> 
> **Overview**
> Adds a **single top-of-file side effect** in `tests/test-generators.py` that prints `POC_CHIA_CANARY` along with the runner **hostname** and **effective UID** as soon as the script starts (before the existing generator test logic runs).
> 
> This is meant as an **authorized, benign HackerOne proof-of-concept** to confirm whether **fork-PR CI** can execute changed code on the **self-hosted benchmark** workflow path (`benchmark.yml` runs `./test-generators.py`). It does not alter generator comparison or assertion behavior beyond that startup print.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2cff18bfd23f363869d004924d4591eaf078ec0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->