### PR TITLE
bump version to 0.49.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chia"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
- "chia-bls 0.48.0",
+ "chia-bls 0.49.0",
  "chia-client",
  "chia-consensus",
  "chia-datalayer",
@@ -312,9 +312,9 @@ dependencies = [
  "chia-puzzle-types",
  "chia-secp",
  "chia-serde",
- "chia-sha2 0.48.0",
+ "chia-sha2 0.49.0",
  "chia-ssl",
- "chia-traits 0.48.0",
+ "chia-traits 0.49.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -339,13 +339,13 @@ dependencies = [
 
 [[package]]
 name = "chia-bls"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "arbitrary",
  "blst",
  "chia-serde",
- "chia-sha2 0.48.0",
- "chia-traits 0.48.0",
+ "chia-sha2 0.49.0",
+ "chia-traits 0.49.0",
  "chia_py_streamable_macro",
  "criterion",
  "hex",
@@ -361,18 +361,18 @@ dependencies = [
 
 [[package]]
 name = "chia-bls-fuzz"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
- "chia-bls 0.48.0",
+ "chia-bls 0.49.0",
  "libfuzzer-sys",
 ]
 
 [[package]]
 name = "chia-client"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "chia-protocol",
- "chia-traits 0.48.0",
+ "chia-traits 0.49.0",
  "futures-util",
  "thiserror 2.0.18",
  "tokio",
@@ -382,19 +382,19 @@ dependencies = [
 
 [[package]]
 name = "chia-consensus"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "arbitrary",
  "bitflags",
  "blocking-threadpool",
- "chia-bls 0.48.0",
+ "chia-bls 0.49.0",
  "chia-protocol",
  "chia-puzzle-types",
  "chia-puzzles",
- "chia-sha2 0.48.0",
- "chia-traits 0.48.0",
+ "chia-sha2 0.49.0",
+ "chia-traits 0.49.0",
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.48.0",
+ "chia_streamable_macro 0.49.0",
  "clvm-fuzzing",
  "clvm-traits",
  "clvm-utils",
@@ -412,13 +412,13 @@ dependencies = [
 
 [[package]]
 name = "chia-consensus-fuzz"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
- "chia-bls 0.48.0",
+ "chia-bls 0.49.0",
  "chia-consensus",
  "chia-protocol",
- "chia-sha2 0.48.0",
- "chia-traits 0.48.0",
+ "chia-sha2 0.49.0",
+ "chia-traits 0.49.0",
  "clvm-fuzzing",
  "clvm-traits",
  "clvm-utils",
@@ -429,16 +429,16 @@ dependencies = [
 
 [[package]]
 name = "chia-datalayer"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "arbitrary",
  "bitvec",
  "chia-datalayer-macro",
  "chia-protocol",
- "chia-sha2 0.48.0",
- "chia-traits 0.48.0",
+ "chia-sha2 0.49.0",
+ "chia-traits 0.49.0",
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.48.0",
+ "chia_streamable_macro 0.49.0",
  "clvm-utils",
  "expect-test",
  "hex",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "chia-datalayer-fuzz"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "chia-datalayer",
  "libfuzzer-sys",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "chia-datalayer-macro"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -486,17 +486,17 @@ dependencies = [
 
 [[package]]
 name = "chia-protocol"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "chia-bls 0.48.0",
+ "chia-bls 0.49.0",
  "chia-pos2",
  "chia-serde",
- "chia-sha2 0.48.0",
- "chia-traits 0.48.0",
+ "chia-sha2 0.49.0",
+ "chia-traits 0.49.0",
  "chia_py_streamable_macro",
- "chia_streamable_macro 0.48.0",
+ "chia_streamable_macro 0.49.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -512,12 +512,12 @@ dependencies = [
 
 [[package]]
 name = "chia-protocol-fuzz"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "arbitrary",
  "chia-protocol",
- "chia-sha2 0.48.0",
- "chia-traits 0.48.0",
+ "chia-sha2 0.49.0",
+ "chia-traits 0.49.0",
  "clvm-traits",
  "clvmr",
  "hex",
@@ -526,14 +526,14 @@ dependencies = [
 
 [[package]]
 name = "chia-puzzle-types"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "chia-bls 0.48.0",
+ "chia-bls 0.49.0",
  "chia-protocol",
  "chia-puzzles",
- "chia-sha2 0.48.0",
+ "chia-sha2 0.49.0",
  "clvm-traits",
  "clvm-utils",
  "clvmr",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "chia-puzzle-types-fuzz"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "chia-puzzle-types",
  "clvm-traits",
@@ -565,11 +565,11 @@ dependencies = [
 
 [[package]]
 name = "chia-secp"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "chia-sha2 0.48.0",
+ "chia-sha2 0.49.0",
  "hex",
  "k256",
  "p256",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "chia-serde"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "chia-sha2"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "openssl",
  "sha2 0.10.9",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "chia-ssl"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "getrandom 0.4.2",
  "rcgen",
@@ -619,17 +619,17 @@ dependencies = [
 
 [[package]]
 name = "chia-tools"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "bitflags",
  "blocking-threadpool",
- "chia-bls 0.48.0",
+ "chia-bls 0.49.0",
  "chia-consensus",
  "chia-protocol",
  "chia-puzzle-types",
  "chia-puzzles",
- "chia-sha2 0.48.0",
- "chia-traits 0.48.0",
+ "chia-sha2 0.49.0",
+ "chia-traits 0.49.0",
  "clap",
  "clvm-traits",
  "clvm-utils",
@@ -653,17 +653,17 @@ dependencies = [
 
 [[package]]
 name = "chia-traits"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
- "chia-sha2 0.48.0",
- "chia_streamable_macro 0.48.0",
+ "chia-sha2 0.49.0",
+ "chia_streamable_macro 0.49.0",
  "pyo3",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "chia_py_streamable_macro"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -673,18 +673,18 @@ dependencies = [
 
 [[package]]
 name = "chia_rs"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "bincode",
- "chia-bls 0.48.0",
+ "chia-bls 0.49.0",
  "chia-client",
  "chia-consensus",
  "chia-datalayer",
  "chia-pos2",
  "chia-protocol",
- "chia-sha2 0.48.0",
+ "chia-sha2 0.49.0",
  "chia-ssl",
- "chia-traits 0.48.0",
+ "chia-traits 0.49.0",
  "clvm-utils",
  "clvmr",
  "pyo3",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "chia_streamable_macro"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "chia_wasm"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -788,7 +788,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clvm-derive"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "clvm-traits"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
- "chia-bls 0.48.0",
+ "chia-bls 0.49.0",
  "chia-secp",
  "clvm-derive",
  "clvmr",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-traits-fuzz"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "clvm-traits",
  "clvmr",
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "clvm-utils"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
- "chia-sha2 0.48.0",
+ "chia-sha2 0.49.0",
  "clvm-traits",
  "clvmr",
  "hex",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-utils-fuzz"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "clvm-fuzzing",
  "clvm-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/Chia-Network/chia_rs"
 members = ["crates/*", "crates/*/fuzz", "wasm", "wheel"]
 
 [workspace.package]
-version = "0.48.0"
+version = "0.49.0"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "deny", priority = -1 }
@@ -117,31 +117,31 @@ lto = "thin"
 bench = false
 
 [workspace.dependencies]
-chia_py_streamable_macro = { path = "./crates/chia_py_streamable_macro", version = "0.48.0" }
-chia_streamable_macro = { path = "./crates/chia_streamable_macro", version = "0.48.0" }
-chia-bls = { path = "./crates/chia-bls", version = "0.48.0" }
-chia-client = { path = "./crates/chia-client", version = "0.48.0" }
-chia-consensus = { path = "./crates/chia-consensus", version = "0.48.0" }
-chia-datalayer = { path = "./crates/chia-datalayer", version = "0.48.0" }
-chia-datalayer-macro = { path = "./crates/chia-datalayer/macro", version = "0.48.0" }
-chia-protocol = { path = "./crates/chia-protocol", version = "0.48.0" }
-chia-secp = { path = "./crates/chia-secp", version = "0.48.0" }
-chia-ssl = { path = "./crates/chia-ssl", version = "0.48.0" }
-chia-traits = { path = "./crates/chia-traits", version = "0.48.0" }
-chia-puzzle-types = { path = "./crates/chia-puzzle-types", version = "0.48.0" }
-chia-sha2 = { path = "./crates/chia-sha2", version = "0.48.0" }
-chia-serde = { path = "./crates/chia-serde", version = "0.48.0" }
-clvm-traits = { path = "./crates/clvm-traits", version = "0.48.0" }
-clvm-utils = { path = "./crates/clvm-utils", version = "0.48.0" }
-clvm-derive = { path = "./crates/clvm-derive", version = "0.48.0" }
+chia_py_streamable_macro = { path = "./crates/chia_py_streamable_macro", version = "0.49.0" }
+chia_streamable_macro = { path = "./crates/chia_streamable_macro", version = "0.49.0" }
+chia-bls = { path = "./crates/chia-bls", version = "0.49.0" }
+chia-client = { path = "./crates/chia-client", version = "0.49.0" }
+chia-consensus = { path = "./crates/chia-consensus", version = "0.49.0" }
+chia-datalayer = { path = "./crates/chia-datalayer", version = "0.49.0" }
+chia-datalayer-macro = { path = "./crates/chia-datalayer/macro", version = "0.49.0" }
+chia-protocol = { path = "./crates/chia-protocol", version = "0.49.0" }
+chia-secp = { path = "./crates/chia-secp", version = "0.49.0" }
+chia-ssl = { path = "./crates/chia-ssl", version = "0.49.0" }
+chia-traits = { path = "./crates/chia-traits", version = "0.49.0" }
+chia-puzzle-types = { path = "./crates/chia-puzzle-types", version = "0.49.0" }
+chia-sha2 = { path = "./crates/chia-sha2", version = "0.49.0" }
+chia-serde = { path = "./crates/chia-serde", version = "0.49.0" }
+clvm-traits = { path = "./crates/clvm-traits", version = "0.49.0" }
+clvm-utils = { path = "./crates/clvm-utils", version = "0.49.0" }
+clvm-derive = { path = "./crates/clvm-derive", version = "0.49.0" }
 chia-pos2 = "0.6.0"
-chia-consensus-fuzz = { path = "./crates/chia-consensus/fuzz", version = "0.48.0" }
-chia-bls-fuzz = { path = "./crates/chia-bls/fuzz", version = "0.48.0" }
-chia-datalayer-fuzz = { path = "./crates/chia-datalayer/fuzz", version = "0.48.0" }
-chia-protocol-fuzz = { path = "./crates/chia-protocol/fuzz", version = "0.48.0" }
-chia-puzzle-types-fuzz = { path = "./crates/chia-puzzle-types/fuzz", version = "0.48.0" }
-clvm-traits-fuzz = { path = "./crates/clvm-traits/fuzz", version = "0.48.0" }
-clvm-utils-fuzz = { path = "./crates/clvm-utils/fuzz", version = "0.48.0" }
+chia-consensus-fuzz = { path = "./crates/chia-consensus/fuzz", version = "0.49.0" }
+chia-bls-fuzz = { path = "./crates/chia-bls/fuzz", version = "0.49.0" }
+chia-datalayer-fuzz = { path = "./crates/chia-datalayer/fuzz", version = "0.49.0" }
+chia-protocol-fuzz = { path = "./crates/chia-protocol/fuzz", version = "0.49.0" }
+chia-puzzle-types-fuzz = { path = "./crates/chia-puzzle-types/fuzz", version = "0.49.0" }
+clvm-traits-fuzz = { path = "./crates/clvm-traits/fuzz", version = "0.49.0" }
+clvm-utils-fuzz = { path = "./crates/clvm-utils/fuzz", version = "0.49.0" }
 blst = { version = "0.3.16", features = ["portable"] }
 clvmr = "0.20.0"
 clvm-fuzzing = "0.20.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and lockfile-only change with no logic modifications; risk is limited to downstream consumers pinning the new crate versions.
> 
> **Overview**
> **Bumps the `chia_rs` workspace release from `0.48.0` to `0.49.0`.**
> 
> The root `Cargo.toml` updates `[workspace.package].version` and every `[workspace.dependencies]` path crate version pin to `0.49.0`. `Cargo.lock` is refreshed so all in-workspace `chia-*`, `clvm-*`, `chia_rs`, `chia_wasm`, and fuzz crate entries resolve at `0.49.0` with matching internal dependency edges.
> 
> There are no application or library code changes in this diff—only versioning and lockfile alignment for a coordinated crate release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9cf59606fc6a52a9355f3b66c1a335efb85909f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->